### PR TITLE
docs: update CLI reference and README for v0.28.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ PostgreSQL schema-as-code management tool. Define schemas in native PostgreSQL D
 - **Drift Detection**: Detect schema drift in CI/CD
 - **Transactional Apply**: All migrations run in a single transaction
 - **Partitioned Tables**: Full support for `PARTITION BY` and `PARTITION OF` syntax
+- **JSON Output**: Machine-readable output for all commands via `--json` / `-j`
+- **Describe**: Inspect available commands, object types, and providers with `pgmold describe`
+- **Grant Management**: `GRANT`/`REVOKE` sync enabled by default; `--manage-ownership` for `ALTER OWNER`
+- **Environment Variable**: Set connection string via `PGMOLD_DATABASE_URL`
 
 ## How pgmold Works
 
@@ -118,8 +122,8 @@ pgmold apply -s sql:schema.sql -d postgres://localhost/mydb --allow-destructive
 # Dry run (preview SQL without executing)
 pgmold apply -s sql:schema.sql -d postgres://localhost/mydb --dry-run
 
-# Lint schema
-pgmold lint -s sql:schema.sql
+# Lint schema (requires a database connection to resolve types)
+pgmold lint -s sql:schema.sql -d postgres://localhost/mydb
 
 # Detect drift (returns JSON report with exit code 1 if drift detected)
 pgmold drift -s sql:schema.sql -d postgres://localhost/mydb -j

--- a/site/src/content/docs/reference/cli.md
+++ b/site/src/content/docs/reference/cli.md
@@ -20,7 +20,13 @@ pgmold plan -s sql:schema.sql -d postgres://localhost/mydb
 | `--exclude <PATTERN>` | Exclude objects matching glob pattern (repeatable) |
 | `--include-types <TYPES>` | Include only these object types (comma-separated) |
 | `--exclude-types <TYPES>` | Exclude these object types (comma-separated) |
+| `--include-extension-objects` | Include objects owned by extensions |
 | `--reverse` | Generate rollback plan (reverse direction) |
+| `--zero-downtime` | Generate expand/contract phased migration plan |
+| `--validate <URL>` | Validate migration against a temporary database first |
+| `--manage-ownership` | Include ownership management (`ALTER ... OWNER TO`) |
+| `--no-manage-grants` | Disable grant/revoke management |
+| `--exclude-grants-for-role <ROLE>` | Exclude grants for a specific role (repeatable) |
 | `--json` | JSON output |
 
 ## pgmold apply
@@ -37,9 +43,18 @@ pgmold apply -s sql:schema.sql -d postgres://localhost/mydb
 | `-d, --database <URL>` | PostgreSQL connection string |
 | `--allow-destructive` | Allow DROP and other destructive operations |
 | `--dry-run` | Preview SQL without executing |
-| `--target-schemas <LIST>` | Comma-separated PostgreSQL schemas |
-| `--include/--exclude` | Same as `plan` |
-| `--include-types/--exclude-types` | Same as `plan` |
+| `--target-schemas <LIST>` | Comma-separated PostgreSQL schemas (default: `public`) |
+| `--include <PATTERN>` | Include objects matching glob pattern (repeatable) |
+| `--exclude <PATTERN>` | Exclude objects matching glob pattern (repeatable) |
+| `--include-types <TYPES>` | Include only these object types (comma-separated) |
+| `--exclude-types <TYPES>` | Exclude these object types (comma-separated) |
+| `--include-extension-objects` | Include objects owned by extensions |
+| `--validate <URL>` | Validate migration against a temporary database first |
+| `--manage-ownership` | Include ownership management (`ALTER ... OWNER TO`) |
+| `--no-manage-grants` | Disable grant/revoke management |
+| `--exclude-grants-for-role <ROLE>` | Exclude grants for a specific role (repeatable) |
+| `-v, --verbose` | Log each statement execution and result |
+| `--json` | JSON output |
 
 ## pgmold diff
 
@@ -67,9 +82,9 @@ Returns exit code 1 if drift is detected.
 
 | Flag | Description |
 |------|-------------|
-| `-s, --schema <SOURCE>` | Schema source |
+| `-s, --schema <SOURCE>` | Schema source (repeatable) |
 | `-d, --database <URL>` | PostgreSQL connection string |
-| `--target-schemas <LIST>` | Comma-separated PostgreSQL schemas |
+| `--target-schemas <LIST>` | Comma-separated PostgreSQL schemas (default: `public`) |
 | `--json` | JSON output |
 
 ## pgmold dump
@@ -85,16 +100,31 @@ pgmold dump -d postgres://localhost/mydb -o schema.sql
 | `-d, --database <URL>` | PostgreSQL connection string |
 | `-o, --output <PATH>` | Output file or directory |
 | `--split` | Split into separate files by object type |
-| `--target-schemas <LIST>` | Comma-separated PostgreSQL schemas |
+| `--target-schemas <LIST>` | Comma-separated PostgreSQL schemas (default: `public`) |
+| `--include <PATTERN>` | Include objects matching glob pattern (repeatable) |
+| `--exclude <PATTERN>` | Exclude objects matching glob pattern (repeatable) |
+| `--include-types <TYPES>` | Include only these object types (comma-separated) |
+| `--exclude-types <TYPES>` | Exclude these object types (comma-separated) |
 | `--include-extension-objects` | Include objects owned by extensions |
+| `--json` | JSON output (includes SQL content and metadata) |
 
 ## pgmold lint
 
-Validate a schema file for issues.
+Validate a schema against a live database for issues.
 
 ```bash
-pgmold lint -s sql:schema.sql
+pgmold lint -s sql:schema.sql -d postgres://localhost/mydb
 ```
+
+| Flag | Description |
+|------|-------------|
+| `-s, --schema <SOURCE>` | Schema source (repeatable) |
+| `-d, --database <URL>` | PostgreSQL connection string |
+| `--target-schemas <LIST>` | Comma-separated PostgreSQL schemas (default: `public`) |
+| `--manage-ownership` | Include ownership management (`ALTER ... OWNER TO`) |
+| `--no-manage-grants` | Disable grant/revoke management |
+| `--exclude-grants-for-role <ROLE>` | Exclude grants for a specific role (repeatable) |
+| `--json` | JSON output |
 
 ## pgmold migrate
 
@@ -110,6 +140,33 @@ pgmold migrate \
 
 Auto-detects the next migration number in the output directory.
 
+| Flag | Description |
+|------|-------------|
+| `-s, --schema <SOURCE>` | Schema source (repeatable) |
+| `-d, --database <URL>` | PostgreSQL connection string |
+| `-m, --migrations <DIR>` | Directory for migration files |
+| `-n, --name <NAME>` | Migration name/description |
+| `--target-schemas <LIST>` | Comma-separated PostgreSQL schemas (default: `public`) |
+| `--manage-ownership` | Include ownership management (`ALTER ... OWNER TO`) |
+| `--no-manage-grants` | Disable grant/revoke management |
+| `--exclude-grants-for-role <ROLE>` | Exclude grants for a specific role (repeatable) |
+| `--json` | JSON output |
+
+## pgmold describe
+
+Describe available commands, object types, providers, and filters. Intended for agent introspection.
+
+```bash
+pgmold describe
+pgmold describe plan
+```
+
+| Argument | Description |
+|----------|-------------|
+| `[COMMAND]` | Optional command name to describe (e.g., `plan`, `apply`) |
+
+Always outputs JSON. No database connection required.
+
 ## Schema source prefixes
 
 | Prefix | Description |
@@ -118,8 +175,11 @@ Auto-detects the next migration number in the output directory.
 | `drizzle:<path>` | Drizzle ORM config file |
 | `db:<url>` | Live PostgreSQL database |
 
+All commands that accept `-d` also accept a bare `postgres://...` URL without the `db:` prefix.
+
 ## Environment variables
 
 | Variable | Description |
 |----------|-------------|
+| `PGMOLD_DATABASE_URL` | Default value for `-d` on all commands that accept a database URL |
 | `PGMOLD_PROD` | Set to `1` to enable production mode (blocks table drops) |


### PR DESCRIPTION
## Summary

- Add missing CLI flags to reference docs (describe, --validate, --zero-downtime, --verbose, GrantArgs, --json on all commands)
- Fix lint examples to require --database (breaking change from #105)
- Add PGMOLD_DATABASE_URL to environment variables section
- Expand apply/migrate/lint/dump flag tables with full details
- Add describe command section to CLI reference
- Update README feature list

## Test plan

- [x] All 799 unit tests pass
- [x] Pre-push hooks (fmt, clippy, test) pass