### PR TITLE
refactor(lint): change rule field from String to &'static str

### DIFF
--- a/src/check.rs
+++ b/src/check.rs
@@ -10,7 +10,7 @@ pub enum IssueSeverity {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SchemaIssue {
-    pub rule: String,
+    pub rule: &'static str,
     pub severity: IssueSeverity,
     pub message: String,
 }
@@ -48,7 +48,7 @@ fn check_foreign_key_references(schema: &Schema, issues: &mut Vec<SchemaIssue>) 
             let referenced_key = format!("{}.{}", fk.referenced_schema, fk.referenced_table);
             if !table_keys.contains(&referenced_key) {
                 issues.push(SchemaIssue {
-                    rule: "fk_references_missing_table".to_string(),
+                    rule: "fk_references_missing_table",
                     severity: IssueSeverity::Error,
                     message: format!(
                         "Foreign key \"{}\" on \"{}\" references non-existent table \"{}\"",
@@ -62,7 +62,7 @@ fn check_foreign_key_references(schema: &Schema, issues: &mut Vec<SchemaIssue>) 
                 for col in &fk.referenced_columns {
                     if !referenced_table.columns.contains_key(col) {
                         issues.push(SchemaIssue {
-                            rule: "fk_references_missing_column".to_string(),
+                            rule: "fk_references_missing_column",
                             severity: IssueSeverity::Error,
                             message: format!(
                                 "Foreign key \"{}\" on \"{}\" references non-existent column \"{}\".\"{}\"",
@@ -87,7 +87,7 @@ fn check_enum_references(schema: &Schema, issues: &mut Vec<SchemaIssue>) {
                 };
                 if !schema.enums.contains_key(&qualified) {
                     issues.push(SchemaIssue {
-                        rule: "column_references_missing_enum".to_string(),
+                        rule: "column_references_missing_enum",
                         severity: IssueSeverity::Error,
                         message: format!(
                             "Column \"{}\".\"{}\" references non-existent enum \"{}\"",
@@ -107,7 +107,7 @@ fn check_trigger_references(schema: &Schema, issues: &mut Vec<SchemaIssue>) {
         let target_key = format!("{}.{}", trigger.target_schema, trigger.target_name);
         if !table_keys.contains(&target_key) {
             issues.push(SchemaIssue {
-                rule: "trigger_references_missing_table".to_string(),
+                rule: "trigger_references_missing_table",
                 severity: IssueSeverity::Error,
                 message: format!(
                     "Trigger \"{}\" targets non-existent table \"{}\"",
@@ -123,7 +123,7 @@ fn check_trigger_references(schema: &Schema, issues: &mut Vec<SchemaIssue>) {
             .any(|k| k.starts_with(&function_prefix));
         if !function_exists {
             issues.push(SchemaIssue {
-                rule: "trigger_references_missing_function".to_string(),
+                rule: "trigger_references_missing_function",
                 severity: IssueSeverity::Error,
                 message: format!(
                     "Trigger \"{}\" references non-existent function \"{}\".\"{}\"",
@@ -139,7 +139,7 @@ fn check_partition_references(schema: &Schema, issues: &mut Vec<SchemaIssue>) {
         let parent_key = format!("{}.{}", partition.parent_schema, partition.parent_name);
         if !schema.tables.contains_key(&parent_key) {
             issues.push(SchemaIssue {
-                rule: "partition_references_missing_parent".to_string(),
+                rule: "partition_references_missing_parent",
                 severity: IssueSeverity::Error,
                 message: format!(
                     "Partition \"{}\" references non-existent parent table \"{}\"",
@@ -157,7 +157,7 @@ fn check_sequence_owner_references(schema: &Schema, issues: &mut Vec<SchemaIssue
             if let Some(table) = schema.tables.get(&table_key) {
                 if !table.columns.contains_key(&owner.column_name) {
                     issues.push(SchemaIssue {
-                        rule: "sequence_owner_missing_column".to_string(),
+                        rule: "sequence_owner_missing_column",
                         severity: IssueSeverity::Error,
                         message: format!(
                             "Sequence \"{}\" owned by non-existent column \"{}\".\"{}\"",
@@ -167,7 +167,7 @@ fn check_sequence_owner_references(schema: &Schema, issues: &mut Vec<SchemaIssue
                 }
             } else if !schema.partitions.contains_key(&table_key) {
                 issues.push(SchemaIssue {
-                    rule: "sequence_owner_missing_table".to_string(),
+                    rule: "sequence_owner_missing_table",
                     severity: IssueSeverity::Error,
                     message: format!(
                         "Sequence \"{}\" owned by non-existent table \"{}\"",
@@ -235,7 +235,7 @@ fn check_circular_foreign_keys(schema: &Schema, issues: &mut Vec<SchemaIssue>) {
             .map(|(&n, _)| n)
             .collect();
         issues.push(SchemaIssue {
-            rule: "circular_foreign_keys".to_string(),
+            rule: "circular_foreign_keys",
             severity: IssueSeverity::Warning,
             message: format!(
                 "Circular foreign key dependency involving: {}",

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -992,7 +992,7 @@ pub async fn run() -> Result<()> {
                                 LintSeverity::Error => "error".to_string(),
                                 LintSeverity::Warning => "warning".to_string(),
                             },
-                            rule: r.rule.clone(),
+                            rule: r.rule.to_string(),
                             message: r.message.clone(),
                         })
                         .collect(),
@@ -1252,7 +1252,7 @@ pub async fn run() -> Result<()> {
                                 IssueSeverity::Error => "error".to_string(),
                                 IssueSeverity::Warning => "warning".to_string(),
                             },
-                            rule: i.rule.clone(),
+                            rule: i.rule.to_string(),
                             message: i.message.clone(),
                         })
                         .collect(),

--- a/src/lint/mod.rs
+++ b/src/lint/mod.rs
@@ -28,7 +28,7 @@ pub enum LintSeverity {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LintResult {
-    pub rule: String,
+    pub rule: &'static str,
     pub severity: LintSeverity,
     pub message: String,
 }
@@ -50,7 +50,7 @@ fn lint_op(op: &MigrationOp, options: &LintOptions) -> Vec<LintResult> {
         MigrationOp::DropColumn { table, column } => {
             if !options.allow_destructive {
                 results.push(LintResult {
-                    rule: "deny_drop_column".to_string(),
+                    rule: "deny_drop_column",
                     severity: LintSeverity::Error,
                     message: format!(
                         "Dropping column {table}.{column} requires --allow-destructive flag"
@@ -62,7 +62,7 @@ fn lint_op(op: &MigrationOp, options: &LintOptions) -> Vec<LintResult> {
         MigrationOp::DropTable(name) => {
             if options.is_production {
                 results.push(LintResult {
-                    rule: "deny_drop_table_in_prod".to_string(),
+                    rule: "deny_drop_table_in_prod",
                     severity: LintSeverity::Error,
                     message: format!(
                         "Dropping table {name} is not allowed in production (PGMOLD_PROD=1)"
@@ -70,7 +70,7 @@ fn lint_op(op: &MigrationOp, options: &LintOptions) -> Vec<LintResult> {
                 });
             } else if !options.allow_destructive {
                 results.push(LintResult {
-                    rule: "deny_drop_table".to_string(),
+                    rule: "deny_drop_table",
                     severity: LintSeverity::Error,
                     message: format!("Dropping table {name} requires --allow-destructive flag"),
                 });
@@ -85,7 +85,7 @@ fn lint_op(op: &MigrationOp, options: &LintOptions) -> Vec<LintResult> {
             if let Some(ref new_type) = changes.data_type {
                 if is_type_narrowing(new_type) {
                     results.push(LintResult {
-                        rule: "warn_type_narrowing".to_string(),
+                        rule: "warn_type_narrowing",
                         severity: LintSeverity::Warning,
                         message: format!(
                             "Altering column {table}.{column} to a smaller type may cause data loss"
@@ -96,7 +96,7 @@ fn lint_op(op: &MigrationOp, options: &LintOptions) -> Vec<LintResult> {
 
             if changes.nullable == Some(false) {
                 results.push(LintResult {
-                    rule: "warn_set_not_null".to_string(),
+                    rule: "warn_set_not_null",
                     severity: LintSeverity::Warning,
                     message: format!(
                         "Setting column {table}.{column} to NOT NULL may fail if existing rows have NULL values"
@@ -113,7 +113,7 @@ fn lint_op(op: &MigrationOp, options: &LintOptions) -> Vec<LintResult> {
                     ("deny_drop_view", "view")
                 };
                 results.push(LintResult {
-                    rule: rule.to_string(),
+                    rule,
                     severity: LintSeverity::Error,
                     message: format!(
                         "Dropping {view_type} {name} requires --allow-destructive flag"
@@ -125,7 +125,7 @@ fn lint_op(op: &MigrationOp, options: &LintOptions) -> Vec<LintResult> {
         MigrationOp::DropEnum(name) => {
             if !options.allow_destructive {
                 results.push(LintResult {
-                    rule: "deny_drop_enum".to_string(),
+                    rule: "deny_drop_enum",
                     severity: LintSeverity::Error,
                     message: format!("Dropping enum {name} requires --allow-destructive flag"),
                 });
@@ -139,7 +139,7 @@ fn lint_op(op: &MigrationOp, options: &LintOptions) -> Vec<LintResult> {
         } => {
             if !options.allow_destructive {
                 results.push(LintResult {
-                    rule: "deny_drop_trigger".to_string(),
+                    rule: "deny_drop_trigger",
                     severity: LintSeverity::Error,
                     message: format!(
                         "Dropping trigger \"{target_schema}\".\"{target_name}\".{name} requires --allow-destructive flag"
@@ -151,7 +151,7 @@ fn lint_op(op: &MigrationOp, options: &LintOptions) -> Vec<LintResult> {
         MigrationOp::DropSequence(name) => {
             if !options.allow_destructive {
                 results.push(LintResult {
-                    rule: "deny_drop_sequence".to_string(),
+                    rule: "deny_drop_sequence",
                     severity: LintSeverity::Error,
                     message: format!(
                         "Dropping sequence \"{name}\" requires --allow-destructive flag"
@@ -166,7 +166,7 @@ fn lint_op(op: &MigrationOp, options: &LintOptions) -> Vec<LintResult> {
         } => {
             if !options.allow_destructive {
                 results.push(LintResult {
-                    rule: "deny_drop_unique_constraint".to_string(),
+                    rule: "deny_drop_unique_constraint",
                     severity: LintSeverity::Error,
                     message: format!(
                         "Dropping unique constraint \"{constraint_name}\" on \"{table}\" requires --allow-destructive flag"
@@ -178,7 +178,7 @@ fn lint_op(op: &MigrationOp, options: &LintOptions) -> Vec<LintResult> {
         MigrationOp::AlterSequence { name, changes } => {
             if changes.restart.is_some() {
                 results.push(LintResult {
-                    rule: "warn_sequence_restart".to_string(),
+                    rule: "warn_sequence_restart",
                     severity: LintSeverity::Warning,
                     message: format!(
                         "Restarting sequence \"{name}\" may cause duplicate key violations"
@@ -190,7 +190,7 @@ fn lint_op(op: &MigrationOp, options: &LintOptions) -> Vec<LintResult> {
         MigrationOp::DropSchema(name) => {
             if !options.allow_destructive {
                 results.push(LintResult {
-                    rule: "deny_drop_schema".to_string(),
+                    rule: "deny_drop_schema",
                     severity: LintSeverity::Error,
                     message: format!(
                         "Dropping schema \"{name}\" requires --allow-destructive flag"
@@ -202,7 +202,7 @@ fn lint_op(op: &MigrationOp, options: &LintOptions) -> Vec<LintResult> {
         MigrationOp::DropExtension(name) => {
             if !options.allow_destructive {
                 results.push(LintResult {
-                    rule: "deny_drop_extension".to_string(),
+                    rule: "deny_drop_extension",
                     severity: LintSeverity::Error,
                     message: format!(
                         "Dropping extension \"{name}\" requires --allow-destructive flag"
@@ -214,7 +214,7 @@ fn lint_op(op: &MigrationOp, options: &LintOptions) -> Vec<LintResult> {
         MigrationOp::DropDomain(name) => {
             if !options.allow_destructive {
                 results.push(LintResult {
-                    rule: "deny_drop_domain".to_string(),
+                    rule: "deny_drop_domain",
                     severity: LintSeverity::Error,
                     message: format!(
                         "Dropping domain \"{name}\" requires --allow-destructive flag"
@@ -379,7 +379,7 @@ mod tests {
     #[test]
     fn has_errors_returns_false_for_warnings_only() {
         let results = vec![LintResult {
-            rule: "warn_something".to_string(),
+            rule: "warn_something",
             severity: LintSeverity::Warning,
             message: "Just a warning".to_string(),
         }];


### PR DESCRIPTION
## Summary

- Change `LintResult.rule` and `SchemaIssue.rule` from `String` to `&'static str`
- All rule values are string literals, so no allocation needed
- CLI serialization structs convert to `String` at the boundary

Closes pgmold-197