### PR TITLE
refactor: address code smells across codebase (round 4)

### DIFF
--- a/src/diff/objects.rs
+++ b/src/diff/objects.rs
@@ -524,41 +524,17 @@ pub(super) fn diff_sequences(
 }
 
 pub(super) fn compute_sequence_changes(from: &Sequence, to: &Sequence) -> Option<SequenceChanges> {
-    let mut changes = SequenceChanges::default();
-    let mut has_changes = false;
-
-    if from.data_type != to.data_type {
-        changes.data_type = Some(to.data_type.clone());
-        has_changes = true;
-    }
-    if from.increment != to.increment {
-        changes.increment = to.increment;
-        has_changes = true;
-    }
-    if from.min_value != to.min_value {
-        changes.min_value = Some(to.min_value);
-        has_changes = true;
-    }
-    if from.max_value != to.max_value {
-        changes.max_value = Some(to.max_value);
-        has_changes = true;
-    }
-    if from.start != to.start {
-        changes.restart = to.start;
-        has_changes = true;
-    }
-    if from.cache != to.cache {
-        changes.cache = to.cache;
-        has_changes = true;
-    }
-    if from.cycle != to.cycle {
-        changes.cycle = Some(to.cycle);
-        has_changes = true;
-    }
-    if from.owned_by != to.owned_by {
-        changes.owned_by = Some(to.owned_by.clone());
-        has_changes = true;
-    }
-
-    has_changes.then_some(changes)
+    let changes = SequenceChanges {
+        data_type: (from.data_type != to.data_type).then(|| to.data_type.clone()),
+        increment: (from.increment != to.increment)
+            .then_some(to.increment)
+            .flatten(),
+        min_value: (from.min_value != to.min_value).then_some(to.min_value),
+        max_value: (from.max_value != to.max_value).then_some(to.max_value),
+        restart: (from.start != to.start).then_some(to.start).flatten(),
+        cache: (from.cache != to.cache).then_some(to.cache).flatten(),
+        cycle: (from.cycle != to.cycle).then_some(to.cycle),
+        owned_by: (from.owned_by != to.owned_by).then(|| to.owned_by.clone()),
+    };
+    changes.has_changes().then_some(changes)
 }

--- a/src/diff/types.rs
+++ b/src/diff/types.rs
@@ -271,6 +271,19 @@ pub struct SequenceChanges {
     pub owned_by: Option<Option<SequenceOwner>>,
 }
 
+impl SequenceChanges {
+    pub fn has_changes(&self) -> bool {
+        self.data_type.is_some()
+            || self.increment.is_some()
+            || self.min_value.is_some()
+            || self.max_value.is_some()
+            || self.restart.is_some()
+            || self.cache.is_some()
+            || self.cycle.is_some()
+            || self.owned_by.is_some()
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum EnumValuePosition {
     Before(String),

--- a/src/parser/dependencies.rs
+++ b/src/parser/dependencies.rs
@@ -12,6 +12,8 @@ use sqlparser::parser::Parser;
 use std::collections::{HashSet, VecDeque};
 use std::sync::LazyLock;
 
+use super::util::unquote_ident;
+
 static ROWTYPE_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r#"(?i)(?:(\w+|"[^"]+")\s*\.\s*)?(\w+|"[^"]+")%ROWTYPE"#).unwrap());
 
@@ -38,7 +40,7 @@ impl ObjectRef {
         let parts: Vec<String> = name
             .0
             .iter()
-            .map(|p| p.to_string().trim_matches('"').to_string())
+            .map(|p| unquote_ident(&p.to_string()).to_string())
             .collect();
 
         if parts.len() == 1 {
@@ -501,9 +503,9 @@ pub fn extract_rowtype_references(body: &str, default_schema: &str) -> HashSet<O
     for cap in ROWTYPE_RE.captures_iter(body) {
         let schema = cap
             .get(1)
-            .map(|m| m.as_str().trim_matches('"'))
+            .map(|m| unquote_ident(m.as_str()))
             .unwrap_or(default_schema);
-        let name = cap[2].trim_matches('"');
+        let name = unquote_ident(&cap[2]);
         refs.insert(ObjectRef::new(schema, name));
     }
 

--- a/src/parser/grants.rs
+++ b/src/parser/grants.rs
@@ -3,6 +3,8 @@ use crate::util::Result;
 use regex::Regex;
 use std::collections::BTreeSet;
 
+use super::util::unquote_ident;
+
 fn parse_privileges(privileges_str: &str, object_type: Option<&str>) -> BTreeSet<Privilege> {
     let mut privileges = BTreeSet::new();
     for priv_str in privileges_str.split(',') {
@@ -78,8 +80,8 @@ fn parse_grant_all_in_schema(sql: &str, schema: &mut Schema) {
     for cap in re.captures_iter(sql) {
         let privileges_str = cap.get(1).unwrap().as_str();
         let object_kind = cap.get(2).unwrap().as_str().to_uppercase();
-        let schema_name = cap.get(3).unwrap().as_str().trim_matches('"');
-        let grantee = cap.get(4).unwrap().as_str().trim_matches('"');
+        let schema_name = unquote_ident(cap.get(3).unwrap().as_str());
+        let grantee = unquote_ident(cap.get(4).unwrap().as_str());
         let with_grant_option = cap.get(5).is_some();
 
         let inferred_type = match object_kind.as_str() {
@@ -167,7 +169,7 @@ pub(super) fn parse_grant_statements(sql: &str, schema: &mut Schema) -> Result<(
         let privileges_str = cap.get(1).unwrap().as_str();
         let object_type = cap.get(2).map(|m| m.as_str().to_uppercase());
         let object_name_raw = cap.get(3).unwrap().as_str();
-        let grantee = cap.get(4).unwrap().as_str().trim_matches('"');
+        let grantee = unquote_ident(cap.get(4).unwrap().as_str());
         let with_grant_option = cap.get(5).is_some();
 
         if object_name_raw.to_uppercase().starts_with("ALL ") {
@@ -233,7 +235,7 @@ pub(super) fn parse_grant_statements(sql: &str, schema: &mut Schema) -> Result<(
                 }
             }
             "SCHEMA" => {
-                let schema_name = object_name_raw.trim().trim_matches('"');
+                let schema_name = unquote_ident(object_name_raw.trim());
                 if let Some(pg_schema) = schema.schemas.get_mut(schema_name) {
                     pg_schema.grants.push(grant);
                 } else {
@@ -277,7 +279,7 @@ pub(super) fn parse_revoke_statements(sql: &str, schema: &mut Schema) -> Result<
         let privileges_str = cap.get(2).unwrap().as_str();
         let object_type = cap.get(3).map(|m| m.as_str().to_uppercase());
         let object_name_raw = cap.get(4).unwrap().as_str();
-        let grantee = cap.get(5).unwrap().as_str().trim_matches('"');
+        let grantee = unquote_ident(cap.get(5).unwrap().as_str());
 
         if object_name_raw.to_uppercase().starts_with("ALL ") {
             continue;
@@ -347,7 +349,7 @@ pub(super) fn parse_revoke_statements(sql: &str, schema: &mut Schema) -> Result<
                 }
             }
             "SCHEMA" => {
-                let schema_name = object_name_raw.trim().trim_matches('"');
+                let schema_name = unquote_ident(object_name_raw.trim());
                 if let Some(pg_schema) = schema.schemas.get_mut(schema_name) {
                     revoke_from_grants(
                         &mut pg_schema.grants,
@@ -566,11 +568,11 @@ pub(super) fn parse_alter_default_privileges(sql: &str, schema: &mut Schema) -> 
 }
 
 fn parse_object_name(name: &str) -> (String, String) {
-    let trimmed = name.trim().trim_matches('"');
+    let trimmed = unquote_ident(name.trim());
     match trimmed.split_once('.') {
         Some((schema, obj)) => (
-            schema.trim_matches('"').to_string(),
-            obj.trim_matches('"').to_string(),
+            unquote_ident(schema).to_string(),
+            unquote_ident(obj).to_string(),
         ),
         None => ("public".to_string(), trimmed.to_string()),
     }
@@ -584,16 +586,16 @@ fn parse_function_signature(sig: &str) -> String {
         let args_part = &trimmed[paren_pos..];
 
         if let Some(dot_pos) = before_paren.rfind('.') {
-            let schema_part = &before_paren[..dot_pos].trim_matches('"');
-            let func_name = &before_paren[dot_pos + 1..].trim_matches('"');
+            let schema_part = unquote_ident(&before_paren[..dot_pos]);
+            let func_name = unquote_ident(&before_paren[dot_pos + 1..]);
             format!("{schema_part}.{func_name}{args_part}")
         } else {
-            let name = before_paren.trim_matches('"');
+            let name = unquote_ident(before_paren);
             format!("public.{name}{args_part}")
         }
     } else if trimmed.contains('.') {
         trimmed.to_string()
     } else {
-        format!("public.{}", trimmed.trim_matches('"'))
+        format!("public.{}", unquote_ident(trimmed))
     }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -37,7 +37,8 @@ use preprocess::preprocess_sql;
 use sequences::parse_create_sequence;
 use tables::{parse_column_with_serial, parse_create_table, parse_referential_action};
 use util::{
-    extract_qualified_name, normalize_expr, parse_data_type, parse_for_values, parse_policy_command,
+    extract_qualified_name, normalize_expr, parse_data_type, parse_for_values,
+    parse_policy_command, unquote_ident,
 };
 
 pub fn parse_sql_file(path: &str) -> Result<Schema> {
@@ -93,7 +94,7 @@ pub fn parse_sql_string(sql: &str) -> Result<Schema> {
             Statement::CreateIndex(ci) => {
                 let idx_name = ci
                     .name
-                    .map(|n| n.to_string().trim_matches('"').to_string())
+                    .map(|n| unquote_ident(&n.to_string()).to_string())
                     .ok_or_else(|| SchemaError::ParseError("Index must have name".into()))?;
                 let (tbl_schema, tbl_name) = extract_qualified_name(&ci.table_name);
                 let tbl_key = qualified_name(&tbl_schema, &tbl_name);
@@ -104,7 +105,7 @@ pub fn parse_sql_string(sql: &str) -> Result<Schema> {
                         columns: ci
                             .columns
                             .iter()
-                            .map(|c| c.column.expr.to_string().trim_matches('"').to_string())
+                            .map(|c| unquote_ident(&c.column.expr.to_string()).to_string())
                             .collect(),
                         unique: ci.unique,
                         index_type: IndexType::BTree,
@@ -144,7 +145,7 @@ pub fn parse_sql_string(sql: &str) -> Result<Schema> {
             } => {
                 let (tbl_schema, tbl_name) = extract_qualified_name(&table_name);
                 let policy = Policy {
-                    name: name.to_string().trim_matches('"').to_string(),
+                    name: unquote_ident(&name.to_string()).to_string(),
                     table_schema: tbl_schema,
                     table: tbl_name,
                     command: parse_policy_command(&command),
@@ -217,12 +218,12 @@ pub fn parse_sql_string(sql: &str) -> Result<Schema> {
                                     let fk_name = fk
                                         .name
                                         .as_ref()
-                                        .map(|n| n.to_string().trim_matches('"').to_string())
+                                        .map(|n| unquote_ident(&n.to_string()).to_string())
                                         .unwrap_or_else(|| {
                                             format!(
                                                 "{}_{}_fkey",
                                                 tbl_name,
-                                                fk.columns[0].to_string().trim_matches('"')
+                                                unquote_ident(&fk.columns[0].to_string())
                                             )
                                         });
                                     let (ref_schema, ref_table) =
@@ -232,14 +233,14 @@ pub fn parse_sql_string(sql: &str) -> Result<Schema> {
                                         columns: fk
                                             .columns
                                             .iter()
-                                            .map(|c| c.to_string().trim_matches('"').to_string())
+                                            .map(|c| unquote_ident(&c.to_string()).to_string())
                                             .collect(),
                                         referenced_schema: ref_schema,
                                         referenced_table: ref_table,
                                         referenced_columns: fk
                                             .referred_columns
                                             .iter()
-                                            .map(|c| c.to_string().trim_matches('"').to_string())
+                                            .map(|c| unquote_ident(&c.to_string()).to_string())
                                             .collect(),
                                         on_delete: parse_referential_action(&fk.on_delete),
                                         on_update: parse_referential_action(&fk.on_update),
@@ -248,7 +249,7 @@ pub fn parse_sql_string(sql: &str) -> Result<Schema> {
                                     let constraint_name = chk
                                         .name
                                         .as_ref()
-                                        .map(|n| n.to_string().trim_matches('"').to_string())
+                                        .map(|n| unquote_ident(&n.to_string()).to_string())
                                         .unwrap_or_else(|| format!("{tbl_name}_check"));
 
                                     table.check_constraints.push(CheckConstraint {
@@ -260,7 +261,7 @@ pub fn parse_sql_string(sql: &str) -> Result<Schema> {
                                     let constraint_name = uniq
                                         .name
                                         .as_ref()
-                                        .map(|n| n.to_string().trim_matches('"').to_string())
+                                        .map(|n| unquote_ident(&n.to_string()).to_string())
                                         .unwrap_or_else(|| format!("{tbl_name}_unique"));
 
                                     table.indexes.push(Index {
@@ -269,10 +270,7 @@ pub fn parse_sql_string(sql: &str) -> Result<Schema> {
                                             .columns
                                             .iter()
                                             .map(|c| {
-                                                c.column
-                                                    .expr
-                                                    .to_string()
-                                                    .trim_matches('"')
+                                                unquote_ident(&c.column.expr.to_string())
                                                     .to_string()
                                             })
                                             .collect(),
@@ -300,7 +298,7 @@ pub fn parse_sql_string(sql: &str) -> Result<Schema> {
                             if let Some(table) = schema.tables.get_mut(&tbl_key) {
                                 let names_to_drop: Vec<String> = column_names
                                     .iter()
-                                    .map(|n| n.value.trim_matches('"').to_string())
+                                    .map(|n| unquote_ident(&n.value).to_string())
                                     .collect();
                                 table
                                     .columns
@@ -332,8 +330,8 @@ pub fn parse_sql_string(sql: &str) -> Result<Schema> {
                             new_column_name,
                         } => {
                             if let Some(table) = schema.tables.get_mut(&tbl_key) {
-                                let old_name = old_column_name.value.trim_matches('"').to_string();
-                                let new_name = new_column_name.value.trim_matches('"').to_string();
+                                let old_name = unquote_ident(&old_column_name.value).to_string();
+                                let new_name = unquote_ident(&new_column_name.value).to_string();
 
                                 if let Some(mut column) = table.columns.remove(&old_name) {
                                     column.name = new_name.clone();
@@ -342,8 +340,8 @@ pub fn parse_sql_string(sql: &str) -> Result<Schema> {
                             }
                         }
                         AlterTableOperation::RenameConstraint { old_name, new_name } => {
-                            let old_constraint_name = old_name.value.trim_matches('"').to_string();
-                            let new_constraint_name = new_name.value.trim_matches('"').to_string();
+                            let old_constraint_name = unquote_ident(&old_name.value).to_string();
+                            let new_constraint_name = unquote_ident(&new_name.value).to_string();
 
                             if let Some(table) = schema.tables.get_mut(&tbl_key) {
                                 for idx in &mut table.indexes {
@@ -419,7 +417,7 @@ pub fn parse_sql_string(sql: &str) -> Result<Schema> {
                 schema: ext_schema,
                 ..
             }) => {
-                let ext_name = name.to_string().trim_matches('"').to_string();
+                let ext_name = unquote_ident(&name.to_string()).to_string();
                 if ext_name == "plpgsql" {
                     continue;
                 }
@@ -430,18 +428,18 @@ pub fn parse_sql_string(sql: &str) -> Result<Schema> {
                         .map(|v| v.to_string().trim_matches('\'').to_string()),
                     schema: ext_schema
                         .as_ref()
-                        .map(|s| s.to_string().trim_matches('"').to_string()),
+                        .map(|s| unquote_ident(&s.to_string()).to_string()),
                 };
                 schema.extensions.insert(ext_name, ext);
             }
             Statement::CreateSchema { schema_name, .. } => {
                 let name = match &schema_name {
-                    SchemaName::Simple(obj) => obj.to_string().trim_matches('"').to_string(),
+                    SchemaName::Simple(obj) => unquote_ident(&obj.to_string()).to_string(),
                     SchemaName::UnnamedAuthorization(ident) => {
-                        ident.to_string().trim_matches('"').to_string()
+                        unquote_ident(&ident.to_string()).to_string()
                     }
                     SchemaName::NamedAuthorization(obj, _) => {
-                        obj.to_string().trim_matches('"').to_string()
+                        unquote_ident(&obj.to_string()).to_string()
                     }
                 };
                 schema.schemas.insert(
@@ -508,7 +506,7 @@ pub fn parse_sql_string(sql: &str) -> Result<Schema> {
                 ..
             }) => {
                 let (tbl_schema, tbl_name) = extract_qualified_name(&table_name);
-                let trigger_name = name.to_string().trim_matches('"').to_string();
+                let trigger_name = unquote_ident(&name.to_string()).to_string();
                 let exec = exec_body.as_ref().ok_or_else(|| {
                     SchemaError::ParseError(format!(
                         "Trigger '{trigger_name}' missing EXECUTE clause"
@@ -723,7 +721,7 @@ pub fn parse_sql_string(sql: &str) -> Result<Schema> {
                     "{}.{}.{}",
                     tbl_schema,
                     tbl_name,
-                    trigger_name.to_string().trim_matches('"')
+                    unquote_ident(&trigger_name.to_string())
                 );
                 schema.triggers.remove(&trigger_key);
             }
@@ -733,7 +731,7 @@ pub fn parse_sql_string(sql: &str) -> Result<Schema> {
             } => {
                 let (tbl_schema, tbl_name) = extract_qualified_name(&table_name);
                 let tbl_key = qualified_name(&tbl_schema, &tbl_name);
-                let policy_name = name.to_string().trim_matches('"').to_string();
+                let policy_name = unquote_ident(&name.to_string()).to_string();
 
                 if let Some(table) = schema.tables.get_mut(&tbl_key) {
                     table.policies.retain(|p| p.name != policy_name);
@@ -744,7 +742,7 @@ pub fn parse_sql_string(sql: &str) -> Result<Schema> {
             }
             Statement::DropExtension(DropExtension { names, .. }) => {
                 for name in names {
-                    let ext_name = name.to_string().trim_matches('"').to_string();
+                    let ext_name = unquote_ident(&name.to_string()).to_string();
                     if ext_name == "plpgsql" {
                         continue;
                     }

--- a/src/parser/ownership.rs
+++ b/src/parser/ownership.rs
@@ -1,16 +1,18 @@
 use crate::model::*;
 use regex::Regex;
 
+use super::util::unquote_ident;
+
 pub(super) fn parse_owner_statements(sql: &str, schema: &mut Schema) {
     let alter_function_owner_re = Regex::new(
         r#"(?i)ALTER\s+FUNCTION\s+(?:["']?([^"'\s(]+)["']?\.)?["']?([^"'\s(]+)["']?\s*\(([^)]*)\)\s+OWNER\s+TO\s+["']?([^"'\s;]+)["']?"#
     ).unwrap();
 
     for cap in alter_function_owner_re.captures_iter(sql) {
-        let schema_part = cap.get(1).map(|m| m.as_str().trim_matches('"'));
-        let func_name = cap.get(2).unwrap().as_str().trim_matches('"');
+        let schema_part = cap.get(1).map(|m| unquote_ident(m.as_str()));
+        let func_name = unquote_ident(cap.get(2).unwrap().as_str());
         let args_str = cap.get(3).unwrap().as_str();
-        let owner = cap.get(4).unwrap().as_str().trim_matches('"');
+        let owner = unquote_ident(cap.get(4).unwrap().as_str());
 
         let func_schema = schema_part.unwrap_or("public");
         let object_key = format!("{func_schema}.{func_name}({args_str})");
@@ -26,9 +28,9 @@ pub(super) fn parse_owner_statements(sql: &str, schema: &mut Schema) {
     ).unwrap();
 
     for cap in alter_type_owner_re.captures_iter(sql) {
-        let schema_part = cap.get(1).map(|m| m.as_str().trim_matches('"'));
-        let type_name = cap.get(2).unwrap().as_str().trim_matches('"');
-        let owner = cap.get(3).unwrap().as_str().trim_matches('"');
+        let schema_part = cap.get(1).map(|m| unquote_ident(m.as_str()));
+        let type_name = unquote_ident(cap.get(2).unwrap().as_str());
+        let owner = unquote_ident(cap.get(3).unwrap().as_str());
 
         let type_schema = schema_part.unwrap_or("public");
         let object_key = qualified_name(type_schema, type_name);
@@ -44,9 +46,9 @@ pub(super) fn parse_owner_statements(sql: &str, schema: &mut Schema) {
     ).unwrap();
 
     for cap in alter_domain_owner_re.captures_iter(sql) {
-        let schema_part = cap.get(1).map(|m| m.as_str().trim_matches('"'));
-        let domain_name = cap.get(2).unwrap().as_str().trim_matches('"');
-        let owner = cap.get(3).unwrap().as_str().trim_matches('"');
+        let schema_part = cap.get(1).map(|m| unquote_ident(m.as_str()));
+        let domain_name = unquote_ident(cap.get(2).unwrap().as_str());
+        let owner = unquote_ident(cap.get(3).unwrap().as_str());
 
         let domain_schema = schema_part.unwrap_or("public");
         let object_key = qualified_name(domain_schema, domain_name);
@@ -62,9 +64,9 @@ pub(super) fn parse_owner_statements(sql: &str, schema: &mut Schema) {
     ).unwrap();
 
     for cap in alter_table_owner_re.captures_iter(sql) {
-        let schema_part = cap.get(1).map(|m| m.as_str().trim_matches('"'));
-        let table_name = cap.get(2).unwrap().as_str().trim_matches('"');
-        let owner = cap.get(3).unwrap().as_str().trim_matches('"');
+        let schema_part = cap.get(1).map(|m| unquote_ident(m.as_str()));
+        let table_name = unquote_ident(cap.get(2).unwrap().as_str());
+        let owner = unquote_ident(cap.get(3).unwrap().as_str());
 
         let table_schema = schema_part.unwrap_or("public");
         let object_key = qualified_name(table_schema, table_name);
@@ -80,9 +82,9 @@ pub(super) fn parse_owner_statements(sql: &str, schema: &mut Schema) {
     ).unwrap();
 
     for cap in alter_materialized_view_owner_re.captures_iter(sql) {
-        let schema_part = cap.get(1).map(|m| m.as_str().trim_matches('"'));
-        let view_name = cap.get(2).unwrap().as_str().trim_matches('"');
-        let owner = cap.get(3).unwrap().as_str().trim_matches('"');
+        let schema_part = cap.get(1).map(|m| unquote_ident(m.as_str()));
+        let view_name = unquote_ident(cap.get(2).unwrap().as_str());
+        let owner = unquote_ident(cap.get(3).unwrap().as_str());
 
         let view_schema = schema_part.unwrap_or("public");
         let object_key = qualified_name(view_schema, view_name);
@@ -98,9 +100,9 @@ pub(super) fn parse_owner_statements(sql: &str, schema: &mut Schema) {
     ).unwrap();
 
     for cap in alter_view_owner_re.captures_iter(sql) {
-        let schema_part = cap.get(1).map(|m| m.as_str().trim_matches('"'));
-        let view_name = cap.get(2).unwrap().as_str().trim_matches('"');
-        let owner = cap.get(3).unwrap().as_str().trim_matches('"');
+        let schema_part = cap.get(1).map(|m| unquote_ident(m.as_str()));
+        let view_name = unquote_ident(cap.get(2).unwrap().as_str());
+        let owner = unquote_ident(cap.get(3).unwrap().as_str());
 
         let view_schema = schema_part.unwrap_or("public");
         let object_key = qualified_name(view_schema, view_name);
@@ -116,9 +118,9 @@ pub(super) fn parse_owner_statements(sql: &str, schema: &mut Schema) {
     ).unwrap();
 
     for cap in alter_sequence_owner_re.captures_iter(sql) {
-        let schema_part = cap.get(1).map(|m| m.as_str().trim_matches('"'));
-        let sequence_name = cap.get(2).unwrap().as_str().trim_matches('"');
-        let owner = cap.get(3).unwrap().as_str().trim_matches('"');
+        let schema_part = cap.get(1).map(|m| unquote_ident(m.as_str()));
+        let sequence_name = unquote_ident(cap.get(2).unwrap().as_str());
+        let owner = unquote_ident(cap.get(3).unwrap().as_str());
 
         let seq_schema = schema_part.unwrap_or("public");
         let object_key = qualified_name(seq_schema, sequence_name);

--- a/src/parser/sequences.rs
+++ b/src/parser/sequences.rs
@@ -2,6 +2,8 @@ use crate::model::*;
 use crate::util::Result;
 use sqlparser::ast::{DataType, Expr, ObjectName, SequenceOptions, UnaryOperator, Value};
 
+use super::util::unquote_ident;
+
 pub(super) fn parse_create_sequence(
     schema: &str,
     name: &str,
@@ -53,7 +55,7 @@ pub(super) fn parse_create_sequence(
         let parts: Vec<String> = obj_name
             .0
             .iter()
-            .map(|part| part.to_string().trim_matches('"').to_string())
+            .map(|part| unquote_ident(&part.to_string()).to_string())
             .collect();
         match parts.as_slice() {
             [table_schema, table_name, column_name] => Some(SequenceOwner {

--- a/src/parser/tables.rs
+++ b/src/parser/tables.rs
@@ -6,7 +6,7 @@ use sqlparser::ast::{
 };
 use std::collections::BTreeMap;
 
-use super::util::{extract_qualified_name, normalize_expr, parse_data_type};
+use super::util::{extract_qualified_name, normalize_expr, parse_data_type, unquote_ident};
 
 pub(super) struct ParsedTable {
     pub(super) table: Table,
@@ -49,7 +49,7 @@ pub(super) fn parse_create_table(
     for col_def in columns {
         for option in &col_def.options {
             if matches!(option.option, ColumnOption::PrimaryKey(_)) {
-                let pk_col = col_def.name.to_string().trim_matches('"').to_string();
+                let pk_col = unquote_ident(&col_def.name.to_string()).to_string();
                 table.primary_key = Some(PrimaryKey {
                     columns: vec![pk_col.clone()],
                 });
@@ -66,7 +66,7 @@ pub(super) fn parse_create_table(
                 let pk_columns: Vec<String> = pk
                     .columns
                     .iter()
-                    .map(|c| c.to_string().trim_matches('"').to_string())
+                    .map(|c| unquote_ident(&c.to_string()).to_string())
                     .collect();
                 table.primary_key = Some(PrimaryKey {
                     columns: pk_columns.clone(),
@@ -81,12 +81,12 @@ pub(super) fn parse_create_table(
                 let fk_name = fk
                     .name
                     .as_ref()
-                    .map(|n| n.to_string().trim_matches('"').to_string())
+                    .map(|n| unquote_ident(&n.to_string()).to_string())
                     .unwrap_or_else(|| {
                         format!(
                             "{}_{}_fkey",
                             table.name,
-                            fk.columns[0].to_string().trim_matches('"')
+                            unquote_ident(&fk.columns[0].to_string())
                         )
                     });
 
@@ -96,14 +96,14 @@ pub(super) fn parse_create_table(
                     columns: fk
                         .columns
                         .iter()
-                        .map(|c| c.to_string().trim_matches('"').to_string())
+                        .map(|c| unquote_ident(&c.to_string()).to_string())
                         .collect(),
                     referenced_schema: ref_schema,
                     referenced_table: ref_table,
                     referenced_columns: fk
                         .referred_columns
                         .iter()
-                        .map(|c| c.to_string().trim_matches('"').to_string())
+                        .map(|c| unquote_ident(&c.to_string()).to_string())
                         .collect(),
                     on_delete: parse_referential_action(&fk.on_delete),
                     on_update: parse_referential_action(&fk.on_update),
@@ -113,7 +113,7 @@ pub(super) fn parse_create_table(
                 let constraint_name = chk
                     .name
                     .as_ref()
-                    .map(|n| n.to_string().trim_matches('"').to_string())
+                    .map(|n| unquote_ident(&n.to_string()).to_string())
                     .unwrap_or_else(|| format!("{}_check", table.name));
 
                 table.check_constraints.push(CheckConstraint {
@@ -125,7 +125,7 @@ pub(super) fn parse_create_table(
                 let constraint_name = uniq
                     .name
                     .as_ref()
-                    .map(|n| n.to_string().trim_matches('"').to_string())
+                    .map(|n| unquote_ident(&n.to_string()).to_string())
                     .unwrap_or_else(|| format!("{}_unique", table.name));
 
                 table.indexes.push(Index {
@@ -133,7 +133,7 @@ pub(super) fn parse_create_table(
                     columns: uniq
                         .columns
                         .iter()
-                        .map(|c| c.column.expr.to_string().trim_matches('"').to_string())
+                        .map(|c| unquote_ident(&c.column.expr.to_string()).to_string())
                         .collect(),
                     unique: true,
                     index_type: IndexType::BTree,
@@ -171,7 +171,7 @@ pub(super) fn parse_column_with_serial(
         }
     }
 
-    let col_name = col_def.name.to_string().trim_matches('"').to_string();
+    let col_name = unquote_ident(&col_def.name.to_string()).to_string();
 
     if let Some(seq_data_type) = detect_serial_type(&col_def.data_type) {
         let seq_name = format!("{table_name}_{col_name}_seq");

--- a/src/parser/util.rs
+++ b/src/parser/util.rs
@@ -5,6 +5,10 @@ use sqlparser::ast::{
     PartitionBoundValue, TimezoneInfo,
 };
 
+pub(super) fn unquote_ident(s: &str) -> &str {
+    s.trim_matches('"')
+}
+
 pub(super) fn normalize_expr(expr: &str) -> String {
     normalize_type_casts(expr)
 }
@@ -13,7 +17,7 @@ pub(super) fn extract_qualified_name(name: &ObjectName) -> (String, String) {
     let parts: Vec<String> = name
         .0
         .iter()
-        .map(|part| part.to_string().trim_matches('"').to_string())
+        .map(|part| unquote_ident(&part.to_string()).to_string())
         .collect();
     match parts.as_slice() {
         [schema, table] => (schema.clone(), table.clone()),
@@ -98,7 +102,7 @@ pub(super) fn parse_data_type(dt: &DataType) -> Result<PgType> {
             let parts: Vec<String> = name
                 .0
                 .iter()
-                .map(|part| part.to_string().trim_matches('"').to_string())
+                .map(|part| unquote_ident(&part.to_string()).to_string())
                 .collect();
 
             let type_name_raw = parts.last().map(|s| s.as_str()).unwrap_or("");

--- a/src/pg/introspect.rs
+++ b/src/pg/introspect.rs
@@ -514,9 +514,7 @@ async fn introspect_partition_keys(
             _ => continue,
         };
 
-        // key_def is like "RANGE (logdate)" or "LIST (status)"
-        // Extract the columns by parsing the parentheses
-        let columns = parse_partition_key_columns(&key_def);
+        let columns = extract_paren_values(&key_def);
 
         let partition_key = PartitionKey {
             strategy,
@@ -666,21 +664,6 @@ fn extract_paren_values(s: &str) -> Vec<String> {
         if let Some(end) = s.rfind(')') {
             let inner = &s[start + 1..end];
             return inner.split(',').map(|v| v.trim().to_string()).collect();
-        }
-    }
-    Vec::new()
-}
-
-/// Parse column names from a partition key definition like "RANGE (col1, col2)"
-fn parse_partition_key_columns(key_def: &str) -> Vec<String> {
-    // Find content between parentheses
-    if let Some(start) = key_def.find('(') {
-        if let Some(end) = key_def.rfind(')') {
-            let columns_str = &key_def[start + 1..end];
-            return columns_str
-                .split(',')
-                .map(|s| s.trim().to_string())
-                .collect();
         }
     }
     Vec::new()
@@ -1366,10 +1349,9 @@ fn parse_function_arguments(args_str: &str) -> Vec<FunctionArg> {
         .map(|arg| {
             let arg = arg.trim();
 
-            // Find the DEFAULT keyword case-insensitively outside of quotes,
-            // then extract the value from the original string to preserve its case.
             let (arg_without_default, default) = if let Some(idx) = find_default_keyword(arg) {
-                let default_value = arg[idx + 9..].trim().to_string();
+                let keyword = " DEFAULT ";
+                let default_value = arg[idx + keyword.len()..].trim().to_string();
                 (arg[..idx].trim(), Some(default_value))
             } else {
                 (arg, None)
@@ -1406,6 +1388,40 @@ fn parse_function_arguments(args_str: &str) -> Vec<FunctionArg> {
         .collect()
 }
 
+async fn fetch_views(
+    connection: &PgConnection,
+    target_schemas: &[String],
+    include_extension_objects: bool,
+    query: &str,
+    name_column: &str,
+    materialized: bool,
+) -> Result<Vec<View>> {
+    let rows = sqlx::query(query)
+        .bind(target_schemas)
+        .bind(include_extension_objects)
+        .fetch_all(connection.pool())
+        .await
+        .map_err(|e| SchemaError::DatabaseError(format!("Failed to fetch views: {e}")))?;
+
+    let mut result = Vec::new();
+    for row in rows {
+        let schema: String = row.get("schemaname");
+        let name: String = row.get(name_column);
+        let definition: String = row.get("definition");
+        let owner: String = row.get("owner");
+
+        result.push(View {
+            name,
+            schema,
+            query: normalize_sql_whitespace(definition.trim_end_matches(';')),
+            materialized,
+            owner: Some(owner),
+            grants: Vec::new(),
+        });
+    }
+    Ok(result)
+}
+
 async fn introspect_views(
     connection: &PgConnection,
     target_schemas: &[String],
@@ -1413,7 +1429,10 @@ async fn introspect_views(
 ) -> Result<BTreeMap<String, View>> {
     let mut views = BTreeMap::new();
 
-    let regular_views = sqlx::query(
+    let regular_views = fetch_views(
+        connection,
+        target_schemas,
+        include_extension_objects,
         r#"
         SELECT v.schemaname, v.viewname, v.definition, r.rolname AS owner
         FROM pg_views v
@@ -1427,31 +1446,19 @@ async fn introspect_views(
               AND d.deptype = 'e'
           ))
         "#,
+        "viewname",
+        false,
     )
-    .bind(target_schemas)
-    .bind(include_extension_objects)
-    .fetch_all(connection.pool())
-    .await
-    .map_err(|e| SchemaError::DatabaseError(format!("Failed to fetch views: {e}")))?;
+    .await?;
 
-    for row in regular_views {
-        let schema: String = row.get("schemaname");
-        let name: String = row.get("viewname");
-        let definition: String = row.get("definition");
-        let owner: String = row.get("owner");
-
-        let view = View {
-            name: name.clone(),
-            schema: schema.clone(),
-            query: normalize_sql_whitespace(definition.trim_end_matches(';')),
-            materialized: false,
-            owner: Some(owner),
-            grants: Vec::new(),
-        };
-        views.insert(qualified_name(&schema, &name), view);
+    for view in regular_views {
+        views.insert(qualified_name(&view.schema, &view.name), view);
     }
 
-    let materialized_views = sqlx::query(
+    let materialized_views = fetch_views(
+        connection,
+        target_schemas,
+        include_extension_objects,
         r#"
         SELECT v.schemaname, v.matviewname, v.definition, r.rolname AS owner
         FROM pg_matviews v
@@ -1465,32 +1472,25 @@ async fn introspect_views(
               AND d.deptype = 'e'
           ))
         "#,
+        "matviewname",
+        true,
     )
-    .bind(target_schemas)
-    .bind(include_extension_objects)
-    .fetch_all(connection.pool())
-    .await
-    .map_err(|e| SchemaError::DatabaseError(format!("Failed to fetch materialized views: {e}")))?;
+    .await?;
 
-    for row in materialized_views {
-        let schema: String = row.get("schemaname");
-        let name: String = row.get("matviewname");
-        let definition: String = row.get("definition");
-        let owner: String = row.get("owner");
-
-        let view = View {
-            name: name.clone(),
-            schema: schema.clone(),
-            query: normalize_sql_whitespace(definition.trim_end_matches(';')),
-            materialized: true,
-            owner: Some(owner),
-            grants: Vec::new(),
-        };
-        views.insert(qualified_name(&schema, &name), view);
+    for view in materialized_views {
+        views.insert(qualified_name(&view.schema, &view.name), view);
     }
 
     Ok(views)
 }
+
+const TRIGGER_TYPE_ROW: i16 = 0x0001;
+const TRIGGER_TYPE_BEFORE: i16 = 0x0002;
+const TRIGGER_TYPE_INSERT: i16 = 0x0004;
+const TRIGGER_TYPE_DELETE: i16 = 0x0008;
+const TRIGGER_TYPE_UPDATE: i16 = 0x0010;
+const TRIGGER_TYPE_TRUNCATE: i16 = 0x0020;
+const TRIGGER_TYPE_INSTEAD: i16 = 0x0040;
 
 async fn introspect_triggers(
     connection: &PgConnection,
@@ -1552,27 +1552,27 @@ async fn introspect_triggers(
         let old_table_name: Option<String> = row.get("old_table_name");
         let new_table_name: Option<String> = row.get("new_table_name");
 
-        let timing = if tgtype & 0x0040 != 0 {
+        let timing = if tgtype & TRIGGER_TYPE_INSTEAD != 0 {
             TriggerTiming::InsteadOf
-        } else if tgtype & 0x0002 != 0 {
+        } else if tgtype & TRIGGER_TYPE_BEFORE != 0 {
             TriggerTiming::Before
         } else {
             TriggerTiming::After
         };
 
-        let for_each_row = tgtype & 0x0001 != 0;
+        let for_each_row = tgtype & TRIGGER_TYPE_ROW != 0;
 
         let mut events = Vec::new();
-        if tgtype & 0x0004 != 0 {
+        if tgtype & TRIGGER_TYPE_INSERT != 0 {
             events.push(TriggerEvent::Insert);
         }
-        if tgtype & 0x0010 != 0 {
+        if tgtype & TRIGGER_TYPE_UPDATE != 0 {
             events.push(TriggerEvent::Update);
         }
-        if tgtype & 0x0008 != 0 {
+        if tgtype & TRIGGER_TYPE_DELETE != 0 {
             events.push(TriggerEvent::Delete);
         }
-        if tgtype & 0x0020 != 0 {
+        if tgtype & TRIGGER_TYPE_TRUNCATE != 0 {
             events.push(TriggerEvent::Truncate);
         }
 


### PR DESCRIPTION
## Summary

- Unify `extract_paren_values` and `parse_partition_key_columns` into single function in introspect.rs
- Extract `unquote_ident` helper in parser/util.rs, replacing ~50 inline `.trim_matches('"')` calls across parser modules
- Refactor `compute_sequence_changes` to construct `SequenceChanges` directly instead of tracking mutable `has_changes` flag
- Name trigger bitmask constants (`TRIGGER_TYPE_ROW`, `TRIGGER_TYPE_INSERT`, etc.) replacing magic hex values
- Extract `fetch_views` helper to deduplicate regular/materialized view queries in `introspect_views`
- Replace magic offset `9` with `keyword.len()` in function arg default parsing

## Test plan
- [x] All 915 unit tests pass
- [x] Clippy clean
- [x] `cargo fmt` clean