### PR TITLE
refactor: address code smells across codebase (round 7)

### DIFF
--- a/src/diff/grants.rs
+++ b/src/diff/grants.rs
@@ -212,6 +212,18 @@ pub(super) fn diff_default_privileges(from: &Schema, to: &Schema) -> Vec<Migrati
         )
     }
 
+    let emit_dp = |dp: &DefaultPrivilege, privileges: Vec<Privilege>, revoke: bool| {
+        MigrationOp::AlterDefaultPrivileges {
+            target_role: dp.target_role.clone(),
+            schema: dp.schema.clone(),
+            object_type: dp.object_type.clone(),
+            grantee: dp.grantee.clone(),
+            privileges,
+            with_grant_option: dp.with_grant_option,
+            revoke,
+        }
+    };
+
     let from_map: BTreeMap<DpKey, &DefaultPrivilege> = from
         .default_privileges
         .iter()
@@ -227,15 +239,7 @@ pub(super) fn diff_default_privileges(from: &Schema, to: &Schema) -> Vec<Migrati
         if !to_map.contains_key(key) {
             let privs: Vec<Privilege> = from_dp.privileges.iter().cloned().collect();
             if !privs.is_empty() {
-                ops.push(MigrationOp::AlterDefaultPrivileges {
-                    target_role: from_dp.target_role.clone(),
-                    schema: from_dp.schema.clone(),
-                    object_type: from_dp.object_type.clone(),
-                    grantee: from_dp.grantee.clone(),
-                    privileges: privs,
-                    with_grant_option: from_dp.with_grant_option,
-                    revoke: true,
-                });
+                ops.push(emit_dp(from_dp, privs, true));
             }
         }
     }
@@ -254,27 +258,11 @@ pub(super) fn diff_default_privileges(from: &Schema, to: &Schema) -> Vec<Migrati
                 .collect();
 
             if !privs_to_revoke.is_empty() {
-                ops.push(MigrationOp::AlterDefaultPrivileges {
-                    target_role: from_dp.target_role.clone(),
-                    schema: from_dp.schema.clone(),
-                    object_type: from_dp.object_type.clone(),
-                    grantee: from_dp.grantee.clone(),
-                    privileges: privs_to_revoke,
-                    with_grant_option: from_dp.with_grant_option,
-                    revoke: true,
-                });
+                ops.push(emit_dp(from_dp, privs_to_revoke, true));
             }
 
             if !privs_to_grant.is_empty() {
-                ops.push(MigrationOp::AlterDefaultPrivileges {
-                    target_role: to_dp.target_role.clone(),
-                    schema: to_dp.schema.clone(),
-                    object_type: to_dp.object_type.clone(),
-                    grantee: to_dp.grantee.clone(),
-                    privileges: privs_to_grant,
-                    with_grant_option: to_dp.with_grant_option,
-                    revoke: false,
-                });
+                ops.push(emit_dp(to_dp, privs_to_grant, false));
             }
 
             if from_dp.with_grant_option != to_dp.with_grant_option {
@@ -284,38 +272,14 @@ pub(super) fn diff_default_privileges(from: &Schema, to: &Schema) -> Vec<Migrati
                     .cloned()
                     .collect();
                 if !common_privs.is_empty() {
-                    ops.push(MigrationOp::AlterDefaultPrivileges {
-                        target_role: from_dp.target_role.clone(),
-                        schema: from_dp.schema.clone(),
-                        object_type: from_dp.object_type.clone(),
-                        grantee: from_dp.grantee.clone(),
-                        privileges: common_privs.clone(),
-                        with_grant_option: from_dp.with_grant_option,
-                        revoke: true,
-                    });
-                    ops.push(MigrationOp::AlterDefaultPrivileges {
-                        target_role: to_dp.target_role.clone(),
-                        schema: to_dp.schema.clone(),
-                        object_type: to_dp.object_type.clone(),
-                        grantee: to_dp.grantee.clone(),
-                        privileges: common_privs,
-                        with_grant_option: to_dp.with_grant_option,
-                        revoke: false,
-                    });
+                    ops.push(emit_dp(from_dp, common_privs.clone(), true));
+                    ops.push(emit_dp(to_dp, common_privs, false));
                 }
             }
         } else {
             let privs: Vec<Privilege> = to_dp.privileges.iter().cloned().collect();
             if !privs.is_empty() {
-                ops.push(MigrationOp::AlterDefaultPrivileges {
-                    target_role: to_dp.target_role.clone(),
-                    schema: to_dp.schema.clone(),
-                    object_type: to_dp.object_type.clone(),
-                    grantee: to_dp.grantee.clone(),
-                    privileges: privs,
-                    with_grant_option: to_dp.with_grant_option,
-                    revoke: false,
-                });
+                ops.push(emit_dp(to_dp, privs, false));
             }
         }
     }

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -369,14 +369,20 @@ impl DefaultPrivilegeObjectType {
 
     /// Parse from SQL keyword string
     pub fn from_sql_str(s: &str) -> Option<Self> {
-        match s.to_uppercase().as_str() {
-            "TABLES" => Some(DefaultPrivilegeObjectType::Tables),
-            "SEQUENCES" => Some(DefaultPrivilegeObjectType::Sequences),
-            "FUNCTIONS" => Some(DefaultPrivilegeObjectType::Functions),
-            "ROUTINES" => Some(DefaultPrivilegeObjectType::Routines),
-            "TYPES" => Some(DefaultPrivilegeObjectType::Types),
-            "SCHEMAS" => Some(DefaultPrivilegeObjectType::Schemas),
-            _ => None,
+        if s.eq_ignore_ascii_case("TABLES") {
+            Some(DefaultPrivilegeObjectType::Tables)
+        } else if s.eq_ignore_ascii_case("SEQUENCES") {
+            Some(DefaultPrivilegeObjectType::Sequences)
+        } else if s.eq_ignore_ascii_case("FUNCTIONS") {
+            Some(DefaultPrivilegeObjectType::Functions)
+        } else if s.eq_ignore_ascii_case("ROUTINES") {
+            Some(DefaultPrivilegeObjectType::Routines)
+        } else if s.eq_ignore_ascii_case("TYPES") {
+            Some(DefaultPrivilegeObjectType::Types)
+        } else if s.eq_ignore_ascii_case("SCHEMAS") {
+            Some(DefaultPrivilegeObjectType::Schemas)
+        } else {
+            None
         }
     }
 }
@@ -1107,8 +1113,12 @@ pub fn normalize_pg_type(type_name: &str) -> String {
         return format!("table({})", normalized_cols.join(", "));
     }
 
-    let lower = trimmed.to_lowercase();
-    match lower.as_str() {
+    let lower: std::borrow::Cow<str> = if trimmed.bytes().any(|b| b.is_ascii_uppercase()) {
+        std::borrow::Cow::Owned(trimmed.to_lowercase())
+    } else {
+        std::borrow::Cow::Borrowed(trimmed)
+    };
+    match lower.as_ref() {
         "int" | "int4" => "integer".to_string(),
         "int8" => "bigint".to_string(),
         "int2" => "smallint".to_string(),
@@ -1120,7 +1130,7 @@ pub fn normalize_pg_type(type_name: &str) -> String {
         "timestamptz" => "timestamp with time zone".to_string(),
         "time" => "time without time zone".to_string(),
         "timetz" => "time with time zone".to_string(),
-        _ => lower,
+        _ => lower.into_owned(),
     }
 }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -185,30 +185,26 @@ pub fn parse_sql_string(sql: &str) -> Result<Schema> {
                             }
                         }
                         AlterTableOperation::EnableTrigger { name: trig_name } => {
-                            let trigger_key =
-                                format!("{}.{}.{}", tbl_schema, tbl_name, trig_name.value);
-                            if let Some(trigger) = schema.triggers.get_mut(&trigger_key) {
+                            let key = make_trigger_key(&tbl_schema, &tbl_name, &trig_name.value);
+                            if let Some(trigger) = schema.triggers.get_mut(&key) {
                                 trigger.enabled = TriggerEnabled::Origin;
                             }
                         }
                         AlterTableOperation::DisableTrigger { name: trig_name } => {
-                            let trigger_key =
-                                format!("{}.{}.{}", tbl_schema, tbl_name, trig_name.value);
-                            if let Some(trigger) = schema.triggers.get_mut(&trigger_key) {
+                            let key = make_trigger_key(&tbl_schema, &tbl_name, &trig_name.value);
+                            if let Some(trigger) = schema.triggers.get_mut(&key) {
                                 trigger.enabled = TriggerEnabled::Disabled;
                             }
                         }
                         AlterTableOperation::EnableReplicaTrigger { name: trig_name } => {
-                            let trigger_key =
-                                format!("{}.{}.{}", tbl_schema, tbl_name, trig_name.value);
-                            if let Some(trigger) = schema.triggers.get_mut(&trigger_key) {
+                            let key = make_trigger_key(&tbl_schema, &tbl_name, &trig_name.value);
+                            if let Some(trigger) = schema.triggers.get_mut(&key) {
                                 trigger.enabled = TriggerEnabled::Replica;
                             }
                         }
                         AlterTableOperation::EnableAlwaysTrigger { name: trig_name } => {
-                            let trigger_key =
-                                format!("{}.{}.{}", tbl_schema, tbl_name, trig_name.value);
-                            if let Some(trigger) = schema.triggers.get_mut(&trigger_key) {
+                            let key = make_trigger_key(&tbl_schema, &tbl_name, &trig_name.value);
+                            if let Some(trigger) = schema.triggers.get_mut(&key) {
                                 trigger.enabled = TriggerEnabled::Always;
                             }
                         }
@@ -761,4 +757,8 @@ pub fn parse_sql_string(sql: &str) -> Result<Schema> {
     schema.pending_policies = schema.finalize_partial();
 
     Ok(schema)
+}
+
+fn make_trigger_key(schema: &str, table: &str, trigger_name: &str) -> String {
+    format!("{}.{}.{}", schema, table, trigger_name)
 }

--- a/src/pg/sqlgen.rs
+++ b/src/pg/sqlgen.rs
@@ -255,7 +255,7 @@ fn generate_op_sql(op: &MigrationOp) -> Vec<String> {
         // Note: We don't generate ALTER FUNCTION ... OWNER TO for new functions.
         // PostgreSQL automatically sets the owner to the creating user.
         // Changing ownership requires schema ownership which the user may not have.
-        MigrationOp::CreateFunction(func) => vec![generate_create_function(func)],
+        MigrationOp::CreateFunction(func) => vec![generate_function_ddl(func, false)],
 
         MigrationOp::DropFunction { name, args } => {
             let (schema, func_name) = parse_qualified_name(name);
@@ -267,10 +267,10 @@ fn generate_op_sql(op: &MigrationOp) -> Vec<String> {
         }
 
         MigrationOp::AlterFunction { new_function, .. } => {
-            vec![generate_create_or_replace_function(new_function)]
+            vec![generate_function_ddl(new_function, true)]
         }
 
-        MigrationOp::CreateView(view) => generate_create_view(view),
+        MigrationOp::CreateView(view) => generate_view_ddl(view, false),
 
         MigrationOp::DropView { name, materialized } => {
             let (schema, view_name) = parse_qualified_name(name);
@@ -286,7 +286,7 @@ fn generate_op_sql(op: &MigrationOp) -> Vec<String> {
             )]
         }
 
-        MigrationOp::AlterView { new_view, .. } => generate_create_or_replace_view(new_view),
+        MigrationOp::AlterView { new_view, .. } => generate_view_ddl(new_view, true),
 
         MigrationOp::CreateTrigger(trigger) => {
             let mut statements = vec![generate_create_trigger(trigger)];
@@ -953,14 +953,6 @@ fn format_policy_command(command: &PolicyCommand) -> &'static str {
     }
 }
 
-fn generate_create_function(func: &Function) -> String {
-    generate_function_ddl(func, false)
-}
-
-fn generate_create_or_replace_function(func: &Function) -> String {
-    generate_function_ddl(func, true)
-}
-
 fn generate_function_ddl(func: &Function, replace: bool) -> String {
     let create_stmt = if replace {
         "CREATE OR REPLACE FUNCTION"
@@ -1012,14 +1004,6 @@ fn generate_function_ddl(func: &Function, replace: bool) -> String {
     parts.push(format!("AS $${}$$;", func.body));
 
     parts.join(" ")
-}
-
-fn generate_create_view(view: &View) -> Vec<String> {
-    generate_view_ddl(view, false)
-}
-
-fn generate_create_or_replace_view(view: &View) -> Vec<String> {
-    generate_view_ddl(view, true)
 }
 
 fn generate_view_ddl(view: &View, replace: bool) -> Vec<String> {
@@ -2628,7 +2612,7 @@ mod tests {
             grants: Vec::new(),
         };
 
-        let ddl = generate_create_function(&func);
+        let ddl = generate_function_ddl(&func, false);
 
         assert!(
             ddl.contains("\"p_role_name\" text"),
@@ -2705,7 +2689,7 @@ mod tests {
             grants: Vec::new(),
         };
 
-        let ddl = generate_create_function(&func);
+        let ddl = generate_function_ddl(&func, false);
 
         assert!(
             ddl.contains("SET search_path = public"),
@@ -2731,7 +2715,7 @@ mod tests {
             grants: Vec::new(),
         };
 
-        let ddl = generate_create_function(&func);
+        let ddl = generate_function_ddl(&func, false);
 
         assert!(
             ddl.contains("SET search_path = ''"),
@@ -2760,7 +2744,7 @@ mod tests {
             grants: Vec::new(),
         };
 
-        let ddl = generate_create_function(&func);
+        let ddl = generate_function_ddl(&func, false);
 
         assert!(
             ddl.contains("SET search_path = public SET work_mem = '64MB'"),

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -620,15 +620,12 @@ fn strip_text_cast_from_string_literals(query: &str) -> String {
 }
 
 fn collapse_double_parens(query: &str) -> String {
-    let mut result = query.to_string();
-    loop {
-        let new_result = RE_DOUBLE_PAREN.replace_all(&result, "($1)").to_string();
-        if new_result == result {
-            break;
+    apply_until_stable(query.to_string(), |input| {
+        match RE_DOUBLE_PAREN.replace_all(input, "($1)") {
+            std::borrow::Cow::Borrowed(_) => None,
+            std::borrow::Cow::Owned(s) => Some(s),
         }
-        result = new_result;
-    }
-    result
+    })
 }
 
 fn strip_on_clause_parens(query: &str) -> String {


### PR DESCRIPTION
## Summary

- inline dead single-call wrapper functions in sqlgen (generate_create_function, etc.)
- extract emit_dp closure to deduplicate default privilege op construction
- use apply_until_stable with Cow for collapse_double_parens (zero-cost no-op path)
- extract make_trigger_key helper to deduplicate trigger format strings
- use eq_ignore_ascii_case to avoid allocation in DefaultPrivilegeObjectType::from_sql_str
- use Cow in normalize_pg_type to skip allocation when input is already lowercase

## Test plan

- [x] `cargo build` passes
- [x] all 915 unit tests pass
- [x] `cargo fmt --check` passes
- [x] `cargo clippy` passes