### PR TITLE
test: regression tests for object-level diffs (closes #86)

### DIFF
--- a/tests/multi_file.rs
+++ b/tests/multi_file.rs
@@ -71,3 +71,149 @@ async fn multi_file_schema_loading() {
         "FK should reference users"
     );
 }
+
+/// Parse SQL, diff against an empty schema, and apply the resulting migration.
+async fn apply_sql(connection: &PgConnection, sql: &str) {
+    let schema = parse_sql_string(sql).unwrap();
+    let operations = compute_diff(&Schema::new(), &schema);
+    let statements = generate_sql(&plan_migration(operations));
+    for statement in &statements {
+        sqlx::query(statement)
+            .execute(connection.pool())
+            .await
+            .unwrap();
+    }
+}
+
+/// Diff the live database against a new SQL string and return the operations.
+async fn diff_against_database(connection: &PgConnection, sql: &str) -> Vec<MigrationOp> {
+    let database_schema = introspect_schema(connection, &["public".to_string()], false)
+        .await
+        .unwrap();
+    let target = parse_sql_string(sql).unwrap();
+    compute_diff(&database_schema, &target)
+}
+
+/// Reproduction for GitHub issue #86:
+/// "File-level granularity causes unnecessary object recreation"
+///
+/// Scenario: multiple functions in a single SQL string. Change only one.
+/// Verify only the changed function produces a diff.
+#[tokio::test]
+async fn single_file_change_one_function_only_diffs_that_function() {
+    let (_container, url) = setup_postgres().await;
+    let connection = PgConnection::new(&url).await.unwrap();
+
+    apply_sql(
+        &connection,
+        r#"
+        CREATE FUNCTION func_a(x integer) RETURNS integer
+        LANGUAGE sql IMMUTABLE AS $$ SELECT x + 1 $$;
+
+        CREATE FUNCTION func_b(x integer) RETURNS integer
+        LANGUAGE sql IMMUTABLE AS $$ SELECT x + 2 $$;
+
+        CREATE FUNCTION func_c(x integer) RETURNS integer
+        LANGUAGE sql IMMUTABLE AS $$ SELECT x + 3 $$;
+    "#,
+    )
+    .await;
+
+    let diff_ops = diff_against_database(
+        &connection,
+        r#"
+        CREATE FUNCTION func_a(x integer) RETURNS integer
+        LANGUAGE sql IMMUTABLE AS $$ SELECT x + 1 $$;
+
+        CREATE FUNCTION func_b(x integer) RETURNS integer
+        LANGUAGE sql IMMUTABLE AS $$ SELECT x + 20 $$;
+
+        CREATE FUNCTION func_c(x integer) RETURNS integer
+        LANGUAGE sql IMMUTABLE AS $$ SELECT x + 3 $$;
+    "#,
+    )
+    .await;
+
+    assert_eq!(
+        diff_ops.len(),
+        1,
+        "Only func_b changed — expected exactly 1 operation total, got: {diff_ops:?}",
+    );
+
+    match &diff_ops[0] {
+        MigrationOp::AlterFunction { name, .. } => {
+            assert!(
+                name.ends_with("func_b"),
+                "Only func_b should be altered, got: {name}"
+            );
+        }
+        other => panic!("Expected AlterFunction for func_b, got: {other:?}"),
+    }
+}
+
+/// Same reproduction for tables: multiple tables in one file, change one column.
+#[tokio::test]
+async fn single_file_change_one_table_only_diffs_that_table() {
+    let (_container, url) = setup_postgres().await;
+    let connection = PgConnection::new(&url).await.unwrap();
+
+    apply_sql(
+        &connection,
+        r#"
+        CREATE TABLE table_a (
+            id serial PRIMARY KEY,
+            name text NOT NULL
+        );
+
+        CREATE TABLE table_b (
+            id serial PRIMARY KEY,
+            value integer NOT NULL
+        );
+
+        CREATE TABLE table_c (
+            id serial PRIMARY KEY,
+            active boolean NOT NULL DEFAULT true
+        );
+    "#,
+    )
+    .await;
+
+    let diff_ops = diff_against_database(
+        &connection,
+        r#"
+        CREATE TABLE table_a (
+            id serial PRIMARY KEY,
+            name text NOT NULL
+        );
+
+        CREATE TABLE table_b (
+            id serial PRIMARY KEY,
+            value integer NOT NULL,
+            description text
+        );
+
+        CREATE TABLE table_c (
+            id serial PRIMARY KEY,
+            active boolean NOT NULL DEFAULT true
+        );
+    "#,
+    )
+    .await;
+
+    assert_eq!(
+        diff_ops.len(),
+        1,
+        "Only table_b changed — expected exactly 1 operation total, got: {diff_ops:?}",
+    );
+
+    match &diff_ops[0] {
+        MigrationOp::AddColumn { table, column, .. } => {
+            assert_eq!(
+                table.name, "table_b",
+                "Only table_b should have a column added"
+            );
+            assert_eq!(column.name, "description");
+        }
+        other => panic!("Expected AddColumn on table_b, got: {other:?}"),
+    }
+}


### PR DESCRIPTION
## Summary

- Add two integration tests proving pgmold diffs at the object level, not file level
- Changing one function/table in a multi-object SQL string produces only a diff for the changed object
- Extracted `apply_sql` and `diff_against_database` helpers to reduce duplication in multi_file tests

Closes #86 — the reported behavior is not reproducible. Root cause of observed recreation was likely normalization mismatches (convergence failures), not file-level tracking.