### PR TITLE
refactor(cli): improve CLI UX across 9 areas

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1443,12 +1443,7 @@ mod tests {
 
     #[test]
     fn dump_accepts_bare_postgres_url() {
-        let args = Cli::parse_from([
-            "pgmold",
-            "dump",
-            "--database",
-            "postgres://localhost/db",
-        ]);
+        let args = Cli::parse_from(["pgmold", "dump", "--database", "postgres://localhost/db"]);
 
         if let Commands::Dump { database, .. } = args.command {
             assert_eq!(database, "postgres://localhost/db");


### PR DESCRIPTION
## Summary

- remove `monitor` command (redundant with `drift`)
- add help text to `--database`, `--dry-run`, `--allow-destructive`, `--from`, `--to`
- switch `--manage-grants=false` to `--no-manage-grants`
- add short flags: `-s` (schema), `-d` (database), `-j` (json)
- accept bare `postgres://` URLs without `db:` prefix
- fix `--validate` help text to document `db:` prefix
- render `diff` output as SQL instead of debug format
- flatten `migrate generate` into `migrate`
- extract shared `FilterArgs` and `GrantArgs` with `#[command(flatten)]`

Bonus: `migrate` now properly passes `--exclude-grants-for-role` through to the diff engine (was hardcoded to empty HashSet before).

**BREAKING:**
- `--manage-grants=false` → `--no-manage-grants`
- `pgmold migrate generate` → `pgmold migrate`
- `monitor` command removed (use `drift` instead)

## Test plan

- [x] all 31 CLI unit tests pass
- [x] all 751 library unit tests pass (5 Docker-dependent validate tests skipped — pre-existing)
- [x] `cargo clippy` clean
- [x] `cargo fmt --check` clean
- [ ] manual smoke test against a real database