### PR TITLE
fix(util): normalize schema name quoting in CHECK constraint expressions

### DIFF
--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -168,7 +168,7 @@ fn normalize_ident_quoting(ident: sqlparser::ast::Ident) -> sqlparser::ast::Iden
             || !value
                 .chars()
                 .next()
-                .map_or(false, |c| c.is_ascii_lowercase() || c == '_')
+                .is_some_and(|c| c.is_ascii_lowercase() || c == '_')
             || value
                 .chars()
                 .any(|c| !c.is_ascii_alphanumeric() && c != '_');


### PR DESCRIPTION
## Summary

- Normalize identifier quoting in CHECK constraint cast expressions to match PostgreSQL's canonical output
- Strips unnecessary double-quotes from all-lowercase schema names in `DataType::Custom` (e.g., `"mrv"."Type"` → `mrv."Type"`)
- Scoped to cast type names only — column reference quoting is untouched
- 4 new tests covering schema quoting normalization, mixed-case preservation, digit-leading identifiers

Closes #81