### PR TITLE
test(parser): verify DML statements are skipped gracefully

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -5072,4 +5072,21 @@ DROP SCHEMA staging;
         assert!(!schema.schemas.contains_key("staging"));
         assert!(schema.schemas.contains_key("production"));
     }
+
+    #[test]
+    fn dml_statements_skipped_gracefully() {
+        let sql = r#"
+CREATE TABLE users (
+    id SERIAL PRIMARY KEY,
+    email TEXT NOT NULL UNIQUE
+);
+INSERT INTO users (email) VALUES ('test@example.com') ON CONFLICT DO NOTHING;
+INSERT INTO users (email) VALUES ('a@b.com')
+    ON CONFLICT (email) DO UPDATE SET email = EXCLUDED.email;
+UPDATE users SET email = 'bob@example.com' WHERE id = 1;
+DELETE FROM users WHERE id = 1;
+"#;
+        let schema = parse_sql_string(sql).unwrap();
+        assert!(schema.tables.contains_key("public.users"));
+    }
 }


### PR DESCRIPTION
## Summary

- Add regression test verifying INSERT INTO (with ON CONFLICT DO NOTHING/DO UPDATE), UPDATE, and DELETE are silently skipped by the parser
- Bug was not reproducible — sqlparser handles these fine and the catch-all `_ => {}` match arm skips them

## Test plan

- [x] New test `dml_statements_skipped_gracefully` passes
- [x] 725 existing tests pass, 0 regressions

Closes pgmold-135