### PR TITLE
chore: bump version to 0.24.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1394,7 +1394,7 @@ dependencies = [
 
 [[package]]
 name = "pgmold"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "pgmold"
-version = "0.24.0"
+version = "0.24.1"
 edition = "2021"
 exclude = [".auto-claude/", ".auto-claude-security.json", ".claude_settings.json"]
 description = "PostgreSQL schema-as-code management tool"


### PR DESCRIPTION
Version bump for v0.24.1 release.

Changes since v0.24.0:
- fix: improve round-trip fidelity for serial defaults, grants, and expressions (#50)
- fix(parser): handle DO blocks, COMMENT ON, and GRANT ALL per object type (#49)
- refactor(diff): split mod.rs into domain-specific submodules (#47)