### PR TITLE
fix(planner): add remaining function dependency edges for all object types

### DIFF
--- a/src/diff/planner.rs
+++ b/src/diff/planner.rs
@@ -1551,7 +1551,7 @@ fn topological_sort(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::diff::{ColumnChanges, OwnerObjectKind};
+    use crate::diff::{ColumnChanges, OwnerObjectKind, PolicyChanges};
     use crate::model::*;
     use std::collections::BTreeMap;
 


### PR DESCRIPTION
## Summary

- Add function dependency edges for check constraints, indexes, column defaults, AlterPolicy, AlterView, and AlterColumn defaults
- Extract `push_function_ref_edges` and `drop_targets_table` helpers to reduce duplication
- Remove domain→function edges that conflict with domain→function phase ordering (PostgreSQL validates domain CHECK constraints lazily)
- Fix missing `PolicyChanges` import in test module

Continuation of #123 — those commits were pushed after the squash merge landed.

Closes #122