### PR TITLE
fix(introspect): cast typcategory to text for sqlx compatibility

### DIFF
--- a/src/pg/introspect.rs
+++ b/src/pg/introspect.rs
@@ -253,7 +253,7 @@ async fn introspect_domains(
             n.nspname AS schema_name,
             t.typname AS domain_name,
             bt.typname AS base_type,
-            bt.typcategory AS base_category,
+            bt.typcategory::text AS base_category,
             t.typnotnull AS not_null,
             pg_get_expr(t.typdefaultbin, 0) AS default_expr,
             r.rolname AS owner


### PR DESCRIPTION
## Summary

- `bt.typcategory` in `pg_type` is `"char"` (single-byte), not `text`
- sqlx can't decode `"char"` into `String`, causing `baseline_captures_domain` integration test to panic
- Cast to `::text` in the query

Fixes CI failure introduced in #72.