### PR TITLE
refactor: address code smells across codebase (round 6)

### DIFF
--- a/src/diff/grants.rs
+++ b/src/diff/grants.rs
@@ -4,10 +4,6 @@ use crate::model::{DefaultPrivilege, Grant, Privilege, Schema};
 
 use super::{GrantObjectKind, MigrationOp};
 
-fn collect_privileges(set: &BTreeSet<Privilege>) -> Vec<Privilege> {
-    set.iter().cloned().collect()
-}
-
 struct GrantOptionChange {
     revoke_grant_option: Option<Vec<Privilege>>,
     regrant_with_option: Option<Vec<Privilege>>,
@@ -137,7 +133,7 @@ pub(super) fn diff_grants_for_object(
                 }
             }
             None => {
-                let privs = collect_privileges(&from_grant.privileges);
+                let privs: Vec<Privilege> = from_grant.privileges.iter().cloned().collect();
                 if !privs.is_empty() {
                     ops.push(MigrationOp::RevokePrivileges {
                         object_kind,
@@ -155,7 +151,7 @@ pub(super) fn diff_grants_for_object(
 
     for (grantee, to_grant) in &to_by_grantee {
         if !from_by_grantee.contains_key(grantee) {
-            let privs = collect_privileges(&to_grant.privileges);
+            let privs: Vec<Privilege> = to_grant.privileges.iter().cloned().collect();
             if !privs.is_empty() {
                 ops.push(MigrationOp::GrantPrivileges {
                     object_kind,
@@ -185,7 +181,7 @@ pub(super) fn create_grants_for_new_object(
         .iter()
         .filter(|grant| !excluded_grant_roles.contains(&grant.grantee.to_lowercase()))
         .filter_map(|grant| {
-            let privs = collect_privileges(&grant.privileges);
+            let privs: Vec<Privilege> = grant.privileges.iter().cloned().collect();
             if privs.is_empty() {
                 return None;
             }
@@ -229,7 +225,7 @@ pub(super) fn diff_default_privileges(from: &Schema, to: &Schema) -> Vec<Migrati
 
     for (key, from_dp) in &from_map {
         if !to_map.contains_key(key) {
-            let privs = collect_privileges(&from_dp.privileges);
+            let privs: Vec<Privilege> = from_dp.privileges.iter().cloned().collect();
             if !privs.is_empty() {
                 ops.push(MigrationOp::AlterDefaultPrivileges {
                     target_role: from_dp.target_role.clone(),
@@ -239,23 +235,6 @@ pub(super) fn diff_default_privileges(from: &Schema, to: &Schema) -> Vec<Migrati
                     privileges: privs,
                     with_grant_option: from_dp.with_grant_option,
                     revoke: true,
-                });
-            }
-        }
-    }
-
-    for (key, to_dp) in &to_map {
-        if !from_map.contains_key(key) {
-            let privs = collect_privileges(&to_dp.privileges);
-            if !privs.is_empty() {
-                ops.push(MigrationOp::AlterDefaultPrivileges {
-                    target_role: to_dp.target_role.clone(),
-                    schema: to_dp.schema.clone(),
-                    object_type: to_dp.object_type.clone(),
-                    grantee: to_dp.grantee.clone(),
-                    privileges: privs,
-                    with_grant_option: to_dp.with_grant_option,
-                    revoke: false,
                 });
             }
         }
@@ -324,6 +303,19 @@ pub(super) fn diff_default_privileges(from: &Schema, to: &Schema) -> Vec<Migrati
                         revoke: false,
                     });
                 }
+            }
+        } else {
+            let privs: Vec<Privilege> = to_dp.privileges.iter().cloned().collect();
+            if !privs.is_empty() {
+                ops.push(MigrationOp::AlterDefaultPrivileges {
+                    target_role: to_dp.target_role.clone(),
+                    schema: to_dp.schema.clone(),
+                    object_type: to_dp.object_type.clone(),
+                    grantee: to_dp.grantee.clone(),
+                    privileges: privs,
+                    with_grant_option: to_dp.with_grant_option,
+                    revoke: false,
+                });
             }
         }
     }

--- a/src/diff/objects.rs
+++ b/src/diff/objects.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use crate::model::{
-    parse_qualified_name, qualified_name, EnumType, Function, Grant, Schema, Sequence, Trigger,
+    parse_qualified_name, qualified_name, EnumType, Grant, Schema, Sequence, Trigger,
 };
 use crate::util::optional_expressions_equal;
 
@@ -10,15 +10,6 @@ use super::{
     DiffOptions, DomainChanges, EnumValuePosition, GrantObjectKind, MigrationOp, OwnerObjectKind,
     SequenceChanges,
 };
-
-fn function_args_string(function: &Function) -> String {
-    function
-        .arguments
-        .iter()
-        .map(|a| a.data_type.as_str())
-        .collect::<Vec<_>>()
-        .join(", ")
-}
 
 fn emit_ownership_change(
     ops: &mut Vec<MigrationOp>,
@@ -363,13 +354,13 @@ pub(super) fn diff_functions(
                 if from_func.requires_drop_recreate(to_func) {
                     ops.push(MigrationOp::DropFunction {
                         name: qualified_name(&from_func.schema, &from_func.name),
-                        args: function_args_string(from_func),
+                        args: from_func.args_string(),
                     });
                     ops.push(MigrationOp::CreateFunction(to_func.clone()));
                 } else {
                     ops.push(MigrationOp::AlterFunction {
                         name: qualified_name(&to_func.schema, &to_func.name),
-                        args: function_args_string(to_func),
+                        args: to_func.args_string(),
                         new_function: to_func.clone(),
                     });
                 }
@@ -377,12 +368,12 @@ pub(super) fn diff_functions(
         },
         |_key, func| MigrationOp::DropFunction {
             name: qualified_name(&func.schema, &func.name),
-            args: function_args_string(func),
+            args: func.args_string(),
         },
         |_key, func| ObjectCoords {
             schema: func.schema.clone(),
             name: func.name.clone(),
-            args: Some(function_args_string(func)),
+            args: Some(func.args_string()),
         },
         Some(GrantObjectKind::Function),
         |_val| Some(OwnerObjectKind::Function),

--- a/src/diff/op_key.rs
+++ b/src/diff/op_key.rs
@@ -292,12 +292,7 @@ impl OpKey {
             },
             MigrationOp::CreateFunction(f) => OpKey::CreateFunction {
                 name: qualified_name(&f.schema, &f.name),
-                args: f
-                    .arguments
-                    .iter()
-                    .map(|a| a.data_type.clone())
-                    .collect::<Vec<_>>()
-                    .join(", "),
+                args: f.args_string(),
             },
             MigrationOp::DropFunction { name, args } => OpKey::DropFunction {
                 name: name.clone(),

--- a/src/lint/mod.rs
+++ b/src/lint/mod.rs
@@ -107,15 +107,10 @@ fn lint_op(op: &MigrationOp, options: &LintOptions) -> Vec<LintResult> {
 
         MigrationOp::DropView { name, materialized } => {
             if !options.allow_destructive {
-                let rule = if *materialized {
-                    "deny_drop_materialized_view"
+                let (rule, view_type) = if *materialized {
+                    ("deny_drop_materialized_view", "materialized view")
                 } else {
-                    "deny_drop_view"
-                };
-                let view_type = if *materialized {
-                    "materialized view"
-                } else {
-                    "view"
+                    ("deny_drop_view", "view")
                 };
                 results.push(LintResult {
                     rule: rule.to_string(),

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1068,6 +1068,14 @@ impl Default for Schema {
 }
 
 impl Function {
+    pub fn args_string(&self) -> String {
+        self.arguments
+            .iter()
+            .map(|a| a.data_type.as_str())
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
+
     pub fn signature(&self) -> String {
         let args = self
             .arguments

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -11,11 +11,13 @@ static RE_WHITESPACE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\s+").expe
 static RE_TYPE_CAST: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"::([A-Za-z][A-Za-z0-9_\[\]]*)").expect("valid regex"));
 
+const STRING_TEXT_CAST_PATTERN: &str = r"'([^']*)'::text";
+
 static RE_STRING_TEXT_CAST: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"'([^']*)'::text").expect("valid regex"));
+    LazyLock::new(|| Regex::new(STRING_TEXT_CAST_PATTERN).expect("valid regex"));
 
 static RE_STRING_TEXT_CAST_CI: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"(?i)'([^']*)'::text").expect("valid regex"));
+    LazyLock::new(|| Regex::new(&format!("(?i){STRING_TEXT_CAST_PATTERN}")).expect("valid regex"));
 
 static RE_STRING_CUSTOM_CAST: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r#"'([^']*)'::(?:[a-z_][a-z0-9_]*\.)?"?[A-Za-z_][A-Za-z0-9_]*"?"#)
@@ -539,25 +541,18 @@ fn remove_outer_parens_around_pattern(s: &str, pattern: &str) -> String {
 /// Removes parens around JOINs in FROM clause
 /// FROM (table1 JOIN table2 ON (...)) -> FROM table1 JOIN table2 ON (...)
 fn remove_from_join_parens(s: &str) -> String {
-    let mut result = s.to_string();
-
-    loop {
-        let mut found = false;
-        if let Some(mat) = RE_FROM_PAREN.find(&result) {
+    apply_until_stable(s.to_string(), |input| {
+        if let Some(mat) = RE_FROM_PAREN.find(input) {
             let open_pos = mat.end() - 1;
-            let after_paren = &result[mat.end()..];
+            let after_paren = &input[mat.end()..];
             if RE_JOIN_PATTERN.is_match(after_paren) {
-                if let Some(close_pos) = find_matching_paren(&result, open_pos) {
-                    result = remove_byte_pair(&result, open_pos, close_pos);
-                    found = true;
+                if let Some(close_pos) = find_matching_paren(input, open_pos) {
+                    return Some(remove_byte_pair(input, open_pos, close_pos));
                 }
             }
         }
-        if !found {
-            break;
-        }
-    }
-    result
+        None
+    })
 }
 
 fn apply_until_stable<F>(mut input: String, mut transform: F) -> String
@@ -641,32 +636,24 @@ fn strip_on_clause_parens(query: &str) -> String {
 }
 
 fn remove_parens_around_and_groups_in_or(query: &str) -> String {
-    let mut result = query.to_string();
-    loop {
-        let mut found = false;
-        if let Some(mat) = RE_OR_PAREN.find(&result) {
+    apply_until_stable(query.to_string(), |input| {
+        if let Some(mat) = RE_OR_PAREN.find(input) {
             let open_pos = mat.end() - 1;
-            if let Some(close_pos) = find_matching_paren(&result, open_pos) {
-                let content = &result[open_pos + 1..close_pos];
+            if let Some(close_pos) = find_matching_paren(input, open_pos) {
+                let content = &input[open_pos + 1..close_pos];
                 if content.contains(" AND ") && !content.contains(" OR ") {
-                    result = remove_byte_pair(&result, open_pos, close_pos);
-                    found = true;
+                    return Some(remove_byte_pair(input, open_pos, close_pos));
                 }
             }
         }
-        if !found {
-            break;
-        }
-    }
-    result
+        None
+    })
 }
 
 fn remove_simple_expression_parens(query: &str) -> String {
-    let mut result = query.to_string();
-    loop {
-        let before = result.clone();
-        result = RE_SIMPLE_PAREN
-            .replace_all(&result, |caps: &regex::Captures| {
+    apply_until_stable(query.to_string(), |input| {
+        let new = RE_SIMPLE_PAREN
+            .replace_all(input, |caps: &regex::Captures| {
                 let content = &caps[1];
                 if !content.contains(" AND ")
                     && !content.contains(" OR ")
@@ -679,11 +666,12 @@ fn remove_simple_expression_parens(query: &str) -> String {
                 }
             })
             .to_string();
-        if result == before {
-            break;
+        if new != input {
+            Some(new)
+        } else {
+            None
         }
-    }
-    result
+    })
 }
 
 fn remove_structural_parens(query: &str) -> String {


### PR DESCRIPTION
## Summary

- extract `args_string()` method on `Function` to deduplicate 3 call sites
- collapse parallel if/else in `DropView` lint rule into single destructure
- use `apply_until_stable` for 3 manual loop patterns in util
- remove trivial `collect_privileges` wrapper (added in round 5, reverted)
- extract shared regex base pattern for text cast matching
- combine double iteration in `diff_default_privileges`

## Test plan

- [x] `cargo build` passes
- [x] all 915 unit tests pass
- [x] `cargo fmt --check` passes
- [x] `cargo clippy` passes