### PR TITLE
fix(introspect): normalize proconfig double-quoted values to SQL string literals

### DIFF
--- a/src/pg/sqlgen.rs
+++ b/src/pg/sqlgen.rs
@@ -2635,6 +2635,32 @@ mod tests {
     }
 
     #[test]
+    fn generate_function_ddl_with_empty_search_path() {
+        use crate::model::{Function, SecurityType, Volatility};
+
+        let func = Function {
+            name: "secure_func".to_string(),
+            schema: "public".to_string(),
+            arguments: vec![],
+            return_type: "void".to_string(),
+            language: "plpgsql".to_string(),
+            body: "BEGIN END;".to_string(),
+            volatility: Volatility::Volatile,
+            security: SecurityType::Definer,
+            config_params: vec![("search_path".to_string(), "''".to_string())],
+            owner: None,
+            grants: Vec::new(),
+        };
+
+        let ddl = generate_create_function(&func);
+
+        assert!(
+            ddl.contains("SET search_path = ''"),
+            "Expected SET search_path = '' in: {ddl}"
+        );
+    }
+
+    #[test]
     fn generate_function_ddl_with_multiple_config_params() {
         use crate::model::{Function, SecurityType, Volatility};
 


### PR DESCRIPTION
## Summary

- PostgreSQL stores `SET search_path = ''` as `search_path=""` in `pg_proc.proconfig`
- pgmold reads `""` and generates `SET search_path = ""` — invalid SQL (zero-length delimited identifier)
- Normalize double-quoted proconfig values to single-quoted SQL string literals during introspection
- Eliminates perpetual drift for functions with `SET search_path = ''`

## Test plan

- [x] 4 unit tests for `normalize_proconfig_value()` (empty, quoted, unquoted, single-quoted passthrough)
- [x] 1 sqlgen test for empty search_path DDL generation
- [x] Full test suite passes (730/730, 5 Docker-dependent tests skipped)