### PR TITLE
chore: bump version to v0.25.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1394,7 +1394,7 @@ dependencies = [
 
 [[package]]
 name = "pgmold"
-version = "0.24.6"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "pgmold"
-version = "0.24.6"
+version = "0.25.0"
 edition = "2021"
 exclude = [".auto-claude/", ".auto-claude-security.json", ".claude_settings.json"]
 description = "PostgreSQL schema-as-code management tool"


### PR DESCRIPTION
## Summary

Bump version to 0.25.0 for breaking CLI changes in #66:

- `--manage-grants=false` → `--no-manage-grants`
- `migrate generate` → `migrate`
- `monitor` removed (use `drift`)