### PR TITLE
fix(sqlgen): use TABLE keyword for views in GRANT/REVOKE statements

### DIFF
--- a/tests/grants.rs
+++ b/tests/grants.rs
@@ -345,3 +345,126 @@ async fn grants_management_end_to_end() {
         "Should not have UPDATE privilege after revoke"
     );
 }
+
+/// Issue #36: REVOKE from public pseudo-role generates malformed SQL
+/// When database has GRANT to public and schema file grants to a different role,
+/// pgmold should REVOKE from public using unquoted 'public', not ""public"".
+#[tokio::test]
+async fn revoke_from_public_pseudo_role() {
+    let (_container, url) = setup_postgres().await;
+    let connection = PgConnection::new(&url).await.unwrap();
+
+    // Create role and view
+    sqlx::query("CREATE ROLE authenticated NOLOGIN")
+        .execute(connection.pool())
+        .await
+        .unwrap();
+
+    sqlx::query("CREATE VIEW test_view AS SELECT 1 AS id")
+        .execute(connection.pool())
+        .await
+        .unwrap();
+
+    // Grant to public (the pseudo-role meaning "all roles")
+    sqlx::query("GRANT SELECT ON test_view TO public")
+        .execute(connection.pool())
+        .await
+        .unwrap();
+
+    // Introspect current state
+    let db_schema = introspect_schema(&connection, &["public".to_string()], false)
+        .await
+        .unwrap();
+
+    // Verify introspection sees the public grant
+    let view = db_schema.views.get("public.test_view").unwrap();
+    assert!(
+        view.grants.iter().any(|g| g.grantee == "PUBLIC"),
+        "Should have grant to PUBLIC. Grants: {:?}",
+        view.grants
+    );
+
+    // Schema file only grants to authenticated, not public
+    let schema_sql = r#"
+        CREATE VIEW test_view AS SELECT 1 AS id;
+        GRANT SELECT ON VIEW test_view TO authenticated;
+    "#;
+
+    let target_schema = parse_sql_string(schema_sql).unwrap();
+
+    // Compute diff - should generate REVOKE from public
+    let ops = pgmold::diff::compute_diff_with_flags(
+        &db_schema,
+        &target_schema,
+        false,
+        true,
+        &std::collections::HashSet::new(),
+    );
+
+    // There should be a REVOKE from PUBLIC
+    let revoke_from_public = ops.iter().find(|op| {
+        matches!(
+            op,
+            MigrationOp::RevokePrivileges { grantee, .. }
+            if grantee == "PUBLIC"
+        )
+    });
+    assert!(
+        revoke_from_public.is_some(),
+        "Should generate REVOKE from PUBLIC. Ops: {ops:?}"
+    );
+
+    // Generate and execute SQL
+    let planned = plan_migration(ops);
+    let sql = generate_sql(&planned);
+
+    // Verify the SQL looks correct (unquoted 'public', not ""public"")
+    // Look specifically for REVOKE ... FROM public; (the pseudo-role, not postgres user)
+    let revoke_from_public_sql = sql
+        .iter()
+        .find(|s| s.contains("REVOKE") && s.ends_with("FROM public;"));
+    assert!(
+        revoke_from_public_sql.is_some(),
+        "Should have REVOKE FROM public; statement. SQL: {sql:?}"
+    );
+
+    // The key assertion: 'FROM public;' not 'FROM ""public"";'
+    let revoke_stmt = revoke_from_public_sql.unwrap();
+    // Verify it doesn't have double-quoted ""public""
+    assert!(
+        !revoke_stmt.contains(r#""""public""""#),
+        "REVOKE should NOT have double-quoted public. Got: {revoke_stmt}"
+    );
+
+    // Execute the SQL - this is what failed in the issue
+    for stmt in &sql {
+        sqlx::query(stmt)
+            .execute(connection.pool())
+            .await
+            .unwrap_or_else(|e| panic!("Failed to execute: {stmt}\nError: {e}"));
+    }
+
+    // Verify final state
+    let final_schema = introspect_schema(&connection, &["public".to_string()], false)
+        .await
+        .unwrap();
+
+    let final_view = final_schema.views.get("public.test_view").unwrap();
+
+    // Should no longer have grant to PUBLIC
+    assert!(
+        !final_view.grants.iter().any(|g| g.grantee == "PUBLIC"),
+        "Should not have grant to PUBLIC after revoke. Grants: {:?}",
+        final_view.grants
+    );
+
+    // Should have grant to authenticated
+    assert!(
+        final_view
+            .grants
+            .iter()
+            .any(|g| g.grantee == "authenticated"),
+        "Should have grant to authenticated. Grants: {:?}",
+        final_view.grants
+    );
+}


### PR DESCRIPTION
## Summary

PostgreSQL's GRANT/REVOKE syntax requires the `TABLE` keyword for both tables AND views, not `VIEW`. Using `VIEW` causes syntax errors like "syntax error at or near "public"".

The bug was misdiagnosed in issue #36 as a role name quoting problem (`""public""`), but the actual issue was the invalid `VIEW` keyword in GRANT/REVOKE statements.

## Root Cause

`grant_object_kind_to_sql()` returned `"VIEW"` for `GrantObjectKind::View`, but PostgreSQL's GRANT/REVOKE statements only accept:
- `TABLE` for tables AND views
- `SEQUENCE` for sequences
- `FUNCTION` for functions
- etc.

Example of invalid SQL that was generated:
```sql
REVOKE SELECT ON VIEW "public"."test_view" FROM public;
-- Error: syntax error at or near "public"
```

The error message points to the schema qualifier `"public"`, but the actual problem is the `VIEW` keyword.

## Fix

Changed `grant_object_kind_to_sql()` to return `"TABLE"` for View objects:
```rust
GrantObjectKind::View => "TABLE",  // PostgreSQL uses TABLE for views in GRANT/REVOKE
```

## Test Plan

- [x] Unit test: `revoke_privileges_from_public` - verifies SQL generation
- [x] Integration test: `revoke_from_public_pseudo_role` - reproduces the exact issue scenario
- [x] All existing grant tests pass
- [x] All 678 lib tests pass

Closes #36