### PR TITLE
fix: normalize named function arguments in policy expression comparison

### DIFF
--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -44,6 +44,46 @@ pub fn canonicalize_expression(expr: &str) -> String {
     strip_numeric_literal_casts(&result)
 }
 
+/// Strips nested expressions from a FunctionArgExpr (owned version).
+fn strip_all_nested_function_arg_expr(
+    arg_expr: sqlparser::ast::FunctionArgExpr,
+) -> sqlparser::ast::FunctionArgExpr {
+    match arg_expr {
+        sqlparser::ast::FunctionArgExpr::Expr(e) => {
+            sqlparser::ast::FunctionArgExpr::Expr(strip_all_nested(e))
+        }
+        other => other,
+    }
+}
+
+/// Strips nested expressions from a FunctionArg (owned version).
+/// Handles all variants: Unnamed, Named, ExprNamed.
+fn strip_all_nested_function_arg(arg: sqlparser::ast::FunctionArg) -> sqlparser::ast::FunctionArg {
+    match arg {
+        sqlparser::ast::FunctionArg::Unnamed(arg_expr) => {
+            sqlparser::ast::FunctionArg::Unnamed(strip_all_nested_function_arg_expr(arg_expr))
+        }
+        sqlparser::ast::FunctionArg::Named {
+            name,
+            arg,
+            operator,
+        } => sqlparser::ast::FunctionArg::Named {
+            name,
+            arg: strip_all_nested_function_arg_expr(arg),
+            operator,
+        },
+        sqlparser::ast::FunctionArg::ExprNamed {
+            name,
+            arg,
+            operator,
+        } => sqlparser::ast::FunctionArg::ExprNamed {
+            name: strip_all_nested(name),
+            arg: strip_all_nested_function_arg_expr(arg),
+            operator,
+        },
+    }
+}
+
 /// Recursively strips ALL Nested (parenthesized) expressions throughout the AST,
 /// not just the outermost ones. This is needed for normalizing CHECK constraint
 /// expressions where PostgreSQL may add extra parentheses around subexpressions.
@@ -126,14 +166,7 @@ fn strip_all_nested(expr: Expr) -> Expr {
                         args: args
                             .args
                             .into_iter()
-                            .map(|arg| match arg {
-                                sqlparser::ast::FunctionArg::Unnamed(
-                                    sqlparser::ast::FunctionArgExpr::Expr(e),
-                                ) => sqlparser::ast::FunctionArg::Unnamed(
-                                    sqlparser::ast::FunctionArgExpr::Expr(strip_all_nested(e)),
-                                ),
-                                other => other,
-                            })
+                            .map(strip_all_nested_function_arg)
                             .collect(),
                         clauses: args.clauses,
                     })
@@ -664,6 +697,47 @@ fn normalize_object_name(name: &sqlparser::ast::ObjectName) -> sqlparser::ast::O
     sqlparser::ast::ObjectName(normalized_parts)
 }
 
+/// Normalizes a FunctionArgExpr, recursively normalizing contained expressions.
+fn normalize_function_arg_expr(
+    arg_expr: &sqlparser::ast::FunctionArgExpr,
+) -> sqlparser::ast::FunctionArgExpr {
+    match arg_expr {
+        sqlparser::ast::FunctionArgExpr::Expr(e) => {
+            sqlparser::ast::FunctionArgExpr::Expr(normalize_expr(e))
+        }
+        other => other.clone(),
+    }
+}
+
+/// Normalizes a FunctionArg, handling all variants (Unnamed, Named, ExprNamed).
+/// This ensures that expressions inside function arguments are normalized,
+/// including stripping table qualifiers from column references.
+fn normalize_function_arg(arg: &sqlparser::ast::FunctionArg) -> sqlparser::ast::FunctionArg {
+    match arg {
+        sqlparser::ast::FunctionArg::Unnamed(arg_expr) => {
+            sqlparser::ast::FunctionArg::Unnamed(normalize_function_arg_expr(arg_expr))
+        }
+        sqlparser::ast::FunctionArg::Named {
+            name,
+            arg,
+            operator,
+        } => sqlparser::ast::FunctionArg::Named {
+            name: normalize_ident(name),
+            arg: normalize_function_arg_expr(arg),
+            operator: operator.clone(),
+        },
+        sqlparser::ast::FunctionArg::ExprNamed {
+            name,
+            arg,
+            operator,
+        } => sqlparser::ast::FunctionArg::ExprNamed {
+            name: normalize_expr(name),
+            arg: normalize_function_arg_expr(arg),
+            operator: operator.clone(),
+        },
+    }
+}
+
 /// Normalizes a TableFactor (the source in a FROM clause).
 fn normalize_table_factor(factor: &sqlparser::ast::TableFactor) -> sqlparser::ast::TableFactor {
     use sqlparser::ast::TableFactor;
@@ -1050,18 +1124,7 @@ fn normalize_expr(expr: &Expr) -> Expr {
                 sqlparser::ast::FunctionArguments::List(args) => {
                     sqlparser::ast::FunctionArguments::List(sqlparser::ast::FunctionArgumentList {
                         duplicate_treatment: args.duplicate_treatment,
-                        args: args
-                            .args
-                            .iter()
-                            .map(|arg| match arg {
-                                sqlparser::ast::FunctionArg::Unnamed(
-                                    sqlparser::ast::FunctionArgExpr::Expr(e),
-                                ) => sqlparser::ast::FunctionArg::Unnamed(
-                                    sqlparser::ast::FunctionArgExpr::Expr(normalize_expr(e)),
-                                ),
-                                other => other.clone(),
-                            })
-                            .collect(),
+                        args: args.args.iter().map(normalize_function_arg).collect(),
                         clauses: args.clauses.clone(),
                     })
                 }
@@ -1835,5 +1898,37 @@ fn expression_comparison_handles_null_with_type_cast() {
     assert!(
         expressions_semantically_equal(without_cast, with_cast),
         "NULL vs NULL::uuid should be semantically equal"
+    );
+}
+
+#[test]
+fn expression_comparison_handles_named_function_args_with_table_qualifier() {
+    // Bug: PostgreSQL strips table qualifiers from column references in policy expressions
+    // when the table context is unambiguous (policy always references its target table).
+    //
+    // Schema file: auth.user_in_context(p_supplier_id => farmers.supplier_id)
+    // PostgreSQL returns: auth.user_in_context(p_supplier_id => supplier_id)
+    //
+    // This is a regression test for issue #XX - table qualifier normalization in named args
+
+    let schema_expr = r#"auth.user_in_context(p_supplier_id => farmers.supplier_id)"#;
+    let db_expr = r#"auth.user_in_context(p_supplier_id => supplier_id)"#;
+
+    assert!(
+        expressions_semantically_equal(schema_expr, db_expr),
+        "Named function args should normalize table qualifiers: {schema_expr} vs {db_expr}"
+    );
+}
+
+#[test]
+fn expression_comparison_handles_multiple_named_args_with_table_qualifiers() {
+    // More complex case with multiple named arguments
+    let schema_expr =
+        r#"auth.user_has_permission('farmers', 'create', p_supplier_id => farmers.supplier_id)"#;
+    let db_expr = r#"auth.user_has_permission('farmers'::text, 'create'::text, p_supplier_id => supplier_id)"#;
+
+    assert!(
+        expressions_semantically_equal(schema_expr, db_expr),
+        "Mixed positional/named args with table qualifiers and text casts should normalize"
     );
 }


### PR DESCRIPTION
## Summary

- Fix table qualifier normalization in named function arguments within policy expressions
- Previously only unnamed function arguments were normalized
- Now normalizes all `FunctionArg` variants: `Unnamed`, `Named`, and `ExprNamed`

## Problem

PostgreSQL's `pg_get_expr()` strips table qualifiers from column references in policy USING/WITH CHECK expressions when the table context is unambiguous. For example:

| Schema File | PostgreSQL Normalized |
|-------------|----------------------|
| `farmers.supplier_id` | `supplier_id` |
| `'farmers'` | `'farmers'::text` |

This caused false positive diffs for policies using named parameters like:

```sql
-- Schema file
auth.user_in_context(p_supplier_id => farmers.supplier_id)

-- Database (after normalization)
auth.user_in_context(p_supplier_id => supplier_id)
```

## Root Cause

The `normalize_expr` and `strip_all_nested` functions only handled `FunctionArg::Unnamed` arguments, not `Named` or `ExprNamed` variants used for PostgreSQL's named argument syntax (`param => value`).

## Fix

Added helper functions to normalize all function argument variants:
- `normalize_function_arg` / `normalize_function_arg_expr` (for reference-based normalization)
- `strip_all_nested_function_arg` / `strip_all_nested_function_arg_expr` (for ownership-based normalization)

## Test Plan

- [x] Added unit tests for named function argument normalization
- [x] All 608 existing tests pass
- [x] Policy integration tests pass