### PR TITLE
feat(validate): add idempotency check to migration validation

### DIFF
--- a/src/validate/mod.rs
+++ b/src/validate/mod.rs
@@ -1,8 +1,10 @@
+use crate::diff::compute_diff;
 use crate::diff::planner::plan_dump;
 use crate::diff::MigrationOp;
 use crate::dump::schema_to_create_ops;
 use crate::model::Schema;
 use crate::pg::connection::PgConnection;
+use crate::pg::introspect::introspect_schema;
 use crate::pg::sqlgen::generate_sql;
 use crate::util::Result;
 use crate::util::SchemaError;
@@ -11,7 +13,9 @@ use sqlx::Executor;
 #[derive(Debug, Clone)]
 pub struct ValidationResult {
     pub success: bool,
-    pub errors: Vec<ValidationError>,
+    pub execution_errors: Vec<ValidationError>,
+    pub residual_ops: Vec<MigrationOp>,
+    pub idempotent: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -25,6 +29,8 @@ pub async fn validate_migration_on_temp_db(
     ops: &[MigrationOp],
     temp_db_url: &str,
     current_schema: &Schema,
+    target_schema: &Schema,
+    target_db_schemas: &[String],
 ) -> Result<ValidationResult> {
     let connection = PgConnection::new(temp_db_url).await?;
 
@@ -43,11 +49,11 @@ pub async fn validate_migration_on_temp_db(
     }
 
     let migration_sql = generate_sql(ops);
-    let mut errors = Vec::new();
+    let mut execution_errors = Vec::new();
 
     for (index, statement) in migration_sql.iter().enumerate() {
         if let Err(e) = connection.pool().execute(statement.as_str()).await {
-            errors.push(ValidationError {
+            execution_errors.push(ValidationError {
                 statement_index: index,
                 sql: statement.clone(),
                 error_message: e.to_string(),
@@ -55,9 +61,20 @@ pub async fn validate_migration_on_temp_db(
         }
     }
 
+    let (residual_ops, idempotent) = if execution_errors.is_empty() {
+        let actual_schema = introspect_schema(&connection, target_db_schemas, false).await?;
+        let residual = compute_diff(&actual_schema, target_schema);
+        let is_idempotent = residual.is_empty();
+        (residual, is_idempotent)
+    } else {
+        (vec![], false)
+    };
+
     Ok(ValidationResult {
-        success: errors.is_empty(),
-        errors,
+        success: execution_errors.is_empty(),
+        execution_errors,
+        residual_ops,
+        idempotent,
     })
 }
 
@@ -92,12 +109,13 @@ mod tests {
         .unwrap();
 
         let ops = compute_diff(&current, &target);
-        let result = validate_migration_on_temp_db(&ops, &url, &current)
+        let target_schemas = vec!["public".to_string()];
+        let result = validate_migration_on_temp_db(&ops, &url, &current, &target, &target_schemas)
             .await
             .unwrap();
 
         assert!(result.success);
-        assert!(result.errors.is_empty());
+        assert!(result.execution_errors.is_empty());
     }
 
     #[tokio::test]
@@ -105,15 +123,134 @@ mod tests {
         let (_container, url) = setup_temp_postgres().await;
 
         let current = Schema::default();
+        let target = Schema::default();
 
         let invalid_ops = vec![MigrationOp::DropTable("nonexistent_table".to_string())];
+        let target_schemas = vec!["public".to_string()];
 
-        let result = validate_migration_on_temp_db(&invalid_ops, &url, &current)
+        let result =
+            validate_migration_on_temp_db(&invalid_ops, &url, &current, &target, &target_schemas)
+                .await
+                .unwrap();
+
+        assert!(!result.success);
+        assert_eq!(result.execution_errors.len(), 1);
+        assert!(result.execution_errors[0]
+            .error_message
+            .contains("nonexistent_table"));
+    }
+
+    #[tokio::test]
+    async fn idempotent_migration() {
+        let (_container, url) = setup_temp_postgres().await;
+
+        let current = parse_sql_string(
+            r#"
+            CREATE TABLE users (
+                id BIGINT NOT NULL PRIMARY KEY
+            );
+            "#,
+        )
+        .unwrap();
+
+        let target = parse_sql_string(
+            r#"
+            CREATE TABLE users (
+                id BIGINT NOT NULL PRIMARY KEY,
+                email TEXT NOT NULL
+            );
+            "#,
+        )
+        .unwrap();
+
+        let ops = compute_diff(&current, &target);
+        let target_schemas = vec!["public".to_string()];
+
+        let result = validate_migration_on_temp_db(&ops, &url, &current, &target, &target_schemas)
             .await
             .unwrap();
 
+        assert!(result.success);
+        assert!(result.execution_errors.is_empty());
+        assert!(result.idempotent);
+        assert!(result.residual_ops.is_empty());
+    }
+
+    #[tokio::test]
+    async fn incomplete_migration() {
+        let (_container, url) = setup_temp_postgres().await;
+
+        let current = parse_sql_string(
+            r#"
+            CREATE TABLE users (
+                id BIGINT NOT NULL PRIMARY KEY
+            );
+            "#,
+        )
+        .unwrap();
+
+        let target = parse_sql_string(
+            r#"
+            CREATE TABLE users (
+                id BIGINT NOT NULL PRIMARY KEY,
+                email TEXT NOT NULL
+            );
+            "#,
+        )
+        .unwrap();
+
+        let ops = compute_diff(&current, &target);
+        let incomplete_ops: Vec<MigrationOp> = ops
+            .into_iter()
+            .filter(|op| !matches!(op, MigrationOp::AddColumn { .. }))
+            .collect();
+
+        let target_schemas = vec!["public".to_string()];
+
+        let result = validate_migration_on_temp_db(
+            &incomplete_ops,
+            &url,
+            &current,
+            &target,
+            &target_schemas,
+        )
+        .await
+        .unwrap();
+
+        assert!(result.success);
+        assert!(result.execution_errors.is_empty());
+        assert!(!result.idempotent);
+        assert!(!result.residual_ops.is_empty());
+        assert!(result
+            .residual_ops
+            .iter()
+            .any(|op| matches!(op, MigrationOp::AddColumn { .. })));
+    }
+
+    #[tokio::test]
+    async fn execution_error_skips_idempotency() {
+        let (_container, url) = setup_temp_postgres().await;
+
+        let current = Schema::default();
+        let target = parse_sql_string(
+            r#"
+            CREATE TABLE users (
+                id BIGINT NOT NULL PRIMARY KEY
+            );
+            "#,
+        )
+        .unwrap();
+
+        let invalid_ops = vec![MigrationOp::DropTable("nonexistent_table".to_string())];
+        let target_schemas = vec!["public".to_string()];
+
+        let result =
+            validate_migration_on_temp_db(&invalid_ops, &url, &current, &target, &target_schemas)
+                .await
+                .unwrap();
+
         assert!(!result.success);
-        assert_eq!(result.errors.len(), 1);
-        assert!(result.errors[0].error_message.contains("nonexistent_table"));
+        assert!(!result.execution_errors.is_empty());
+        assert!(result.residual_ops.is_empty());
     }
 }

--- a/tests/validate.rs
+++ b/tests/validate.rs
@@ -1,0 +1,190 @@
+mod common;
+use common::*;
+use pgmold::diff::planner::plan_migration;
+use pgmold::validate::validate_migration_on_temp_db;
+
+#[tokio::test]
+async fn validate_idempotency_check() {
+    let (_container, url) = setup_postgres().await;
+    let connection = PgConnection::new(&url).await.unwrap();
+
+    let target_schema = parse_sql_string(
+        r#"
+        CREATE TABLE users (
+            id BIGINT NOT NULL PRIMARY KEY,
+            email TEXT NOT NULL
+        );
+        "#,
+    )
+    .unwrap();
+
+    let current_schema = introspect_schema(&connection, &["public".to_string()], false)
+        .await
+        .unwrap();
+    assert!(
+        current_schema.tables.is_empty(),
+        "Database should start empty"
+    );
+
+    let ops = compute_diff(&current_schema, &target_schema);
+    assert!(!ops.is_empty(), "Should have operations to create table");
+
+    let planned_ops = plan_migration(ops);
+    let target_schemas = vec!["public".to_string()];
+
+    let result = validate_migration_on_temp_db(
+        &planned_ops,
+        &url,
+        &current_schema,
+        &target_schema,
+        &target_schemas,
+    )
+    .await
+    .unwrap();
+
+    assert!(result.success, "Migration should execute successfully");
+    assert!(
+        result.execution_errors.is_empty(),
+        "Should have no execution errors"
+    );
+    assert!(result.idempotent, "Migration should be idempotent");
+    assert!(
+        result.residual_ops.is_empty(),
+        "Should have no residual operations"
+    );
+}
+
+#[tokio::test]
+async fn validate_with_existing_schema_idempotency() {
+    let (_container, url) = setup_postgres().await;
+    let connection = PgConnection::new(&url).await.unwrap();
+
+    sqlx::query(
+        r#"
+        CREATE TABLE users (
+            id BIGINT NOT NULL PRIMARY KEY
+        )
+        "#,
+    )
+    .execute(connection.pool())
+    .await
+    .unwrap();
+
+    let target_schema = parse_sql_string(
+        r#"
+        CREATE TABLE users (
+            id BIGINT NOT NULL PRIMARY KEY,
+            email TEXT NOT NULL,
+            bio TEXT
+        );
+        "#,
+    )
+    .unwrap();
+
+    let current_schema = introspect_schema(&connection, &["public".to_string()], false)
+        .await
+        .unwrap();
+    assert!(
+        current_schema.tables.contains_key("public.users"),
+        "Should have users table"
+    );
+
+    let ops = compute_diff(&current_schema, &target_schema);
+    assert!(!ops.is_empty(), "Should have operations to add columns");
+
+    let planned_ops = plan_migration(ops);
+    let target_schemas = vec!["public".to_string()];
+
+    sqlx::query("CREATE DATABASE temp_validation")
+        .execute(connection.pool())
+        .await
+        .unwrap();
+
+    let temp_url = format!("{}/temp_validation", url.rsplit_once('/').unwrap().0);
+
+    let result = validate_migration_on_temp_db(
+        &planned_ops,
+        &temp_url,
+        &current_schema,
+        &target_schema,
+        &target_schemas,
+    )
+    .await
+    .unwrap();
+
+    assert!(result.success, "Migration should execute successfully");
+    assert!(
+        result.execution_errors.is_empty(),
+        "Should have no execution errors"
+    );
+    assert!(result.idempotent, "Migration should be idempotent");
+    assert!(
+        result.residual_ops.is_empty(),
+        "Should have no residual operations"
+    );
+}
+
+#[tokio::test]
+async fn validate_multi_schema_idempotency() {
+    let (_container, url) = setup_postgres().await;
+    let connection = PgConnection::new(&url).await.unwrap();
+
+    sqlx::query("CREATE SCHEMA auth")
+        .execute(connection.pool())
+        .await
+        .unwrap();
+    sqlx::query("CREATE SCHEMA api")
+        .execute(connection.pool())
+        .await
+        .unwrap();
+
+    let target_schema = parse_sql_string(
+        r#"
+        CREATE SCHEMA IF NOT EXISTS auth;
+        CREATE SCHEMA IF NOT EXISTS api;
+
+        CREATE TABLE auth.users (
+            id INTEGER PRIMARY KEY,
+            email TEXT NOT NULL
+        );
+
+        CREATE TABLE api.sessions (
+            id INTEGER PRIMARY KEY,
+            user_id INTEGER,
+            token TEXT NOT NULL,
+            FOREIGN KEY (user_id) REFERENCES auth.users(id)
+        );
+        "#,
+    )
+    .unwrap();
+
+    let current_schema =
+        introspect_schema(&connection, &["auth".to_string(), "api".to_string()], false)
+            .await
+            .unwrap();
+
+    let ops = compute_diff(&current_schema, &target_schema);
+    let planned_ops = plan_migration(ops);
+    let target_schemas = vec!["auth".to_string(), "api".to_string()];
+
+    let result = validate_migration_on_temp_db(
+        &planned_ops,
+        &url,
+        &current_schema,
+        &target_schema,
+        &target_schemas,
+    )
+    .await
+    .unwrap();
+
+    assert!(result.success, "Migration should execute successfully");
+    assert!(
+        result.execution_errors.is_empty(),
+        "Should have no execution errors"
+    );
+    assert!(result.idempotent, "Migration should be idempotent");
+    assert!(
+        result.residual_ops.is_empty(),
+        "Should have no residual operations"
+    );
+}


### PR DESCRIPTION
## Summary

Enhances `--validate` flag to verify migration plan completeness via idempotency check.

**Before**: Validation only checked that SQL executed without errors.
**After**: Validation also re-diffs the resulting schema against target to ensure no residual operations remain.

## Changes

- Add `residual_ops` and `idempotent` fields to `ValidationResult`
- Update `validate_migration_on_temp_db` to accept `target_schema` parameter
- Add idempotency status to CLI output (text and JSON modes)
- Add 5 unit tests + 3 integration tests

## Test plan

- [x] Unit tests: idempotent, incomplete, execution error scenarios
- [x] Integration tests: end-to-end validation with testcontainers
- [x] `cargo test` passes (594 tests)
- [x] `cargo clippy` passes

Closes pgmold-71