### PR TITLE
refactor: address code smells across codebase (round 8)

### DIFF
--- a/src/diff/grants.rs
+++ b/src/diff/grants.rs
@@ -4,6 +4,14 @@ use crate::model::{DefaultPrivilege, Grant, Privilege, Schema};
 
 use super::{GrantObjectKind, MigrationOp};
 
+fn nonempty_privileges(set: &BTreeSet<Privilege>) -> Option<Vec<Privilege>> {
+    if set.is_empty() {
+        None
+    } else {
+        Some(set.iter().cloned().collect())
+    }
+}
+
 struct GrantOptionChange {
     revoke_grant_option: Option<Vec<Privilege>>,
     regrant_with_option: Option<Vec<Privilege>>,
@@ -66,6 +74,29 @@ pub(super) fn diff_grants_for_object(
         .map(|g| (g.grantee.as_str(), g))
         .collect();
 
+    let revoke = |grantee: &str, privileges: Vec<Privilege>, revoke_grant_option: bool| {
+        MigrationOp::RevokePrivileges {
+            object_kind,
+            schema: schema.to_string(),
+            name: name.to_string(),
+            args: args.clone(),
+            grantee: grantee.to_string(),
+            privileges,
+            revoke_grant_option,
+        }
+    };
+    let grant = |grantee: &str, privileges: Vec<Privilege>, with_grant_option: bool| {
+        MigrationOp::GrantPrivileges {
+            object_kind,
+            schema: schema.to_string(),
+            name: name.to_string(),
+            args: args.clone(),
+            grantee: grantee.to_string(),
+            privileges,
+            with_grant_option,
+        }
+    };
+
     for (grantee, from_grant) in &from_by_grantee {
         match to_by_grantee.get(grantee) {
             Some(to_grant) => {
@@ -75,15 +106,7 @@ pub(super) fn diff_grants_for_object(
                     .cloned()
                     .collect();
                 if !privs_to_revoke.is_empty() {
-                    ops.push(MigrationOp::RevokePrivileges {
-                        object_kind,
-                        schema: schema.to_string(),
-                        name: name.to_string(),
-                        args: args.clone(),
-                        grantee: grantee.to_string(),
-                        privileges: privs_to_revoke,
-                        revoke_grant_option: false,
-                    });
+                    ops.push(revoke(grantee, privs_to_revoke, false));
                 }
 
                 let privs_to_grant: Vec<Privilege> = to_grant
@@ -92,15 +115,7 @@ pub(super) fn diff_grants_for_object(
                     .cloned()
                     .collect();
                 if !privs_to_grant.is_empty() {
-                    ops.push(MigrationOp::GrantPrivileges {
-                        object_kind,
-                        schema: schema.to_string(),
-                        name: name.to_string(),
-                        args: args.clone(),
-                        grantee: grantee.to_string(),
-                        privileges: privs_to_grant,
-                        with_grant_option: to_grant.with_grant_option,
-                    });
+                    ops.push(grant(grantee, privs_to_grant, to_grant.with_grant_option));
                 }
 
                 let grant_option_change = compute_grant_option_changes(
@@ -110,40 +125,15 @@ pub(super) fn diff_grants_for_object(
                     to_grant.with_grant_option,
                 );
                 if let Some(privs) = grant_option_change.revoke_grant_option {
-                    ops.push(MigrationOp::RevokePrivileges {
-                        object_kind,
-                        schema: schema.to_string(),
-                        name: name.to_string(),
-                        args: args.clone(),
-                        grantee: grantee.to_string(),
-                        privileges: privs,
-                        revoke_grant_option: true,
-                    });
+                    ops.push(revoke(grantee, privs, true));
                 }
                 if let Some(privs) = grant_option_change.regrant_with_option {
-                    ops.push(MigrationOp::GrantPrivileges {
-                        object_kind,
-                        schema: schema.to_string(),
-                        name: name.to_string(),
-                        args: args.clone(),
-                        grantee: grantee.to_string(),
-                        privileges: privs,
-                        with_grant_option: true,
-                    });
+                    ops.push(grant(grantee, privs, true));
                 }
             }
             None => {
-                let privs: Vec<Privilege> = from_grant.privileges.iter().cloned().collect();
-                if !privs.is_empty() {
-                    ops.push(MigrationOp::RevokePrivileges {
-                        object_kind,
-                        schema: schema.to_string(),
-                        name: name.to_string(),
-                        args: args.clone(),
-                        grantee: grantee.to_string(),
-                        privileges: privs,
-                        revoke_grant_option: false,
-                    });
+                if let Some(privs) = nonempty_privileges(&from_grant.privileges) {
+                    ops.push(revoke(grantee, privs, false));
                 }
             }
         }
@@ -151,17 +141,8 @@ pub(super) fn diff_grants_for_object(
 
     for (grantee, to_grant) in &to_by_grantee {
         if !from_by_grantee.contains_key(grantee) {
-            let privs: Vec<Privilege> = to_grant.privileges.iter().cloned().collect();
-            if !privs.is_empty() {
-                ops.push(MigrationOp::GrantPrivileges {
-                    object_kind,
-                    schema: schema.to_string(),
-                    name: name.to_string(),
-                    args: args.clone(),
-                    grantee: grantee.to_string(),
-                    privileges: privs,
-                    with_grant_option: to_grant.with_grant_option,
-                });
+            if let Some(privs) = nonempty_privileges(&to_grant.privileges) {
+                ops.push(grant(grantee, privs, to_grant.with_grant_option));
             }
         }
     }
@@ -181,10 +162,7 @@ pub(super) fn create_grants_for_new_object(
         .iter()
         .filter(|grant| !excluded_grant_roles.contains(&grant.grantee.to_lowercase()))
         .filter_map(|grant| {
-            let privs: Vec<Privilege> = grant.privileges.iter().cloned().collect();
-            if privs.is_empty() {
-                return None;
-            }
+            let privs = nonempty_privileges(&grant.privileges)?;
             Some(MigrationOp::GrantPrivileges {
                 object_kind,
                 schema: schema.to_string(),
@@ -237,8 +215,7 @@ pub(super) fn diff_default_privileges(from: &Schema, to: &Schema) -> Vec<Migrati
 
     for (key, from_dp) in &from_map {
         if !to_map.contains_key(key) {
-            let privs: Vec<Privilege> = from_dp.privileges.iter().cloned().collect();
-            if !privs.is_empty() {
+            if let Some(privs) = nonempty_privileges(&from_dp.privileges) {
                 ops.push(emit_dp(from_dp, privs, true));
             }
         }
@@ -276,11 +253,8 @@ pub(super) fn diff_default_privileges(from: &Schema, to: &Schema) -> Vec<Migrati
                     ops.push(emit_dp(to_dp, common_privs, false));
                 }
             }
-        } else {
-            let privs: Vec<Privilege> = to_dp.privileges.iter().cloned().collect();
-            if !privs.is_empty() {
-                ops.push(emit_dp(to_dp, privs, false));
-            }
+        } else if let Some(privs) = nonempty_privileges(&to_dp.privileges) {
+            ops.push(emit_dp(to_dp, privs, false));
         }
     }
 

--- a/src/diff/table_elements.rs
+++ b/src/diff/table_elements.rs
@@ -92,7 +92,7 @@ pub(super) fn indexes_semantically_equal(from: &Index, to: &Index) -> bool {
 pub(super) fn diff_indexes(from_table: &Table, to_table: &Table) -> Vec<MigrationOp> {
     let mut ops = Vec::new();
     let qualified_table_name = QualifiedName::new(&to_table.schema, &to_table.name);
-    let from_qualified_table_name = QualifiedName::new(&from_table.schema, &from_table.name);
+    let from_qualified_table_name = || QualifiedName::new(&from_table.schema, &from_table.name);
 
     for index in &to_table.indexes {
         let existing = from_table.indexes.iter().find(|i| i.name == index.name);
@@ -104,7 +104,7 @@ pub(super) fn diff_indexes(from_table: &Table, to_table: &Table) -> Vec<Migratio
                 });
             }
             Some(from_index) if !indexes_semantically_equal(from_index, index) => {
-                ops.push(drop_index_op(from_qualified_table_name.clone(), from_index));
+                ops.push(drop_index_op(from_qualified_table_name(), from_index));
                 ops.push(MigrationOp::AddIndex {
                     table: qualified_table_name.clone(),
                     index: index.clone(),
@@ -116,7 +116,7 @@ pub(super) fn diff_indexes(from_table: &Table, to_table: &Table) -> Vec<Migratio
 
     for index in &from_table.indexes {
         if !to_table.indexes.iter().any(|i| i.name == index.name) {
-            ops.push(drop_index_op(from_qualified_table_name.clone(), index));
+            ops.push(drop_index_op(from_qualified_table_name(), index));
         }
     }
 

--- a/src/pg/introspect.rs
+++ b/src/pg/introspect.rs
@@ -600,10 +600,10 @@ fn parse_partition_bound(expr: &str) -> Result<PartitionBound> {
 
     if expr_upper.contains("FROM") && expr_upper.contains("TO") {
         if let Some(from_start) = expr_upper.find("FROM ") {
-            let after_from_orig = &expr[from_start + 5..];
-            if let Some(to_pos) = after_from_orig.to_uppercase().find(" TO ") {
-                let from_part_raw = &after_from_orig[..to_pos];
-                let to_part_raw = &after_from_orig[to_pos + 4..];
+            let after_from_upper = &expr_upper[from_start + 5..];
+            if let Some(to_pos) = after_from_upper.find(" TO ") {
+                let from_part_raw = &expr[from_start + 5..from_start + 5 + to_pos];
+                let to_part_raw = &expr[from_start + 5 + to_pos + 4..];
                 let from_values = extract_paren_values(from_part_raw.trim());
                 let to_values = extract_paren_values(to_part_raw.trim());
                 return Ok(PartitionBound::Range {

--- a/src/pg/sqlgen.rs
+++ b/src/pg/sqlgen.rs
@@ -1281,9 +1281,7 @@ fn generate_alter_domain(name: &str, changes: &DomainChanges) -> Vec<String> {
     statements
 }
 
-fn generate_create_trigger(trigger: &Trigger) -> String {
-    let mut sql = format!("CREATE TRIGGER {}", quote_ident(&trigger.name));
-
+fn trigger_timing_and_events(trigger: &Trigger) -> String {
     let timing = match trigger.timing {
         TriggerTiming::Before => "BEFORE",
         TriggerTiming::After => "AFTER",
@@ -1315,9 +1313,47 @@ fn generate_create_trigger(trigger: &Trigger) -> String {
         })
         .collect();
 
-    sql.push_str(&format!(" {} {}", timing, events.join(" OR ")));
+    format!("{} {}", timing, events.join(" OR "))
+}
+
+fn trigger_referencing_clause(trigger: &Trigger) -> Option<String> {
+    let mut parts = Vec::new();
+    if let Some(ref name) = trigger.old_table_name {
+        parts.push(format!("OLD TABLE AS {}", quote_ident(name)));
+    }
+    if let Some(ref name) = trigger.new_table_name {
+        parts.push(format!("NEW TABLE AS {}", quote_ident(name)));
+    }
+    if parts.is_empty() {
+        None
+    } else {
+        Some(format!("REFERENCING {}", parts.join(" ")))
+    }
+}
+
+fn trigger_execute_clause(trigger: &Trigger) -> String {
+    let mut sql = String::new();
+    if let Some(ref when_clause) = trigger.when_clause {
+        sql.push_str(&format!(" WHEN ({when_clause})"));
+    }
     sql.push_str(&format!(
-        " ON {}",
+        " EXECUTE FUNCTION {}",
+        quote_qualified(&trigger.function_schema, &trigger.function_name)
+    ));
+    if trigger.function_args.is_empty() {
+        sql.push_str("();");
+    } else {
+        sql.push_str(&format!("({});", trigger.function_args.join(", ")));
+    }
+    sql
+}
+
+fn generate_create_trigger(trigger: &Trigger) -> String {
+    let mut sql = format!("CREATE TRIGGER {}", quote_ident(&trigger.name));
+
+    sql.push_str(&format!(
+        " {} ON {}",
+        trigger_timing_and_events(trigger),
         quote_qualified(&trigger.target_schema, &trigger.target_name)
     ));
 
@@ -1327,32 +1363,11 @@ fn generate_create_trigger(trigger: &Trigger) -> String {
         sql.push_str(" FOR EACH STATEMENT");
     }
 
-    // Generate REFERENCING clause for transition tables
-    let mut referencing_parts = Vec::new();
-    if let Some(ref name) = trigger.old_table_name {
-        referencing_parts.push(format!("OLD TABLE AS {}", quote_ident(name)));
-    }
-    if let Some(ref name) = trigger.new_table_name {
-        referencing_parts.push(format!("NEW TABLE AS {}", quote_ident(name)));
-    }
-    if !referencing_parts.is_empty() {
-        sql.push_str(&format!(" REFERENCING {}", referencing_parts.join(" ")));
+    if let Some(referencing) = trigger_referencing_clause(trigger) {
+        sql.push_str(&format!(" {referencing}"));
     }
 
-    if let Some(ref when_clause) = trigger.when_clause {
-        sql.push_str(&format!(" WHEN ({when_clause})"));
-    }
-
-    sql.push_str(&format!(
-        " EXECUTE FUNCTION {}",
-        quote_qualified(&trigger.function_schema, &trigger.function_name)
-    ));
-
-    if trigger.function_args.is_empty() {
-        sql.push_str("();");
-    } else {
-        sql.push_str(&format!("({});", trigger.function_args.join(", ")));
-    }
+    sql.push_str(&trigger_execute_clause(trigger));
 
     sql
 }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -158,7 +158,7 @@ fn simple_percent_decode(input: &str) -> String {
         raw_bytes.push(bytes[i]);
         i += 1;
     }
-    String::from_utf8(raw_bytes).unwrap_or_else(|_| input.to_string())
+    String::from_utf8(raw_bytes).expect("percent-decoded bytes are valid UTF-8")
 }
 
 /// Strips dollar-quote delimiters from a function body.


### PR DESCRIPTION
## Summary

- extract `nonempty_privileges` helper and `grant`/`revoke` closures in grants diff
- lazy `QualifiedName` allocation in index diffing
- fail-fast in `simple_percent_decode` instead of silent fallback
- remove redundant `to_uppercase` in partition bound parsing
- split `generate_create_trigger` into focused helper functions

## Test plan

- [x] `cargo build` passes
- [x] all 915 unit tests pass
- [x] `cargo fmt --check` passes
- [x] `cargo clippy` passes