### PR TITLE
refactor(diff): precompute type_changed_columns once instead of scanning ops twice

### DIFF
--- a/src/diff/dependencies.rs
+++ b/src/diff/dependencies.rs
@@ -14,7 +14,7 @@ where
 }
 
 /// Extract (table, column) pairs that have type changes from migration ops.
-fn type_changed_columns(ops: &[MigrationOp]) -> HashSet<(String, String)> {
+pub(super) fn type_changed_columns(ops: &[MigrationOp]) -> HashSet<(String, String)> {
     ops.iter()
         .filter_map(|op| {
             if let MigrationOp::AlterColumn {
@@ -32,25 +32,15 @@ fn type_changed_columns(ops: &[MigrationOp]) -> HashSet<(String, String)> {
         .collect()
 }
 
-/// Extract tables that have columns with type changes from migration ops.
-/// Returns qualified name strings (schema.name) for use as map keys.
-pub(super) fn tables_with_type_changes(ops: &[MigrationOp]) -> HashSet<String> {
-    type_changed_columns(ops)
-        .into_iter()
-        .map(|(table, _)| table)
-        .collect()
-}
-
 /// Generate FK drop/add ops for columns with type changes.
 /// PostgreSQL requires FKs to be dropped before altering the type of columns they reference.
 pub(super) fn generate_fk_ops_for_type_changes(
     ops: &[MigrationOp],
     from: &Schema,
     to: &Schema,
+    type_change_columns: &HashSet<(String, String)>,
 ) -> Vec<MigrationOp> {
     let mut additional_ops = Vec::new();
-
-    let type_change_columns = type_changed_columns(ops);
 
     if type_change_columns.is_empty() {
         return additional_ops;

--- a/src/diff/mod.rs
+++ b/src/diff/mod.rs
@@ -18,7 +18,7 @@ pub use types::{
 use dependencies::{
     generate_fk_ops_for_type_changes, generate_policy_ops_for_function_changes,
     generate_policy_ops_for_type_changes, generate_trigger_ops_for_type_changes,
-    generate_view_ops_for_type_changes, tables_with_type_changes,
+    generate_view_ops_for_type_changes, type_changed_columns,
 };
 use grants::diff_default_privileges;
 use objects::{
@@ -80,8 +80,17 @@ pub fn compute_diff_with_flags(
         }
     }
 
-    let affected_tables = tables_with_type_changes(&ops);
-    ops.extend(generate_fk_ops_for_type_changes(&ops, from, to));
+    let type_change_columns = type_changed_columns(&ops);
+    let affected_tables: std::collections::HashSet<String> = type_change_columns
+        .iter()
+        .map(|(table, _)| table.clone())
+        .collect();
+    ops.extend(generate_fk_ops_for_type_changes(
+        &ops,
+        from,
+        to,
+        &type_change_columns,
+    ));
     ops.extend(generate_policy_ops_for_type_changes(
         &ops,
         from,


### PR DESCRIPTION
## Summary

- Make `type_changed_columns` public and compute it once in `compute_diff`
- Derive `affected_tables` from the precomputed set
- Pass precomputed set to `generate_fk_ops_for_type_changes` instead of recomputing
- Remove `tables_with_type_changes` wrapper function

Closes pgmold-201