### PR TITLE
Fix view normalization causing infinite diff loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1378,7 +1378,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pgmold"
-version = "0.14.3"
+version = "0.14.4"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgmold"
-version = "0.14.3"
+version = "0.14.4"
 edition = "2021"
 description = "PostgreSQL schema-as-code management tool"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Fix view normalization that caused infinite diff loops after `pgmold apply`
- Add missing PostgreSQL operator normalizations: `!~~` (NOT LIKE), `~~*` (ILIKE), `!~~*` (NOT ILIKE)
- Add double-parentheses normalization `((x))` → `(x)` for JOIN conditions
- Bump version to 0.14.4

## Test plan

- [x] Added 8 new unit tests for the normalization cases
- [x] All 387 library tests pass
- [x] All 26 integration tests pass
- [x] Cargo clippy shows no new warnings