### PR TITLE
fix(planner): order grants/revokes after object creation

### DIFF
--- a/tests/sequences.rs
+++ b/tests/sequences.rs
@@ -217,11 +217,6 @@ async fn sequence_with_grants_from_scratch() {
     let planned = plan_migration(ops);
     let sql_stmts = generate_sql(&planned);
 
-    // Debug: Print the order of operations
-    for (i, stmt) in sql_stmts.iter().enumerate() {
-        eprintln!("Statement {i}: {stmt}");
-    }
-
     // Execute all statements - the bug causes this to fail
     for stmt in &sql_stmts {
         sqlx::query(stmt)


### PR DESCRIPTION
## Summary

- Fix bug where GRANT statements execute before their referenced objects (sequences) are created
- Add content-aware dependency edges in the migration planner for GrantPrivileges and RevokePrivileges operations
- Add comprehensive unit tests for grant/revoke ordering on all object types (sequence, table, view, function)
- Add integration test reproducing the exact bug scenario

## Test plan

- [x] Unit tests for grant ordering on sequences, tables, views, functions
- [x] Unit test for revoke ordering on sequences
- [x] Integration test `sequence_with_grants_from_scratch` reproduces and validates the fix
- [x] All 667 library tests pass
- [x] All 127 integration tests pass