### PR TITLE
chore: bump version to v0.28.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1408,7 +1408,7 @@ dependencies = [
 
 [[package]]
 name = "pgmold"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "pgmold"
-version = "0.28.1"
+version = "0.28.2"
 edition = "2021"
 exclude = [".auto-claude/", ".auto-claude-security.json", ".claude_settings.json"]
 description = "PostgreSQL schema-as-code management tool"


### PR DESCRIPTION
## Summary
- Bump version from 0.28.1 to 0.28.2

## Changes since v0.28.1
- docs: CLI reference, README updates (PR #109)
- feat(action): tunnel and secret command support for firewalled databases (PR #110)