### PR TITLE
feat(api): add embeddable library API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,12 @@ name = "pgmold"
 version = "0.21.0"
 edition = "2021"
 exclude = [".auto-claude/", ".auto-claude-security.json", ".claude_settings.json"]
-description = "PostgreSQL schema-as-code management tool"
+description = "PostgreSQL schema-as-code library and CLI. Parse SQL, diff schemas, generate migrations."
 license = "MIT"
 repository = "https://github.com/fmguerreiro/pgmold"
-keywords = ["postgresql", "schema", "migrations", "database", "cli"]
-categories = ["command-line-utilities", "database"]
+readme = "README.md"
+keywords = ["postgresql", "schema", "migrations", "database", "diff"]
+categories = ["database", "command-line-utilities", "development-tools"]
 
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }

--- a/docs/plans/2025-02-04-embeddable-library-design.md
+++ b/docs/plans/2025-02-04-embeddable-library-design.md
@@ -1,0 +1,278 @@
+# Embeddable Library API Design
+
+## Overview
+
+Refactor pgmold to expose a clean, high-level public API for embedding in other Rust applications. The API mirrors CLI commands with structured inputs and outputs.
+
+## Decisions
+
+- **Single crate**: Keep existing structure, improve API surface
+- **High-level API**: Functions mirror CLI commands (`plan`, `apply`, `diff`, etc.)
+- **Async + sync**: Async primary, `_blocking` variants for convenience
+- **Typed errors**: Custom `pgmold::Error` enum for programmatic handling
+
+## Public API Surface
+
+### Module: `pgmold::api`
+
+New module containing high-level functions:
+
+```rust
+// Core operations
+pub async fn plan(options: PlanOptions) -> Result<PlanResult, Error>;
+pub async fn apply(options: ApplyOptions) -> Result<ApplyResult, Error>;
+pub async fn diff(options: DiffOptions) -> Result<DiffResult, Error>;
+pub async fn drift(options: DriftOptions) -> Result<DriftResult, Error>;
+pub async fn dump(options: DumpOptions) -> Result<DumpResult, Error>;
+pub async fn lint(options: LintOptions) -> Result<LintResult, Error>;
+
+// Blocking variants
+pub fn plan_blocking(options: PlanOptions) -> Result<PlanResult, Error>;
+pub fn apply_blocking(options: ApplyOptions) -> Result<ApplyResult, Error>;
+pub fn diff_blocking(options: DiffOptions) -> Result<DiffResult, Error>;
+pub fn drift_blocking(options: DriftOptions) -> Result<DriftResult, Error>;
+pub fn dump_blocking(options: DumpOptions) -> Result<DumpResult, Error>;
+pub fn lint_blocking(options: LintOptions) -> Result<LintResult, Error>;
+```
+
+### Options Types
+
+Builder pattern with required fields in constructor:
+
+```rust
+pub struct PlanOptions {
+    pub schema_sources: Vec<String>,      // e.g., ["sql:schema.sql"]
+    pub database_url: String,             // e.g., "postgres://localhost/db"
+    pub target_schemas: Vec<String>,      // default: ["public"]
+    pub filter: Option<Filter>,
+    pub reverse: bool,
+    pub zero_downtime: bool,
+    pub manage_ownership: bool,
+    pub manage_grants: bool,
+    pub include_extension_objects: bool,
+}
+
+pub struct ApplyOptions {
+    pub schema_sources: Vec<String>,
+    pub database_url: String,
+    pub target_schemas: Vec<String>,
+    pub filter: Option<Filter>,
+    pub allow_destructive: bool,
+    pub dry_run: bool,
+    pub manage_ownership: bool,
+    pub manage_grants: bool,
+    pub include_extension_objects: bool,
+}
+
+pub struct DiffOptions {
+    pub from: String,  // schema source
+    pub to: String,    // schema source
+}
+
+pub struct DriftOptions {
+    pub schema_sources: Vec<String>,
+    pub database_url: String,
+    pub target_schemas: Vec<String>,
+}
+
+pub struct DumpOptions {
+    pub database_url: String,
+    pub target_schemas: Vec<String>,
+    pub filter: Option<Filter>,
+    pub include_extension_objects: bool,
+}
+
+pub struct LintOptions {
+    pub schema_sources: Vec<String>,
+    pub database_url: Option<String>,
+    pub target_schemas: Vec<String>,
+}
+```
+
+### Result Types
+
+Structured results for programmatic consumption:
+
+```rust
+pub struct PlanResult {
+    pub operations: Vec<MigrationOp>,
+    pub statements: Vec<String>,
+    pub lock_warnings: Vec<LockWarning>,
+    pub is_empty: bool,
+}
+
+pub struct PhasedPlanResult {
+    pub expand: Vec<String>,
+    pub backfill: Vec<String>,
+    pub contract: Vec<String>,
+}
+
+pub struct ApplyResult {
+    pub statements_executed: usize,
+    pub dry_run: bool,
+}
+
+pub struct DiffResult {
+    pub operations: Vec<MigrationOp>,
+    pub is_empty: bool,
+}
+
+pub struct DriftResult {
+    pub has_drift: bool,
+    pub expected_fingerprint: String,
+    pub actual_fingerprint: String,
+    pub differences: Vec<MigrationOp>,
+}
+
+pub struct DumpResult {
+    pub sql: String,
+    pub schema: Schema,
+}
+
+pub struct LintResult {
+    pub issues: Vec<LintIssue>,
+    pub has_errors: bool,
+}
+```
+
+### Error Type
+
+```rust
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("Parse error: {message}")]
+    Parse { message: String, source: Option<Box<dyn std::error::Error + Send + Sync>> },
+
+    #[error("Database connection failed: {message}")]
+    Connection { message: String, source: Option<Box<dyn std::error::Error + Send + Sync>> },
+
+    #[error("Introspection failed: {message}")]
+    Introspection { message: String },
+
+    #[error("Invalid filter pattern: {pattern}")]
+    InvalidFilter { pattern: String },
+
+    #[error("Migration validation failed: {message}")]
+    Validation { message: String, errors: Vec<ValidationError> },
+
+    #[error("Migration execution failed: {message}")]
+    Execution { message: String, statement_index: usize },
+
+    #[error("Lint check failed with errors")]
+    LintFailed { issues: Vec<LintIssue> },
+
+    #[error("Invalid schema source: {source}")]
+    InvalidSource { source: String },
+}
+```
+
+### Prelude Module
+
+For convenient imports:
+
+```rust
+// src/prelude.rs
+pub use crate::api::{
+    plan, plan_blocking,
+    apply, apply_blocking,
+    diff, diff_blocking,
+    drift, drift_blocking,
+    dump, dump_blocking,
+    lint, lint_blocking,
+    PlanOptions, PlanResult, PhasedPlanResult,
+    ApplyOptions, ApplyResult,
+    DiffOptions, DiffResult,
+    DriftOptions, DriftResult,
+    DumpOptions, DumpResult,
+    LintOptions, LintResult,
+    Error,
+};
+pub use crate::filter::{Filter, ObjectType};
+pub use crate::model::Schema;
+pub use crate::diff::MigrationOp;
+```
+
+## File Changes
+
+| File | Change |
+|------|--------|
+| `src/api/mod.rs` | New - high-level API functions |
+| `src/api/options.rs` | New - options structs with builders |
+| `src/api/results.rs` | New - result structs |
+| `src/api/error.rs` | New - typed error enum |
+| `src/prelude.rs` | New - convenient re-exports |
+| `src/lib.rs` | Add `pub mod api; pub mod prelude;` |
+| `src/cli/mod.rs` | Refactor to use `pgmold::api::*` internally |
+| `Cargo.toml` | Update keywords/categories for library discoverability |
+
+## Usage Examples
+
+### Basic Plan
+
+```rust
+use pgmold::prelude::*;
+
+let options = PlanOptions {
+    schema_sources: vec!["sql:schema.sql".into()],
+    database_url: "postgres://localhost/mydb".into(),
+    target_schemas: vec!["public".into()],
+    ..Default::default()
+};
+
+let result = plan_blocking(options)?;
+for statement in &result.statements {
+    println!("{}", statement);
+}
+```
+
+### Async with Tokio
+
+```rust
+use pgmold::prelude::*;
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    let result = plan(PlanOptions {
+        schema_sources: vec!["sql:schema.sql".into()],
+        database_url: "postgres://localhost/mydb".into(),
+        ..Default::default()
+    }).await?;
+
+    if result.is_empty {
+        println!("No changes needed");
+    }
+    Ok(())
+}
+```
+
+### Diff Two Schemas
+
+```rust
+use pgmold::prelude::*;
+
+let result = diff_blocking(DiffOptions {
+    from: "sql:old_schema.sql".into(),
+    to: "sql:new_schema.sql".into(),
+})?;
+
+for op in &result.operations {
+    println!("{:?}", op);
+}
+```
+
+## Implementation Order
+
+1. Create `src/api/error.rs` - typed error enum
+2. Create `src/api/options.rs` - options structs
+3. Create `src/api/results.rs` - result structs
+4. Create `src/api/mod.rs` - async functions wrapping existing logic
+5. Add blocking variants using `tokio::runtime::Runtime`
+6. Create `src/prelude.rs` - re-exports
+7. Update `src/lib.rs` - expose new modules
+8. Refactor `src/cli/mod.rs` - use new API internally
+9. Add integration tests for library API
+10. Update documentation
+
+## Semver Commitment
+
+The `api` module is the stable public interface. Internal modules (`parser`, `pg`, `diff` internals) may change between minor versions. The `api` module follows semver strictly.

--- a/src/api/error.rs
+++ b/src/api/error.rs
@@ -1,26 +1,36 @@
 use thiserror::Error;
 
 /// Structured error type for pgmold library operations.
+///
+/// This enum is marked `#[non_exhaustive]` to allow adding new variants
+/// in future versions without breaking semver.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum Error {
+    /// Failed to parse schema SQL.
     #[error("Parse error: {message}")]
     Parse { message: String },
 
+    /// Failed to connect to database.
     #[error("Database connection failed: {message}")]
     Connection { message: String },
 
+    /// Failed to introspect database schema.
     #[error("Introspection failed: {message}")]
     Introspection { message: String },
 
+    /// Invalid glob pattern in filter.
     #[error("Invalid filter pattern: {pattern}")]
     InvalidFilter { pattern: String },
 
+    /// Migration validation failed on temp database.
     #[error("Migration validation failed: {message}")]
     Validation {
         message: String,
         errors: Vec<ValidationError>,
     },
 
+    /// Migration statement execution failed.
     #[error("Migration execution failed at statement {statement_index}: {message}")]
     Execution {
         message: String,
@@ -28,15 +38,14 @@ pub enum Error {
         sql: String,
     },
 
+    /// Lint check found errors.
     #[error("Lint check failed with {count} error(s)")]
     LintFailed {
         count: usize,
         issues: Vec<crate::lint::LintResult>,
     },
 
-    #[error("Invalid schema source: {schema_source}")]
-    InvalidSource { schema_source: String },
-
+    /// Failed to create tokio runtime (blocking API only).
     #[error("Runtime error: {message}")]
     Runtime { message: String },
 }
@@ -50,36 +59,35 @@ pub struct ValidationError {
 }
 
 impl Error {
+    /// Create a parse error.
     pub fn parse(message: impl Into<String>) -> Self {
         Self::Parse {
             message: message.into(),
         }
     }
 
+    /// Create a connection error.
     pub fn connection(message: impl Into<String>) -> Self {
         Self::Connection {
             message: message.into(),
         }
     }
 
+    /// Create an introspection error.
     pub fn introspection(message: impl Into<String>) -> Self {
         Self::Introspection {
             message: message.into(),
         }
     }
 
+    /// Create an invalid filter error.
     pub fn invalid_filter(pattern: impl Into<String>) -> Self {
         Self::InvalidFilter {
             pattern: pattern.into(),
         }
     }
 
-    pub fn invalid_source(schema_source: impl Into<String>) -> Self {
-        Self::InvalidSource {
-            schema_source: schema_source.into(),
-        }
-    }
-
+    /// Create a runtime error.
     pub fn runtime(message: impl Into<String>) -> Self {
         Self::Runtime {
             message: message.into(),

--- a/src/api/error.rs
+++ b/src/api/error.rs
@@ -1,0 +1,88 @@
+use thiserror::Error;
+
+/// Structured error type for pgmold library operations.
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("Parse error: {message}")]
+    Parse { message: String },
+
+    #[error("Database connection failed: {message}")]
+    Connection { message: String },
+
+    #[error("Introspection failed: {message}")]
+    Introspection { message: String },
+
+    #[error("Invalid filter pattern: {pattern}")]
+    InvalidFilter { pattern: String },
+
+    #[error("Migration validation failed: {message}")]
+    Validation {
+        message: String,
+        errors: Vec<ValidationError>,
+    },
+
+    #[error("Migration execution failed at statement {statement_index}: {message}")]
+    Execution {
+        message: String,
+        statement_index: usize,
+        sql: String,
+    },
+
+    #[error("Lint check failed with {count} error(s)")]
+    LintFailed {
+        count: usize,
+        issues: Vec<crate::lint::LintResult>,
+    },
+
+    #[error("Invalid schema source: {schema_source}")]
+    InvalidSource { schema_source: String },
+
+    #[error("Runtime error: {message}")]
+    Runtime { message: String },
+}
+
+/// Details about a validation error during migration testing.
+#[derive(Debug, Clone)]
+pub struct ValidationError {
+    pub statement_index: usize,
+    pub sql: String,
+    pub error_message: String,
+}
+
+impl Error {
+    pub fn parse(message: impl Into<String>) -> Self {
+        Self::Parse {
+            message: message.into(),
+        }
+    }
+
+    pub fn connection(message: impl Into<String>) -> Self {
+        Self::Connection {
+            message: message.into(),
+        }
+    }
+
+    pub fn introspection(message: impl Into<String>) -> Self {
+        Self::Introspection {
+            message: message.into(),
+        }
+    }
+
+    pub fn invalid_filter(pattern: impl Into<String>) -> Self {
+        Self::InvalidFilter {
+            pattern: pattern.into(),
+        }
+    }
+
+    pub fn invalid_source(schema_source: impl Into<String>) -> Self {
+        Self::InvalidSource {
+            schema_source: schema_source.into(),
+        }
+    }
+
+    pub fn runtime(message: impl Into<String>) -> Self {
+        Self::Runtime {
+            message: message.into(),
+        }
+    }
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -17,6 +17,15 @@
 //!     println!("{}", statement);
 //! }
 //! ```
+//!
+//! # Async vs Blocking
+//!
+//! All functions have both async and blocking variants. Use async when you
+//! already have a tokio runtime. Use blocking variants for simple scripts
+//! or when embedding in non-async code.
+//!
+//! Note: Blocking variants create a new tokio runtime per call. For
+//! high-frequency usage, prefer the async API with a shared runtime.
 
 mod error;
 mod options;
@@ -30,64 +39,97 @@ pub use results::{
     ApplyResult, DiffResult, DriftResult, DumpResult, LintApiResult, PhasedPlanResult, PlanResult,
 };
 
-use crate::diff::{compute_diff, compute_diff_with_flags, planner::plan_migration};
+use crate::diff::{compute_diff, compute_diff_with_flags, planner::plan_migration, MigrationOp};
 use crate::drift::detect_drift as drift_detect;
 use crate::dump::generate_dump;
-use crate::expand_contract::expand_operations;
-use crate::filter::filter_schema;
+use crate::expand_contract::{expand_operations, PhasedOp};
+use crate::filter::{filter_schema, Filter};
 use crate::lint::locks::detect_lock_hazards;
 use crate::lint::{has_errors, lint_migration_plan, LintOptions};
+use crate::model::Schema;
 use crate::pg::connection::PgConnection;
 use crate::pg::introspect::introspect_schema;
 use crate::pg::sqlgen::generate_sql;
 use crate::provider::load_schema_from_sources;
 use sqlx::Executor;
 
-/// Generate a migration plan comparing schema sources to a database.
-pub async fn plan(options: PlanOptions) -> Result<PlanResult, Error> {
-    let target = load_schema_from_sources(&options.schema_sources)
-        .map_err(|e| Error::parse(e.to_string()))?;
+// ============================================================================
+// Helper functions to reduce duplication
+// ============================================================================
 
-    let filtered_target = if let Some(ref filter) = options.filter {
-        filter_schema(&target, filter)
-    } else {
-        target.clone()
-    };
+fn load_and_filter_schema(sources: &[String], filter: Option<&Filter>) -> Result<Schema, Error> {
+    let schema = load_schema_from_sources(sources).map_err(|e| Error::parse(e.to_string()))?;
+    Ok(apply_filter(schema, filter))
+}
 
-    let connection = PgConnection::new(&options.database_url)
+async fn connect_and_introspect(
+    database_url: &str,
+    target_schemas: &[String],
+    include_extension_objects: bool,
+    filter: Option<&Filter>,
+) -> Result<(PgConnection, Schema), Error> {
+    let connection = PgConnection::new(database_url)
         .await
         .map_err(|e| Error::connection(e.to_string()))?;
 
-    let db_schema = introspect_schema(
-        &connection,
+    let db_schema = introspect_schema(&connection, target_schemas, include_extension_objects)
+        .await
+        .map_err(|e| Error::introspection(e.to_string()))?;
+
+    let filtered = apply_filter(db_schema, filter);
+    Ok((connection, filtered))
+}
+
+fn apply_filter(schema: Schema, filter: Option<&Filter>) -> Schema {
+    match filter {
+        Some(f) => filter_schema(&schema, f),
+        None => schema,
+    }
+}
+
+fn compute_migration(
+    from: &Schema,
+    to: &Schema,
+    manage_ownership: bool,
+    manage_grants: bool,
+) -> Vec<MigrationOp> {
+    plan_migration(compute_diff_with_flags(
+        from,
+        to,
+        manage_ownership,
+        manage_grants,
+    ))
+}
+
+fn phased_ops_to_sql(ops: &[PhasedOp]) -> Vec<String> {
+    ops.iter()
+        .flat_map(|phased_op| generate_sql(std::slice::from_ref(&phased_op.op)))
+        .collect()
+}
+
+// ============================================================================
+// Public API functions
+// ============================================================================
+
+/// Generate a migration plan comparing schema sources to a database.
+pub async fn plan(options: PlanOptions) -> Result<PlanResult, Error> {
+    let target = load_and_filter_schema(&options.schema_sources, options.filter.as_ref())?;
+
+    let (_connection, db_schema) = connect_and_introspect(
+        &options.database_url,
         &options.target_schemas,
         options.include_extension_objects,
+        options.filter.as_ref(),
     )
-    .await
-    .map_err(|e| Error::introspection(e.to_string()))?;
+    .await?;
 
-    let filtered_db_schema = if let Some(ref filter) = options.filter {
-        filter_schema(&db_schema, filter)
+    let (from, to) = if options.reverse {
+        (&target, &db_schema)
     } else {
-        db_schema.clone()
+        (&db_schema, &target)
     };
 
-    let ops = if options.reverse {
-        plan_migration(compute_diff_with_flags(
-            &filtered_target,
-            &filtered_db_schema,
-            options.manage_ownership,
-            options.manage_grants,
-        ))
-    } else {
-        plan_migration(compute_diff_with_flags(
-            &filtered_db_schema,
-            &filtered_target,
-            options.manage_ownership,
-            options.manage_grants,
-        ))
-    };
-
+    let ops = compute_migration(from, to, options.manage_ownership, options.manage_grants);
     let lock_warnings = detect_lock_hazards(&ops);
     let statements = generate_sql(&ops);
     let is_empty = ops.is_empty();
@@ -102,74 +144,34 @@ pub async fn plan(options: PlanOptions) -> Result<PlanResult, Error> {
 
 /// Generate a zero-downtime migration plan with expand/backfill/contract phases.
 pub async fn plan_phased(options: PlanOptions) -> Result<PhasedPlanResult, Error> {
-    let result = plan(PlanOptions {
-        zero_downtime: false, // We handle phasing here
-        ..options
-    })
-    .await?;
-
+    let result = plan(options).await?;
     let phased = expand_operations(result.operations);
 
-    let expand: Vec<String> = phased
-        .expand_ops
-        .iter()
-        .flat_map(|phased_op| generate_sql(std::slice::from_ref(&phased_op.op)))
-        .collect();
-
-    let backfill: Vec<String> = phased
-        .backfill_ops
-        .iter()
-        .flat_map(|phased_op| generate_sql(std::slice::from_ref(&phased_op.op)))
-        .collect();
-
-    let contract: Vec<String> = phased
-        .contract_ops
-        .iter()
-        .flat_map(|phased_op| generate_sql(std::slice::from_ref(&phased_op.op)))
-        .collect();
-
     Ok(PhasedPlanResult {
-        expand,
-        backfill,
-        contract,
+        expand: phased_ops_to_sql(&phased.expand_ops),
+        backfill: phased_ops_to_sql(&phased.backfill_ops),
+        contract: phased_ops_to_sql(&phased.contract_ops),
     })
 }
 
 /// Apply migrations to a database.
 pub async fn apply(options: ApplyOptions) -> Result<ApplyResult, Error> {
-    let target = load_schema_from_sources(&options.schema_sources)
-        .map_err(|e| Error::parse(e.to_string()))?;
+    let target = load_and_filter_schema(&options.schema_sources, options.filter.as_ref())?;
 
-    let filtered_target = if let Some(ref filter) = options.filter {
-        filter_schema(&target, filter)
-    } else {
-        target.clone()
-    };
-
-    let connection = PgConnection::new(&options.database_url)
-        .await
-        .map_err(|e| Error::connection(e.to_string()))?;
-
-    let db_schema = introspect_schema(
-        &connection,
+    let (connection, db_schema) = connect_and_introspect(
+        &options.database_url,
         &options.target_schemas,
         options.include_extension_objects,
+        options.filter.as_ref(),
     )
-    .await
-    .map_err(|e| Error::introspection(e.to_string()))?;
+    .await?;
 
-    let filtered_db_schema = if let Some(ref filter) = options.filter {
-        filter_schema(&db_schema, filter)
-    } else {
-        db_schema.clone()
-    };
-
-    let ops = plan_migration(compute_diff_with_flags(
-        &filtered_db_schema,
-        &filtered_target,
+    let ops = compute_migration(
+        &db_schema,
+        &target,
         options.manage_ownership,
         options.manage_grants,
-    ));
+    );
 
     let lint_options = LintOptions {
         allow_destructive: options.allow_destructive,
@@ -240,7 +242,6 @@ pub async fn apply(options: ApplyOptions) -> Result<ApplyResult, Error> {
 pub async fn diff(options: DiffOptions) -> Result<DiffResult, Error> {
     let from_schema =
         load_schema_from_sources(&[options.from]).map_err(|e| Error::parse(e.to_string()))?;
-
     let to_schema =
         load_schema_from_sources(&[options.to]).map_err(|e| Error::parse(e.to_string()))?;
 
@@ -277,23 +278,13 @@ pub async fn drift(options: DriftOptions) -> Result<DriftResult, Error> {
 
 /// Dump database schema to SQL DDL.
 pub async fn dump(options: DumpOptions) -> Result<DumpResult, Error> {
-    let connection = PgConnection::new(&options.database_url)
-        .await
-        .map_err(|e| Error::connection(e.to_string()))?;
-
-    let db_schema = introspect_schema(
-        &connection,
+    let (_connection, schema) = connect_and_introspect(
+        &options.database_url,
         &options.target_schemas,
         options.include_extension_objects,
+        options.filter.as_ref(),
     )
-    .await
-    .map_err(|e| Error::introspection(e.to_string()))?;
-
-    let schema = if let Some(ref filter) = options.filter {
-        filter_schema(&db_schema, filter)
-    } else {
-        db_schema
-    };
+    .await?;
 
     let sql = generate_dump(&schema, None);
 
@@ -338,6 +329,9 @@ fn create_runtime() -> Result<tokio::runtime::Runtime, Error> {
 }
 
 /// Blocking variant of [`plan`].
+///
+/// Creates a new tokio runtime for each call. For high-frequency usage,
+/// prefer the async API with a shared runtime.
 pub fn plan_blocking(options: PlanOptions) -> Result<PlanResult, Error> {
     create_runtime()?.block_on(plan(options))
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,0 +1,373 @@
+//! High-level API for embedding pgmold in other applications.
+//!
+//! This module provides functions that mirror CLI commands with structured
+//! inputs and outputs. Both async and blocking variants are available.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use pgmold::api::{plan_blocking, PlanOptions};
+//!
+//! let result = plan_blocking(PlanOptions::new(
+//!     vec!["sql:schema.sql".into()],
+//!     "postgres://localhost/mydb",
+//! )).unwrap();
+//!
+//! for statement in &result.statements {
+//!     println!("{}", statement);
+//! }
+//! ```
+
+mod error;
+mod options;
+mod results;
+
+pub use error::{Error, ValidationError};
+pub use options::{
+    ApplyOptions, DiffOptions, DriftOptions, DumpOptions, LintApiOptions, PlanOptions,
+};
+pub use results::{
+    ApplyResult, DiffResult, DriftResult, DumpResult, LintApiResult, PhasedPlanResult, PlanResult,
+};
+
+use crate::diff::{compute_diff, compute_diff_with_flags, planner::plan_migration};
+use crate::drift::detect_drift as drift_detect;
+use crate::dump::generate_dump;
+use crate::expand_contract::expand_operations;
+use crate::filter::filter_schema;
+use crate::lint::locks::detect_lock_hazards;
+use crate::lint::{has_errors, lint_migration_plan, LintOptions};
+use crate::pg::connection::PgConnection;
+use crate::pg::introspect::introspect_schema;
+use crate::pg::sqlgen::generate_sql;
+use crate::provider::load_schema_from_sources;
+use sqlx::Executor;
+
+/// Generate a migration plan comparing schema sources to a database.
+pub async fn plan(options: PlanOptions) -> Result<PlanResult, Error> {
+    let target = load_schema_from_sources(&options.schema_sources)
+        .map_err(|e| Error::parse(e.to_string()))?;
+
+    let filtered_target = if let Some(ref filter) = options.filter {
+        filter_schema(&target, filter)
+    } else {
+        target.clone()
+    };
+
+    let connection = PgConnection::new(&options.database_url)
+        .await
+        .map_err(|e| Error::connection(e.to_string()))?;
+
+    let db_schema = introspect_schema(
+        &connection,
+        &options.target_schemas,
+        options.include_extension_objects,
+    )
+    .await
+    .map_err(|e| Error::introspection(e.to_string()))?;
+
+    let filtered_db_schema = if let Some(ref filter) = options.filter {
+        filter_schema(&db_schema, filter)
+    } else {
+        db_schema.clone()
+    };
+
+    let ops = if options.reverse {
+        plan_migration(compute_diff_with_flags(
+            &filtered_target,
+            &filtered_db_schema,
+            options.manage_ownership,
+            options.manage_grants,
+        ))
+    } else {
+        plan_migration(compute_diff_with_flags(
+            &filtered_db_schema,
+            &filtered_target,
+            options.manage_ownership,
+            options.manage_grants,
+        ))
+    };
+
+    let lock_warnings = detect_lock_hazards(&ops);
+    let statements = generate_sql(&ops);
+    let is_empty = ops.is_empty();
+
+    Ok(PlanResult {
+        operations: ops,
+        statements,
+        lock_warnings,
+        is_empty,
+    })
+}
+
+/// Generate a zero-downtime migration plan with expand/backfill/contract phases.
+pub async fn plan_phased(options: PlanOptions) -> Result<PhasedPlanResult, Error> {
+    let result = plan(PlanOptions {
+        zero_downtime: false, // We handle phasing here
+        ..options
+    })
+    .await?;
+
+    let phased = expand_operations(result.operations);
+
+    let expand: Vec<String> = phased
+        .expand_ops
+        .iter()
+        .flat_map(|phased_op| generate_sql(std::slice::from_ref(&phased_op.op)))
+        .collect();
+
+    let backfill: Vec<String> = phased
+        .backfill_ops
+        .iter()
+        .flat_map(|phased_op| generate_sql(std::slice::from_ref(&phased_op.op)))
+        .collect();
+
+    let contract: Vec<String> = phased
+        .contract_ops
+        .iter()
+        .flat_map(|phased_op| generate_sql(std::slice::from_ref(&phased_op.op)))
+        .collect();
+
+    Ok(PhasedPlanResult {
+        expand,
+        backfill,
+        contract,
+    })
+}
+
+/// Apply migrations to a database.
+pub async fn apply(options: ApplyOptions) -> Result<ApplyResult, Error> {
+    let target = load_schema_from_sources(&options.schema_sources)
+        .map_err(|e| Error::parse(e.to_string()))?;
+
+    let filtered_target = if let Some(ref filter) = options.filter {
+        filter_schema(&target, filter)
+    } else {
+        target.clone()
+    };
+
+    let connection = PgConnection::new(&options.database_url)
+        .await
+        .map_err(|e| Error::connection(e.to_string()))?;
+
+    let db_schema = introspect_schema(
+        &connection,
+        &options.target_schemas,
+        options.include_extension_objects,
+    )
+    .await
+    .map_err(|e| Error::introspection(e.to_string()))?;
+
+    let filtered_db_schema = if let Some(ref filter) = options.filter {
+        filter_schema(&db_schema, filter)
+    } else {
+        db_schema.clone()
+    };
+
+    let ops = plan_migration(compute_diff_with_flags(
+        &filtered_db_schema,
+        &filtered_target,
+        options.manage_ownership,
+        options.manage_grants,
+    ));
+
+    let lint_options = LintOptions {
+        allow_destructive: options.allow_destructive,
+        ..Default::default()
+    };
+    let lint_results = lint_migration_plan(&ops, &lint_options);
+
+    if has_errors(&lint_results) {
+        return Err(Error::LintFailed {
+            count: lint_results
+                .iter()
+                .filter(|r| r.severity == crate::lint::LintSeverity::Error)
+                .count(),
+            issues: lint_results,
+        });
+    }
+
+    let statements = generate_sql(&ops);
+
+    if statements.is_empty() {
+        return Ok(ApplyResult {
+            statements_executed: 0,
+            dry_run: options.dry_run,
+        });
+    }
+
+    if options.dry_run {
+        return Ok(ApplyResult {
+            statements_executed: statements.len(),
+            dry_run: true,
+        });
+    }
+
+    let mut transaction = connection
+        .pool()
+        .begin()
+        .await
+        .map_err(|e| Error::Execution {
+            message: format!("Failed to begin transaction: {e}"),
+            statement_index: 0,
+            sql: String::new(),
+        })?;
+
+    for (i, statement) in statements.iter().enumerate() {
+        transaction
+            .execute(statement.as_str())
+            .await
+            .map_err(|e| Error::Execution {
+                message: e.to_string(),
+                statement_index: i,
+                sql: statement.clone(),
+            })?;
+    }
+
+    transaction.commit().await.map_err(|e| Error::Execution {
+        message: format!("Failed to commit transaction: {e}"),
+        statement_index: statements.len(),
+        sql: String::new(),
+    })?;
+
+    Ok(ApplyResult {
+        statements_executed: statements.len(),
+        dry_run: false,
+    })
+}
+
+/// Compare two schemas and return differences.
+pub async fn diff(options: DiffOptions) -> Result<DiffResult, Error> {
+    let from_schema =
+        load_schema_from_sources(&[options.from]).map_err(|e| Error::parse(e.to_string()))?;
+
+    let to_schema =
+        load_schema_from_sources(&[options.to]).map_err(|e| Error::parse(e.to_string()))?;
+
+    let ops = compute_diff(&from_schema, &to_schema);
+    let is_empty = ops.is_empty();
+
+    Ok(DiffResult {
+        operations: ops,
+        is_empty,
+    })
+}
+
+/// Detect schema drift between sources and database.
+pub async fn drift(options: DriftOptions) -> Result<DriftResult, Error> {
+    let connection = PgConnection::new(&options.database_url)
+        .await
+        .map_err(|e| Error::connection(e.to_string()))?;
+
+    let report = drift_detect(
+        &options.schema_sources,
+        &connection,
+        &options.target_schemas,
+    )
+    .await
+    .map_err(|e| Error::introspection(e.to_string()))?;
+
+    Ok(DriftResult {
+        has_drift: report.has_drift,
+        expected_fingerprint: report.expected_fingerprint,
+        actual_fingerprint: report.actual_fingerprint,
+        differences: report.differences,
+    })
+}
+
+/// Dump database schema to SQL DDL.
+pub async fn dump(options: DumpOptions) -> Result<DumpResult, Error> {
+    let connection = PgConnection::new(&options.database_url)
+        .await
+        .map_err(|e| Error::connection(e.to_string()))?;
+
+    let db_schema = introspect_schema(
+        &connection,
+        &options.target_schemas,
+        options.include_extension_objects,
+    )
+    .await
+    .map_err(|e| Error::introspection(e.to_string()))?;
+
+    let schema = if let Some(ref filter) = options.filter {
+        filter_schema(&db_schema, filter)
+    } else {
+        db_schema
+    };
+
+    let sql = generate_dump(&schema, None);
+
+    Ok(DumpResult { sql, schema })
+}
+
+/// Lint schema or migration plan.
+pub async fn lint(options: LintApiOptions) -> Result<LintApiResult, Error> {
+    let target = load_schema_from_sources(&options.schema_sources)
+        .map_err(|e| Error::parse(e.to_string()))?;
+
+    let ops = if let Some(ref db_url) = options.database_url {
+        let connection = PgConnection::new(db_url)
+            .await
+            .map_err(|e| Error::connection(e.to_string()))?;
+
+        let current = introspect_schema(&connection, &options.target_schemas, false)
+            .await
+            .map_err(|e| Error::introspection(e.to_string()))?;
+
+        plan_migration(compute_diff(&current, &target))
+    } else {
+        vec![]
+    };
+
+    let lint_options = LintOptions::default();
+    let issues = lint_migration_plan(&ops, &lint_options);
+    let has_errs = has_errors(&issues);
+
+    Ok(LintApiResult {
+        issues,
+        has_errors: has_errs,
+    })
+}
+
+// ============================================================================
+// Blocking variants
+// ============================================================================
+
+fn create_runtime() -> Result<tokio::runtime::Runtime, Error> {
+    tokio::runtime::Runtime::new().map_err(|e| Error::runtime(e.to_string()))
+}
+
+/// Blocking variant of [`plan`].
+pub fn plan_blocking(options: PlanOptions) -> Result<PlanResult, Error> {
+    create_runtime()?.block_on(plan(options))
+}
+
+/// Blocking variant of [`plan_phased`].
+pub fn plan_phased_blocking(options: PlanOptions) -> Result<PhasedPlanResult, Error> {
+    create_runtime()?.block_on(plan_phased(options))
+}
+
+/// Blocking variant of [`apply`].
+pub fn apply_blocking(options: ApplyOptions) -> Result<ApplyResult, Error> {
+    create_runtime()?.block_on(apply(options))
+}
+
+/// Blocking variant of [`diff`].
+pub fn diff_blocking(options: DiffOptions) -> Result<DiffResult, Error> {
+    create_runtime()?.block_on(diff(options))
+}
+
+/// Blocking variant of [`drift`].
+pub fn drift_blocking(options: DriftOptions) -> Result<DriftResult, Error> {
+    create_runtime()?.block_on(drift(options))
+}
+
+/// Blocking variant of [`dump`].
+pub fn dump_blocking(options: DumpOptions) -> Result<DumpResult, Error> {
+    create_runtime()?.block_on(dump(options))
+}
+
+/// Blocking variant of [`lint`].
+pub fn lint_blocking(options: LintApiOptions) -> Result<LintApiResult, Error> {
+    create_runtime()?.block_on(lint(options))
+}

--- a/src/api/options.rs
+++ b/src/api/options.rs
@@ -1,0 +1,216 @@
+use crate::filter::Filter;
+
+/// Options for generating a migration plan.
+#[derive(Debug, Clone)]
+pub struct PlanOptions {
+    /// Schema sources with prefix (e.g., "sql:schema.sql", "drizzle:config.ts")
+    pub schema_sources: Vec<String>,
+    /// Database connection URL (without "db:" prefix)
+    pub database_url: String,
+    /// PostgreSQL schemas to target (default: ["public"])
+    pub target_schemas: Vec<String>,
+    /// Optional filter for including/excluding objects
+    pub filter: Option<Filter>,
+    /// Generate rollback SQL (schema → database direction)
+    pub reverse: bool,
+    /// Generate zero-downtime expand/contract migration
+    pub zero_downtime: bool,
+    /// Include ownership management (ALTER ... OWNER TO)
+    pub manage_ownership: bool,
+    /// Include grant management (GRANT/REVOKE)
+    pub manage_grants: bool,
+    /// Include objects owned by extensions
+    pub include_extension_objects: bool,
+}
+
+impl Default for PlanOptions {
+    fn default() -> Self {
+        Self {
+            schema_sources: Vec::new(),
+            database_url: String::new(),
+            target_schemas: vec!["public".into()],
+            filter: None,
+            reverse: false,
+            zero_downtime: false,
+            manage_ownership: false,
+            manage_grants: true,
+            include_extension_objects: false,
+        }
+    }
+}
+
+impl PlanOptions {
+    pub fn new(schema_sources: Vec<String>, database_url: impl Into<String>) -> Self {
+        Self {
+            schema_sources,
+            database_url: database_url.into(),
+            ..Default::default()
+        }
+    }
+}
+
+/// Options for applying migrations.
+#[derive(Debug, Clone)]
+pub struct ApplyOptions {
+    /// Schema sources with prefix
+    pub schema_sources: Vec<String>,
+    /// Database connection URL (without "db:" prefix)
+    pub database_url: String,
+    /// PostgreSQL schemas to target
+    pub target_schemas: Vec<String>,
+    /// Optional filter for including/excluding objects
+    pub filter: Option<Filter>,
+    /// Allow destructive operations (DROP, etc.)
+    pub allow_destructive: bool,
+    /// Preview only, don't execute
+    pub dry_run: bool,
+    /// Include ownership management
+    pub manage_ownership: bool,
+    /// Include grant management
+    pub manage_grants: bool,
+    /// Include objects owned by extensions
+    pub include_extension_objects: bool,
+}
+
+impl Default for ApplyOptions {
+    fn default() -> Self {
+        Self {
+            schema_sources: Vec::new(),
+            database_url: String::new(),
+            target_schemas: vec!["public".into()],
+            filter: None,
+            allow_destructive: false,
+            dry_run: false,
+            manage_ownership: false,
+            manage_grants: true,
+            include_extension_objects: false,
+        }
+    }
+}
+
+impl ApplyOptions {
+    pub fn new(schema_sources: Vec<String>, database_url: impl Into<String>) -> Self {
+        Self {
+            schema_sources,
+            database_url: database_url.into(),
+            ..Default::default()
+        }
+    }
+}
+
+/// Options for comparing two schemas.
+#[derive(Debug, Clone)]
+pub struct DiffOptions {
+    /// Source schema (e.g., "sql:old.sql")
+    pub from: String,
+    /// Target schema (e.g., "sql:new.sql")
+    pub to: String,
+}
+
+impl DiffOptions {
+    pub fn new(from: impl Into<String>, to: impl Into<String>) -> Self {
+        Self {
+            from: from.into(),
+            to: to.into(),
+        }
+    }
+}
+
+/// Options for detecting schema drift.
+#[derive(Debug, Clone)]
+pub struct DriftOptions {
+    /// Schema sources with prefix
+    pub schema_sources: Vec<String>,
+    /// Database connection URL (without "db:" prefix)
+    pub database_url: String,
+    /// PostgreSQL schemas to target
+    pub target_schemas: Vec<String>,
+}
+
+impl Default for DriftOptions {
+    fn default() -> Self {
+        Self {
+            schema_sources: Vec::new(),
+            database_url: String::new(),
+            target_schemas: vec!["public".into()],
+        }
+    }
+}
+
+impl DriftOptions {
+    pub fn new(schema_sources: Vec<String>, database_url: impl Into<String>) -> Self {
+        Self {
+            schema_sources,
+            database_url: database_url.into(),
+            ..Default::default()
+        }
+    }
+}
+
+/// Options for dumping database schema.
+#[derive(Debug, Clone)]
+pub struct DumpOptions {
+    /// Database connection URL (without "db:" prefix)
+    pub database_url: String,
+    /// PostgreSQL schemas to dump
+    pub target_schemas: Vec<String>,
+    /// Optional filter for including/excluding objects
+    pub filter: Option<Filter>,
+    /// Include objects owned by extensions
+    pub include_extension_objects: bool,
+}
+
+impl Default for DumpOptions {
+    fn default() -> Self {
+        Self {
+            database_url: String::new(),
+            target_schemas: vec!["public".into()],
+            filter: None,
+            include_extension_objects: false,
+        }
+    }
+}
+
+impl DumpOptions {
+    pub fn new(database_url: impl Into<String>) -> Self {
+        Self {
+            database_url: database_url.into(),
+            ..Default::default()
+        }
+    }
+}
+
+/// Options for linting schema or migration plan.
+#[derive(Debug, Clone)]
+pub struct LintApiOptions {
+    /// Schema sources with prefix
+    pub schema_sources: Vec<String>,
+    /// Optional database URL for migration linting
+    pub database_url: Option<String>,
+    /// PostgreSQL schemas to target
+    pub target_schemas: Vec<String>,
+}
+
+impl Default for LintApiOptions {
+    fn default() -> Self {
+        Self {
+            schema_sources: Vec::new(),
+            database_url: None,
+            target_schemas: vec!["public".into()],
+        }
+    }
+}
+
+impl LintApiOptions {
+    pub fn new(schema_sources: Vec<String>) -> Self {
+        Self {
+            schema_sources,
+            ..Default::default()
+        }
+    }
+
+    pub fn with_database(mut self, database_url: impl Into<String>) -> Self {
+        self.database_url = Some(database_url.into());
+        self
+    }
+}

--- a/src/api/options.rs
+++ b/src/api/options.rs
@@ -13,8 +13,6 @@ pub struct PlanOptions {
     pub filter: Option<Filter>,
     /// Generate rollback SQL (schema → database direction)
     pub reverse: bool,
-    /// Generate zero-downtime expand/contract migration
-    pub zero_downtime: bool,
     /// Include ownership management (ALTER ... OWNER TO)
     pub manage_ownership: bool,
     /// Include grant management (GRANT/REVOKE)
@@ -31,7 +29,6 @@ impl Default for PlanOptions {
             target_schemas: vec!["public".into()],
             filter: None,
             reverse: false,
-            zero_downtime: false,
             manage_ownership: false,
             manage_grants: true,
             include_extension_objects: false,
@@ -40,12 +37,49 @@ impl Default for PlanOptions {
 }
 
 impl PlanOptions {
+    /// Create new plan options with required fields.
     pub fn new(schema_sources: Vec<String>, database_url: impl Into<String>) -> Self {
         Self {
             schema_sources,
             database_url: database_url.into(),
             ..Default::default()
         }
+    }
+
+    /// Set target schemas.
+    pub fn with_target_schemas(mut self, schemas: Vec<String>) -> Self {
+        self.target_schemas = schemas;
+        self
+    }
+
+    /// Set filter for including/excluding objects.
+    pub fn with_filter(mut self, filter: Filter) -> Self {
+        self.filter = Some(filter);
+        self
+    }
+
+    /// Generate rollback SQL (reverse direction).
+    pub fn reverse(mut self) -> Self {
+        self.reverse = true;
+        self
+    }
+
+    /// Include ownership management.
+    pub fn manage_ownership(mut self) -> Self {
+        self.manage_ownership = true;
+        self
+    }
+
+    /// Disable grant management (enabled by default).
+    pub fn without_grants(mut self) -> Self {
+        self.manage_grants = false;
+        self
+    }
+
+    /// Include extension-owned objects.
+    pub fn include_extension_objects(mut self) -> Self {
+        self.include_extension_objects = true;
+        self
     }
 }
 
@@ -89,12 +123,55 @@ impl Default for ApplyOptions {
 }
 
 impl ApplyOptions {
+    /// Create new apply options with required fields.
     pub fn new(schema_sources: Vec<String>, database_url: impl Into<String>) -> Self {
         Self {
             schema_sources,
             database_url: database_url.into(),
             ..Default::default()
         }
+    }
+
+    /// Set target schemas.
+    pub fn with_target_schemas(mut self, schemas: Vec<String>) -> Self {
+        self.target_schemas = schemas;
+        self
+    }
+
+    /// Set filter for including/excluding objects.
+    pub fn with_filter(mut self, filter: Filter) -> Self {
+        self.filter = Some(filter);
+        self
+    }
+
+    /// Allow destructive operations (DROP, etc.).
+    pub fn allow_destructive(mut self) -> Self {
+        self.allow_destructive = true;
+        self
+    }
+
+    /// Enable dry run mode (preview only).
+    pub fn dry_run(mut self) -> Self {
+        self.dry_run = true;
+        self
+    }
+
+    /// Include ownership management.
+    pub fn manage_ownership(mut self) -> Self {
+        self.manage_ownership = true;
+        self
+    }
+
+    /// Disable grant management (enabled by default).
+    pub fn without_grants(mut self) -> Self {
+        self.manage_grants = false;
+        self
+    }
+
+    /// Include extension-owned objects.
+    pub fn include_extension_objects(mut self) -> Self {
+        self.include_extension_objects = true;
+        self
     }
 }
 
@@ -108,6 +185,7 @@ pub struct DiffOptions {
 }
 
 impl DiffOptions {
+    /// Create new diff options.
     pub fn new(from: impl Into<String>, to: impl Into<String>) -> Self {
         Self {
             from: from.into(),
@@ -138,12 +216,19 @@ impl Default for DriftOptions {
 }
 
 impl DriftOptions {
+    /// Create new drift options with required fields.
     pub fn new(schema_sources: Vec<String>, database_url: impl Into<String>) -> Self {
         Self {
             schema_sources,
             database_url: database_url.into(),
             ..Default::default()
         }
+    }
+
+    /// Set target schemas.
+    pub fn with_target_schemas(mut self, schemas: Vec<String>) -> Self {
+        self.target_schemas = schemas;
+        self
     }
 }
 
@@ -172,11 +257,30 @@ impl Default for DumpOptions {
 }
 
 impl DumpOptions {
+    /// Create new dump options with required fields.
     pub fn new(database_url: impl Into<String>) -> Self {
         Self {
             database_url: database_url.into(),
             ..Default::default()
         }
+    }
+
+    /// Set target schemas.
+    pub fn with_target_schemas(mut self, schemas: Vec<String>) -> Self {
+        self.target_schemas = schemas;
+        self
+    }
+
+    /// Set filter for including/excluding objects.
+    pub fn with_filter(mut self, filter: Filter) -> Self {
+        self.filter = Some(filter);
+        self
+    }
+
+    /// Include extension-owned objects.
+    pub fn include_extension_objects(mut self) -> Self {
+        self.include_extension_objects = true;
+        self
     }
 }
 
@@ -202,6 +306,7 @@ impl Default for LintApiOptions {
 }
 
 impl LintApiOptions {
+    /// Create new lint options with required fields.
     pub fn new(schema_sources: Vec<String>) -> Self {
         Self {
             schema_sources,
@@ -209,8 +314,15 @@ impl LintApiOptions {
         }
     }
 
+    /// Set database URL for migration linting.
     pub fn with_database(mut self, database_url: impl Into<String>) -> Self {
         self.database_url = Some(database_url.into());
+        self
+    }
+
+    /// Set target schemas.
+    pub fn with_target_schemas(mut self, schemas: Vec<String>) -> Self {
+        self.target_schemas = schemas;
         self
     }
 }

--- a/src/api/results.rs
+++ b/src/api/results.rs
@@ -1,0 +1,113 @@
+use crate::diff::MigrationOp;
+use crate::lint::locks::LockWarning;
+use crate::lint::LintResult as LintIssue;
+use crate::model::Schema;
+
+/// Result of a migration plan operation.
+#[derive(Debug, Clone)]
+pub struct PlanResult {
+    /// Migration operations in execution order
+    pub operations: Vec<MigrationOp>,
+    /// SQL statements to execute
+    pub statements: Vec<String>,
+    /// Lock hazard warnings
+    pub lock_warnings: Vec<LockWarning>,
+    /// Whether the plan is empty (no changes needed)
+    pub is_empty: bool,
+}
+
+impl PlanResult {
+    pub fn empty() -> Self {
+        Self {
+            operations: Vec::new(),
+            statements: Vec::new(),
+            lock_warnings: Vec::new(),
+            is_empty: true,
+        }
+    }
+}
+
+/// Result of a zero-downtime migration plan.
+#[derive(Debug, Clone)]
+pub struct PhasedPlanResult {
+    /// Expand phase: additive, safe changes
+    pub expand: Vec<String>,
+    /// Backfill phase: data migration statements
+    pub backfill: Vec<String>,
+    /// Contract phase: cleanup, requires verification
+    pub contract: Vec<String>,
+}
+
+impl PhasedPlanResult {
+    pub fn is_empty(&self) -> bool {
+        self.expand.is_empty() && self.backfill.is_empty() && self.contract.is_empty()
+    }
+
+    pub fn total_statements(&self) -> usize {
+        self.expand.len() + self.backfill.len() + self.contract.len()
+    }
+}
+
+/// Result of applying migrations.
+#[derive(Debug, Clone)]
+pub struct ApplyResult {
+    /// Number of statements executed
+    pub statements_executed: usize,
+    /// Whether this was a dry run
+    pub dry_run: bool,
+}
+
+/// Result of comparing two schemas.
+#[derive(Debug, Clone)]
+pub struct DiffResult {
+    /// Migration operations representing differences
+    pub operations: Vec<MigrationOp>,
+    /// Whether schemas are identical
+    pub is_empty: bool,
+}
+
+impl DiffResult {
+    pub fn empty() -> Self {
+        Self {
+            operations: Vec::new(),
+            is_empty: true,
+        }
+    }
+}
+
+/// Result of drift detection.
+#[derive(Debug, Clone)]
+pub struct DriftResult {
+    /// Whether drift was detected
+    pub has_drift: bool,
+    /// Expected schema fingerprint (from sources)
+    pub expected_fingerprint: String,
+    /// Actual schema fingerprint (from database)
+    pub actual_fingerprint: String,
+    /// Operations representing drift
+    pub differences: Vec<MigrationOp>,
+}
+
+/// Result of schema dump.
+#[derive(Debug, Clone)]
+pub struct DumpResult {
+    /// Generated SQL DDL
+    pub sql: String,
+    /// Parsed schema (for further inspection)
+    pub schema: Schema,
+}
+
+/// Result of schema/migration linting.
+#[derive(Debug, Clone)]
+pub struct LintApiResult {
+    /// Lint issues found
+    pub issues: Vec<LintIssue>,
+    /// Whether any errors (not just warnings) were found
+    pub has_errors: bool,
+}
+
+impl LintApiResult {
+    pub fn is_clean(&self) -> bool {
+        self.issues.is_empty()
+    }
+}

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -86,11 +86,29 @@ impl ObjectType {
     }
 }
 
+#[derive(Clone)]
 pub struct Filter {
     include: Vec<Pattern>,
     exclude: Vec<Pattern>,
     include_types: HashSet<ObjectType>,
     exclude_types: HashSet<ObjectType>,
+}
+
+impl std::fmt::Debug for Filter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Filter")
+            .field(
+                "include",
+                &self.include.iter().map(|p| p.as_str()).collect::<Vec<_>>(),
+            )
+            .field(
+                "exclude",
+                &self.exclude.iter().map(|p| p.as_str()).collect::<Vec<_>>(),
+            )
+            .field("include_types", &self.include_types)
+            .field("exclude_types", &self.exclude_types)
+            .finish()
+    }
 }
 
 impl Filter {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,35 @@
+//! pgmold - PostgreSQL schema-as-code management library.
+//!
+//! This crate provides tools for managing PostgreSQL schemas declaratively.
+//! Define schemas in native SQL, diff against live databases, and apply migrations safely.
+//!
+//! # Quick Start
+//!
+//! Use the high-level API via the [`api`] module or [`prelude`]:
+//!
+//! ```no_run
+//! use pgmold::prelude::*;
+//!
+//! // Generate a migration plan
+//! let result = plan_blocking(PlanOptions::new(
+//!     vec!["sql:schema.sql".into()],
+//!     "postgres://localhost/mydb",
+//! )).unwrap();
+//!
+//! for statement in &result.statements {
+//!     println!("{}", statement);
+//! }
+//! ```
+//!
+//! # Modules
+//!
+//! - [`api`] - High-level API mirroring CLI commands
+//! - [`prelude`] - Convenient re-exports for common usage
+//! - [`model`] - Schema model types (Table, Column, Index, etc.)
+//! - [`diff`] - Schema comparison and migration operations
+//! - [`filter`] - Object filtering by name and type
+
+pub mod api;
 pub mod apply;
 pub mod baseline;
 pub mod diff;
@@ -10,6 +42,7 @@ pub mod migrate;
 pub mod model;
 pub mod parser;
 pub mod pg;
+pub mod prelude;
 pub mod provider;
 pub mod util;
 pub mod validate;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -13,43 +13,32 @@
 //! println!("Generated {} statements", result.statements.len());
 //! ```
 
+// Async functions
+pub use crate::api::{apply, diff, drift, dump, lint, plan, plan_phased};
+
+// Blocking functions
 pub use crate::api::{
-    // Async functions
-    apply,
-    // Blocking functions
-    apply_blocking,
-    diff,
-    diff_blocking,
-    drift,
-    drift_blocking,
-    dump,
-    dump_blocking,
-    lint,
-    lint_blocking,
-    plan,
-    plan_blocking,
-    plan_phased,
+    apply_blocking, diff_blocking, drift_blocking, dump_blocking, lint_blocking, plan_blocking,
     plan_phased_blocking,
-    // Options
-    ApplyOptions,
-    // Results
-    ApplyResult,
-    DiffOptions,
-    DiffResult,
-    DriftOptions,
-    DriftResult,
-    DumpOptions,
-    DumpResult,
-    // Error
-    Error,
-    LintApiOptions,
-    LintApiResult,
-    PhasedPlanResult,
-    PlanOptions,
-    PlanResult,
-    ValidationError,
 };
 
+// Options
+pub use crate::api::{
+    ApplyOptions, DiffOptions, DriftOptions, DumpOptions, LintApiOptions, PlanOptions,
+};
+
+// Results
+pub use crate::api::{
+    ApplyResult, DiffResult, DriftResult, DumpResult, LintApiResult, PhasedPlanResult, PlanResult,
+};
+
+// Error types
+pub use crate::api::{Error, ValidationError};
+
+// Core types
 pub use crate::diff::MigrationOp;
 pub use crate::filter::{Filter, ObjectType};
 pub use crate::model::Schema;
+
+// Re-export LintResult as LintIssue for accessing Error::LintFailed issues
+pub use crate::lint::LintResult as LintIssue;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,0 +1,55 @@
+//! Convenient re-exports for common pgmold usage.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use pgmold::prelude::*;
+//!
+//! let result = plan_blocking(PlanOptions::new(
+//!     vec!["sql:schema.sql".into()],
+//!     "postgres://localhost/mydb",
+//! )).unwrap();
+//!
+//! println!("Generated {} statements", result.statements.len());
+//! ```
+
+pub use crate::api::{
+    // Async functions
+    apply,
+    // Blocking functions
+    apply_blocking,
+    diff,
+    diff_blocking,
+    drift,
+    drift_blocking,
+    dump,
+    dump_blocking,
+    lint,
+    lint_blocking,
+    plan,
+    plan_blocking,
+    plan_phased,
+    plan_phased_blocking,
+    // Options
+    ApplyOptions,
+    // Results
+    ApplyResult,
+    DiffOptions,
+    DiffResult,
+    DriftOptions,
+    DriftResult,
+    DumpOptions,
+    DumpResult,
+    // Error
+    Error,
+    LintApiOptions,
+    LintApiResult,
+    PhasedPlanResult,
+    PlanOptions,
+    PlanResult,
+    ValidationError,
+};
+
+pub use crate::diff::MigrationOp;
+pub use crate::filter::{Filter, ObjectType};
+pub use crate::model::Schema;

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -1,0 +1,122 @@
+//! Integration tests for the library API.
+
+use pgmold::prelude::*;
+use std::fs;
+use tempfile::tempdir;
+
+#[test]
+fn diff_two_sql_files() {
+    let dir = tempdir().unwrap();
+
+    let old_path = dir.path().join("old.sql");
+    fs::write(
+        &old_path,
+        "CREATE TABLE users (id SERIAL PRIMARY KEY, name TEXT);",
+    )
+    .unwrap();
+
+    let new_path = dir.path().join("new.sql");
+    fs::write(
+        &new_path,
+        "CREATE TABLE users (id SERIAL PRIMARY KEY, name TEXT, email TEXT);",
+    )
+    .unwrap();
+
+    let result = diff_blocking(DiffOptions::new(
+        format!("sql:{}", old_path.display()),
+        format!("sql:{}", new_path.display()),
+    ))
+    .unwrap();
+
+    assert!(!result.is_empty);
+    assert!(!result.operations.is_empty());
+
+    // Should have an AddColumn operation
+    let has_add_column = result
+        .operations
+        .iter()
+        .any(|op| matches!(op, MigrationOp::AddColumn { column, .. } if column.name == "email"));
+    assert!(has_add_column);
+}
+
+#[test]
+fn diff_identical_schemas_is_empty() {
+    let dir = tempdir().unwrap();
+
+    let schema_path = dir.path().join("schema.sql");
+    fs::write(&schema_path, "CREATE TABLE users (id SERIAL PRIMARY KEY);").unwrap();
+
+    let result = diff_blocking(DiffOptions::new(
+        format!("sql:{}", schema_path.display()),
+        format!("sql:{}", schema_path.display()),
+    ))
+    .unwrap();
+
+    assert!(result.is_empty);
+    assert!(result.operations.is_empty());
+}
+
+#[test]
+fn plan_options_defaults() {
+    let options = PlanOptions::new(vec!["sql:schema.sql".into()], "postgres://localhost/test");
+
+    assert_eq!(options.target_schemas, vec!["public"]);
+    assert!(!options.reverse);
+    assert!(!options.zero_downtime);
+    assert!(!options.manage_ownership);
+    assert!(options.manage_grants);
+    assert!(!options.include_extension_objects);
+}
+
+#[test]
+fn apply_options_defaults() {
+    let options = ApplyOptions::new(vec!["sql:schema.sql".into()], "postgres://localhost/test");
+
+    assert_eq!(options.target_schemas, vec!["public"]);
+    assert!(!options.allow_destructive);
+    assert!(!options.dry_run);
+    assert!(!options.manage_ownership);
+    assert!(options.manage_grants);
+}
+
+#[test]
+fn lint_options_builder() {
+    let options = LintApiOptions::new(vec!["sql:schema.sql".into()])
+        .with_database("postgres://localhost/test");
+
+    assert!(options.database_url.is_some());
+    assert_eq!(options.target_schemas, vec!["public"]);
+}
+
+#[test]
+fn error_display() {
+    let err = Error::parse("syntax error near 'SELEC'");
+    assert!(err.to_string().contains("Parse error"));
+    assert!(err.to_string().contains("syntax error"));
+
+    let err = Error::connection("connection refused");
+    assert!(err.to_string().contains("connection"));
+
+    let err = Error::invalid_source("unknown:foo.sql");
+    assert!(err.to_string().contains("Invalid schema source"));
+}
+
+#[test]
+fn plan_result_empty() {
+    let result = PlanResult::empty();
+    assert!(result.is_empty);
+    assert!(result.statements.is_empty());
+    assert!(result.operations.is_empty());
+}
+
+#[test]
+fn phased_plan_result_methods() {
+    let result = PhasedPlanResult {
+        expand: vec!["ALTER TABLE users ADD COLUMN email TEXT;".into()],
+        backfill: vec![],
+        contract: vec!["ALTER TABLE users DROP COLUMN old_email;".into()],
+    };
+
+    assert!(!result.is_empty());
+    assert_eq!(result.total_statements(), 2);
+}

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -62,10 +62,21 @@ fn plan_options_defaults() {
 
     assert_eq!(options.target_schemas, vec!["public"]);
     assert!(!options.reverse);
-    assert!(!options.zero_downtime);
     assert!(!options.manage_ownership);
     assert!(options.manage_grants);
     assert!(!options.include_extension_objects);
+}
+
+#[test]
+fn plan_options_builder() {
+    let options = PlanOptions::new(vec!["sql:schema.sql".into()], "postgres://localhost/test")
+        .reverse()
+        .manage_ownership()
+        .with_target_schemas(vec!["public".into(), "auth".into()]);
+
+    assert!(options.reverse);
+    assert!(options.manage_ownership);
+    assert_eq!(options.target_schemas, vec!["public", "auth"]);
 }
 
 #[test]
@@ -77,6 +88,16 @@ fn apply_options_defaults() {
     assert!(!options.dry_run);
     assert!(!options.manage_ownership);
     assert!(options.manage_grants);
+}
+
+#[test]
+fn apply_options_builder() {
+    let options = ApplyOptions::new(vec!["sql:schema.sql".into()], "postgres://localhost/test")
+        .allow_destructive()
+        .dry_run();
+
+    assert!(options.allow_destructive);
+    assert!(options.dry_run);
 }
 
 #[test]
@@ -97,8 +118,8 @@ fn error_display() {
     let err = Error::connection("connection refused");
     assert!(err.to_string().contains("connection"));
 
-    let err = Error::invalid_source("unknown:foo.sql");
-    assert!(err.to_string().contains("Invalid schema source"));
+    let err = Error::introspection("failed to query pg_catalog");
+    assert!(err.to_string().contains("Introspection failed"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Expose high-level API for embedding pgmold in other Rust applications:

- `plan`, `apply`, `diff`, `drift`, `dump`, `lint` functions mirroring CLI commands
- Both async and `_blocking` variants
- Typed `Error` enum for programmatic handling
- `prelude` module for convenient imports

## Usage

```rust
use pgmold::prelude::*;

let result = plan_blocking(PlanOptions::new(
    vec!["sql:schema.sql".into()],
    "postgres://localhost/mydb",
))?;

for statement in &result.statements {
    println!("{}", statement);
}
```

## Test plan

- [x] Unit tests for options and results
- [x] Integration test for diff operations (`tests/api.rs`)
- [x] Doc-tests compile
- [x] All existing tests pass