### PR TITLE
chore: bump version to v0.29.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1408,7 +1408,7 @@ dependencies = [
 
 [[package]]
 name = "pgmold"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "pgmold"
-version = "0.29.2"
+version = "0.29.3"
 edition = "2021"
 exclude = [".auto-claude/", ".auto-claude-security.json", ".claude_settings.json"]
 description = "PostgreSQL schema-as-code management tool"


### PR DESCRIPTION
## Summary

- bump version to v0.29.3 for release

## Changes since v0.29.2

- fix(planner): add column dependency edges for views, policies, and triggers (#126)