### PR TITLE
fix(model): normalize timestamp and time type aliases in function signatures

### DIFF
--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1587,7 +1587,10 @@ mod tests {
         assert_eq!(normalize_pg_type("varchar"), "character varying");
         assert_eq!(normalize_pg_type("timestamptz"), "timestamp with time zone");
         assert_eq!(normalize_pg_type("timetz"), "time with time zone");
-        assert_eq!(normalize_pg_type("timestamp"), "timestamp without time zone");
+        assert_eq!(
+            normalize_pg_type("timestamp"),
+            "timestamp without time zone"
+        );
         assert_eq!(normalize_pg_type("time"), "time without time zone");
         // Already canonical types should remain unchanged
         assert_eq!(normalize_pg_type("integer"), "integer");


### PR DESCRIPTION
## Summary

- Add `timestamp` → `timestamp without time zone` and `time` → `time without time zone` mappings to `normalize_pg_type`
- Prevents perpetual DROP + CREATE cycles for functions using `timestamp`/`time` parameters or return types
- Tests cover: basic normalization, idempotency, precision-qualified variants, TABLE return types, function semantic equality

Closes #80