### PR TITLE
fix(ownership): add partition and materialized view ownership support

### DIFF
--- a/src/diff/mod.rs
+++ b/src/diff/mod.rs
@@ -64,7 +64,7 @@ pub fn compute_diff_with_flags(
         manage_grants,
         excluded_grant_roles,
     ));
-    ops.extend(diff_partitions(from, to));
+    ops.extend(diff_partitions(from, to, manage_ownership));
     ops.extend(diff_functions(
         from,
         to,
@@ -3061,5 +3061,171 @@ CREATE TRIGGER "on_user_role_change" AFTER INSERT OR UPDATE OR DELETE ON "public
                 ..
             } if grantee == "app_user"
         ));
+    }
+
+    #[test]
+    fn detects_partition_owner_change_when_flag_enabled() {
+        use crate::model::{Partition, PartitionBound};
+
+        let partition_key = "public.orders_2024".to_string();
+        let mut from = empty_schema();
+        from.partitions.insert(
+            partition_key.clone(),
+            Partition {
+                name: "orders_2024".to_string(),
+                schema: "public".to_string(),
+                parent_schema: "public".to_string(),
+                parent_name: "orders".to_string(),
+                bound: PartitionBound::Default,
+                indexes: Vec::new(),
+                check_constraints: Vec::new(),
+                owner: Some("oldowner".to_string()),
+            },
+        );
+
+        let mut to = empty_schema();
+        to.partitions.insert(
+            partition_key.clone(),
+            Partition {
+                name: "orders_2024".to_string(),
+                schema: "public".to_string(),
+                parent_schema: "public".to_string(),
+                parent_name: "orders".to_string(),
+                bound: PartitionBound::Default,
+                indexes: Vec::new(),
+                check_constraints: Vec::new(),
+                owner: Some("newowner".to_string()),
+            },
+        );
+
+        let ops = compute_diff_with_flags(&from, &to, true, false, &HashSet::new());
+        assert_eq!(ops.len(), 1);
+        assert!(matches!(
+            &ops[0],
+            MigrationOp::AlterOwner {
+                object_kind: OwnerObjectKind::Partition,
+                schema,
+                name,
+                new_owner,
+                ..
+            } if schema == "public" && name == "orders_2024" && new_owner == "newowner"
+        ));
+    }
+
+    #[test]
+    fn ignores_partition_owner_change_when_flag_disabled() {
+        use crate::model::{Partition, PartitionBound};
+
+        let partition_key = "public.orders_2024".to_string();
+        let mut from = empty_schema();
+        from.partitions.insert(
+            partition_key.clone(),
+            Partition {
+                name: "orders_2024".to_string(),
+                schema: "public".to_string(),
+                parent_schema: "public".to_string(),
+                parent_name: "orders".to_string(),
+                bound: PartitionBound::Default,
+                indexes: Vec::new(),
+                check_constraints: Vec::new(),
+                owner: Some("oldowner".to_string()),
+            },
+        );
+
+        let mut to = empty_schema();
+        to.partitions.insert(
+            partition_key.clone(),
+            Partition {
+                name: "orders_2024".to_string(),
+                schema: "public".to_string(),
+                parent_schema: "public".to_string(),
+                parent_name: "orders".to_string(),
+                bound: PartitionBound::Default,
+                indexes: Vec::new(),
+                check_constraints: Vec::new(),
+                owner: Some("newowner".to_string()),
+            },
+        );
+
+        let ops = compute_diff_with_flags(&from, &to, false, false, &HashSet::new());
+        assert_eq!(ops.len(), 0);
+    }
+
+    #[test]
+    fn detects_materialized_view_owner_change_when_flag_enabled() {
+        use crate::model::View;
+
+        let mut from = empty_schema();
+        from.views.insert(
+            "summary".to_string(),
+            View {
+                name: "summary".to_string(),
+                schema: "public".to_string(),
+                query: "SELECT count(*) FROM users".to_string(),
+                materialized: true,
+                owner: Some("oldowner".to_string()),
+                grants: Vec::new(),
+            },
+        );
+
+        let mut to = empty_schema();
+        to.views.insert(
+            "summary".to_string(),
+            View {
+                name: "summary".to_string(),
+                schema: "public".to_string(),
+                query: "SELECT count(*) FROM users".to_string(),
+                materialized: true,
+                owner: Some("newowner".to_string()),
+                grants: Vec::new(),
+            },
+        );
+
+        let ops = compute_diff_with_flags(&from, &to, true, false, &HashSet::new());
+        assert_eq!(ops.len(), 1);
+        assert!(matches!(
+            &ops[0],
+            MigrationOp::AlterOwner {
+                object_kind: OwnerObjectKind::MaterializedView,
+                schema,
+                name,
+                new_owner,
+                ..
+            } if schema == "public" && name == "summary" && new_owner == "newowner"
+        ));
+    }
+
+    #[test]
+    fn ignores_materialized_view_owner_change_when_flag_disabled() {
+        use crate::model::View;
+
+        let mut from = empty_schema();
+        from.views.insert(
+            "summary".to_string(),
+            View {
+                name: "summary".to_string(),
+                schema: "public".to_string(),
+                query: "SELECT count(*) FROM users".to_string(),
+                materialized: true,
+                owner: Some("oldowner".to_string()),
+                grants: Vec::new(),
+            },
+        );
+
+        let mut to = empty_schema();
+        to.views.insert(
+            "summary".to_string(),
+            View {
+                name: "summary".to_string(),
+                schema: "public".to_string(),
+                query: "SELECT count(*) FROM users".to_string(),
+                materialized: true,
+                owner: Some("newowner".to_string()),
+                grants: Vec::new(),
+            },
+        );
+
+        let ops = compute_diff_with_flags(&from, &to, false, false, &HashSet::new());
+        assert_eq!(ops.len(), 0);
     }
 }

--- a/src/diff/objects.rs
+++ b/src/diff/objects.rs
@@ -326,12 +326,41 @@ pub(super) fn diff_tables(
     ops
 }
 
-pub(super) fn diff_partitions(from: &Schema, to: &Schema) -> Vec<MigrationOp> {
+pub(super) fn diff_partitions(
+    from: &Schema,
+    to: &Schema,
+    manage_ownership: bool,
+) -> Vec<MigrationOp> {
     let mut ops = Vec::new();
 
     for (name, partition) in &to.partitions {
-        if !from.partitions.contains_key(name) {
+        if let Some(from_partition) = from.partitions.get(name) {
+            if manage_ownership && from_partition.owner != partition.owner {
+                if let Some(ref new_owner) = partition.owner {
+                    let (schema, partition_name) = parse_qualified_name(name);
+                    ops.push(MigrationOp::AlterOwner {
+                        object_kind: OwnerObjectKind::Partition,
+                        schema,
+                        name: partition_name,
+                        args: None,
+                        new_owner: new_owner.clone(),
+                    });
+                }
+            }
+        } else {
             ops.push(MigrationOp::CreatePartition(partition.clone()));
+            if manage_ownership {
+                if let Some(ref owner) = partition.owner {
+                    let (schema, partition_name) = parse_qualified_name(name);
+                    ops.push(MigrationOp::AlterOwner {
+                        object_kind: OwnerObjectKind::Partition,
+                        schema,
+                        name: partition_name,
+                        args: None,
+                        new_owner: owner.clone(),
+                    });
+                }
+            }
         }
     }
 
@@ -447,6 +476,14 @@ pub(super) fn diff_functions(
     ops
 }
 
+fn view_owner_kind(materialized: bool) -> OwnerObjectKind {
+    if materialized {
+        OwnerObjectKind::MaterializedView
+    } else {
+        OwnerObjectKind::View
+    }
+}
+
 pub(super) fn diff_views(
     from: &Schema,
     to: &Schema,
@@ -468,7 +505,7 @@ pub(super) fn diff_views(
                 if let Some(ref new_owner) = view.owner {
                     let (schema, view_name) = parse_qualified_name(name);
                     ops.push(MigrationOp::AlterOwner {
-                        object_kind: OwnerObjectKind::View,
+                        object_kind: view_owner_kind(view.materialized),
                         schema,
                         name: view_name,
                         args: None,
@@ -494,7 +531,7 @@ pub(super) fn diff_views(
                 if let Some(ref owner) = view.owner {
                     let (schema, view_name) = parse_qualified_name(name);
                     ops.push(MigrationOp::AlterOwner {
-                        object_kind: OwnerObjectKind::View,
+                        object_kind: view_owner_kind(view.materialized),
                         schema,
                         name: view_name,
                         args: None,

--- a/src/diff/planner.rs
+++ b/src/diff/planner.rs
@@ -1035,7 +1035,10 @@ impl MigrationGraph {
                         "Table" => {
                             edges_to_add.push((OpKey::CreateTable(qualified), key.clone()));
                         }
-                        "View" => {
+                        "Partition" => {
+                            edges_to_add.push((OpKey::CreatePartition(qualified), key.clone()));
+                        }
+                        "View" | "MaterializedView" => {
                             edges_to_add.push((OpKey::CreateView(qualified), key.clone()));
                         }
                         "Sequence" => {
@@ -4815,6 +4818,63 @@ mod tests {
             "CreateDomain",
             "AlterOwner",
             |op| matches!(op, MigrationOp::CreateDomain(_)),
+            |op| matches!(op, MigrationOp::AlterOwner { .. }),
+        );
+    }
+
+    #[test]
+    fn alter_owner_partition_after_create_partition() {
+        let partition = crate::model::Partition {
+            name: "orders_2024".to_string(),
+            schema: "public".to_string(),
+            parent_name: "orders".to_string(),
+            parent_schema: "public".to_string(),
+            bound: crate::model::PartitionBound::Default,
+            indexes: vec![],
+            check_constraints: vec![],
+            owner: None,
+        };
+        let ops = vec![
+            MigrationOp::AlterOwner {
+                object_kind: OwnerObjectKind::Partition,
+                schema: "public".to_string(),
+                name: "orders_2024".to_string(),
+                args: None,
+                new_owner: "app_admin".to_string(),
+            },
+            MigrationOp::CreatePartition(partition),
+        ];
+        let planned = plan_migration(ops);
+        assert_op_position(
+            &planned,
+            "CreatePartition",
+            "AlterOwner",
+            |op| matches!(op, MigrationOp::CreatePartition(_)),
+            |op| matches!(op, MigrationOp::AlterOwner { .. }),
+        );
+    }
+
+    #[test]
+    fn alter_owner_materialized_view_after_create_view() {
+        let ops = vec![
+            MigrationOp::AlterOwner {
+                object_kind: OwnerObjectKind::MaterializedView,
+                schema: "public".to_string(),
+                name: "summary".to_string(),
+                args: None,
+                new_owner: "app_admin".to_string(),
+            },
+            MigrationOp::CreateView(View {
+                materialized: true,
+                ..make_view("summary", "public", "SELECT 1")
+            }),
+        ];
+        let planned = plan_migration(ops);
+        assert_op_position(
+            &planned,
+            "CreateView",
+            "AlterOwner",
+            |op| matches!(op, MigrationOp::CreateView(_)),
             |op| matches!(op, MigrationOp::AlterOwner { .. }),
         );
     }

--- a/src/diff/types.rs
+++ b/src/diff/types.rs
@@ -7,7 +7,9 @@ use crate::model::{
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum OwnerObjectKind {
     Table,
+    Partition,
     View,
+    MaterializedView,
     Sequence,
     Function,
     Type,

--- a/src/parser/ownership.rs
+++ b/src/parser/ownership.rs
@@ -75,6 +75,24 @@ pub(super) fn parse_owner_statements(sql: &str, schema: &mut Schema) {
         });
     }
 
+    let alter_materialized_view_owner_re = Regex::new(
+        r#"(?i)ALTER\s+MATERIALIZED\s+VIEW\s+(?:["']?([^"'\s]+)["']?\.)?["']?([^"'\s;]+)["']?\s+OWNER\s+TO\s+["']?([^"'\s;]+)["']?"#
+    ).unwrap();
+
+    for cap in alter_materialized_view_owner_re.captures_iter(sql) {
+        let schema_part = cap.get(1).map(|m| m.as_str().trim_matches('"'));
+        let view_name = cap.get(2).unwrap().as_str().trim_matches('"');
+        let owner = cap.get(3).unwrap().as_str().trim_matches('"');
+
+        let view_schema = schema_part.unwrap_or("public");
+        let object_key = qualified_name(view_schema, view_name);
+        schema.pending_owners.push(PendingOwner {
+            object_type: PendingOwnerObjectType::View,
+            object_key,
+            owner: owner.to_string(),
+        });
+    }
+
     let alter_view_owner_re = Regex::new(
         r#"(?i)ALTER\s+VIEW\s+(?:["']?([^"'\s]+)["']?\.)?["']?([^"'\s;]+)["']?\s+OWNER\s+TO\s+["']?([^"'\s;]+)["']?"#
     ).unwrap();

--- a/src/parser/preprocess.rs
+++ b/src/parser/preprocess.rs
@@ -45,6 +45,7 @@ pub(super) fn preprocess_sql(sql: &str) -> String {
         r"(?i)\bSET\s+search_path\s+TO\s+'[^']*'(?:\s*,\s*'[^']*')*",
         r"(?i)ALTER\s+TABLE\s+[^;]+\s+OWNER\s+TO\s+[^;]+;",
         r"(?i)ALTER\s+FUNCTION\s+[^;]+;",
+        r"(?i)ALTER\s+MATERIALIZED\s+VIEW\s+[^;]+;",
         r"(?i)ALTER\s+VIEW\s+[^;]+;",
         r"(?i)ALTER\s+SEQUENCE\s+[^;]+;",
         r"(?i)ALTER\s+TYPE\s+[^;]+;",

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -2958,3 +2958,27 @@ fn parse_unsupported_type_returns_error() {
     let err = result.unwrap_err().to_string();
     assert!(err.contains("unsupported column type"));
 }
+
+#[test]
+fn parses_alter_materialized_view_owner() {
+    let sql = r#"
+        CREATE MATERIALIZED VIEW summary AS SELECT count(*) FROM users;
+        ALTER MATERIALIZED VIEW summary OWNER TO analytics_user;
+    "#;
+    let schema = parse_sql_string(sql).unwrap();
+    let view = schema.views.get("public.summary").unwrap();
+    assert!(view.materialized);
+    assert_eq!(view.owner, Some("analytics_user".to_string()));
+}
+
+#[test]
+fn parses_alter_materialized_view_owner_schema_qualified() {
+    let sql = r#"
+        CREATE MATERIALIZED VIEW "reporting"."summary" AS SELECT count(*) FROM users;
+        ALTER MATERIALIZED VIEW "reporting"."summary" OWNER TO "analytics_user";
+    "#;
+    let schema = parse_sql_string(sql).unwrap();
+    let view = schema.views.get("reporting.summary").unwrap();
+    assert!(view.materialized);
+    assert_eq!(view.owner, Some("analytics_user".to_string()));
+}

--- a/src/pg/sqlgen.rs
+++ b/src/pg/sqlgen.rs
@@ -1177,8 +1177,9 @@ fn generate_alter_owner(
     new_owner: &str,
 ) -> String {
     let object_type = match object_kind {
-        OwnerObjectKind::Table => "TABLE",
+        OwnerObjectKind::Table | OwnerObjectKind::Partition => "TABLE",
         OwnerObjectKind::View => "VIEW",
+        OwnerObjectKind::MaterializedView => "MATERIALIZED VIEW",
         OwnerObjectKind::Sequence => "SEQUENCE",
         OwnerObjectKind::Function => "FUNCTION",
         OwnerObjectKind::Type => "TYPE",
@@ -3567,6 +3568,42 @@ mod tests {
         assert_eq!(
             sql[0],
             "ALTER TABLE \"public\".\"data\" ADD COLUMN \"scores\" INTEGER[];"
+        );
+    }
+
+    #[test]
+    fn alter_owner_partition_generates_alter_table_sql() {
+        let ops = vec![MigrationOp::AlterOwner {
+            object_kind: OwnerObjectKind::Partition,
+            schema: "public".to_string(),
+            name: "orders_2024".to_string(),
+            args: None,
+            new_owner: "analytics_user".to_string(),
+        }];
+
+        let sql = generate_sql(&ops);
+        assert_eq!(sql.len(), 1);
+        assert_eq!(
+            sql[0],
+            "ALTER TABLE \"public\".\"orders_2024\" OWNER TO analytics_user;"
+        );
+    }
+
+    #[test]
+    fn alter_owner_materialized_view_generates_valid_sql() {
+        let ops = vec![MigrationOp::AlterOwner {
+            object_kind: OwnerObjectKind::MaterializedView,
+            schema: "public".to_string(),
+            name: "summary".to_string(),
+            args: None,
+            new_owner: "analytics_user".to_string(),
+        }];
+
+        let sql = generate_sql(&ops);
+        assert_eq!(sql.len(), 1);
+        assert_eq!(
+            sql[0],
+            "ALTER MATERIALIZED VIEW \"public\".\"summary\" OWNER TO analytics_user;"
         );
     }
 }


### PR DESCRIPTION
Closes #94

## Summary

- Add `Partition` and `MaterializedView` variants to `OwnerObjectKind`
- `diff_partitions()` now handles ownership changes when `--manage-ownership` is enabled
- Parse `ALTER MATERIALIZED VIEW ... OWNER TO` statements (previously silently ignored)
- Emit correct `ALTER MATERIALIZED VIEW` DDL instead of `ALTER VIEW` for materialized views
- Add planner dependency edges so `AlterOwner` for partitions/matviews is ordered after their `Create*` ops

## Gaps not addressed (by design)

- **Double-emit (gap 3)**: `CreateView` does not emit inline OWNER TO — ownership is only handled via `AlterOwner` ops from the diff layer. No double-emit exists.
- **Owner clearing (gap 4)**: PostgreSQL objects always have an owner. `to.owner = None` means "don't manage ownership for this object" which is the correct default.
- **CreateFunction inline OWNER TO (gap 5)**: Functions and views both handle ownership the same way — via `AlterOwner` ops. No asymmetry exists.

## Test plan

- [x] Partition owner change detected when flag enabled
- [x] Partition owner change ignored when flag disabled
- [x] Materialized view owner change detected when flag enabled
- [x] Materialized view owner change ignored when flag disabled
- [x] `ALTER MATERIALIZED VIEW ... OWNER TO` parsed correctly (unqualified and schema-qualified)
- [x] SQL generation: `Partition` → `ALTER TABLE`, `MaterializedView` → `ALTER MATERIALIZED VIEW`
- [x] Planner: `AlterOwner(Partition)` ordered after `CreatePartition`
- [x] Planner: `AlterOwner(MaterializedView)` ordered after `CreateView`
- [x] All 873 lib tests pass, clippy clean, fmt clean