### PR TITLE
ci: add PostgreSQL version matrix testing (PG 13-17)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,3 +92,19 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Run integration tests
         run: cargo test --all-features --test '*' -- --test-threads=4
+
+  pg-version-matrix:
+    name: PG ${{ matrix.pg-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        pg-version: ["13-alpine", "14-alpine", "15-alpine", "16-alpine", "17-alpine"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Run integration tests against PostgreSQL ${{ matrix.pg-version }}
+        env:
+          PGMOLD_TEST_PG_VERSION: ${{ matrix.pg-version }}
+        run: cargo test --all-features --test '*' -- --test-threads=4

--- a/src/validate/mod.rs
+++ b/src/validate/mod.rs
@@ -84,10 +84,15 @@ mod tests {
     use crate::diff::compute_diff;
     use crate::parser::parse_sql_string;
     use testcontainers::runners::AsyncRunner;
+    use testcontainers::ImageExt;
     use testcontainers_modules::postgres::Postgres;
 
     async fn setup_temp_postgres() -> (testcontainers::ContainerAsync<Postgres>, String) {
-        let container = Postgres::default().start().await.unwrap();
+        let pg = Postgres::default();
+        let container = match std::env::var("PGMOLD_TEST_PG_VERSION") {
+            Ok(version) => pg.with_tag(version).start().await.unwrap(),
+            Err(_) => pg.start().await.unwrap(),
+        };
         let port = container.get_host_port_ipv4(5432).await.unwrap();
         let url = format!("postgres://postgres:postgres@localhost:{port}/postgres");
         (container, url)

--- a/tests/baseline.rs
+++ b/tests/baseline.rs
@@ -7,10 +7,15 @@ use std::fs;
 use tempfile::TempDir;
 use testcontainers::runners::AsyncRunner;
 use testcontainers::ContainerAsync;
+use testcontainers::ImageExt;
 use testcontainers_modules::postgres::Postgres;
 
 async fn setup_postgres() -> (ContainerAsync<Postgres>, String) {
-    let container = Postgres::default().start().await.unwrap();
+    let pg = Postgres::default();
+    let container = match std::env::var("PGMOLD_TEST_PG_VERSION") {
+        Ok(version) => pg.with_tag(version).start().await.unwrap(),
+        Err(_) => pg.start().await.unwrap(),
+    };
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@localhost:{port}/postgres");
     (container, url)

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -17,6 +17,7 @@ pub use tempfile;
 pub use tempfile::NamedTempFile;
 pub use testcontainers::runners::AsyncRunner;
 pub use testcontainers::ContainerAsync;
+pub use testcontainers::ImageExt;
 pub use testcontainers_modules::postgres::Postgres;
 
 pub fn write_sql_temp_file(sql: &str) -> NamedTempFile {
@@ -27,7 +28,11 @@ pub fn write_sql_temp_file(sql: &str) -> NamedTempFile {
 
 #[allow(deprecated)]
 pub async fn setup_postgres() -> (ContainerAsync<Postgres>, String) {
-    let container = Postgres::default().start().await.unwrap();
+    let pg = Postgres::default();
+    let container = match std::env::var("PGMOLD_TEST_PG_VERSION") {
+        Ok(version) => pg.with_tag(version).start().await.unwrap(),
+        Err(_) => pg.start().await.unwrap(),
+    };
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@localhost:{port}/postgres");
     (container, url)

--- a/tests/semantic_equivalence.rs
+++ b/tests/semantic_equivalence.rs
@@ -5,10 +5,15 @@ use pgmold::parser::parse_sql_string;
 use pgmold::pg::introspect::introspect_schema;
 use pgmold::pg::PgConnection;
 use testcontainers::runners::AsyncRunner;
+use testcontainers::ImageExt;
 use testcontainers_modules::postgres::Postgres;
 
 async fn setup_postgres() -> (testcontainers::ContainerAsync<Postgres>, String) {
-    let container = Postgres::default().start().await.unwrap();
+    let pg = Postgres::default();
+    let container = match std::env::var("PGMOLD_TEST_PG_VERSION") {
+        Ok(version) => pg.with_tag(version).start().await.unwrap(),
+        Err(_) => pg.start().await.unwrap(),
+    };
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     (container, url)


### PR DESCRIPTION
## Summary

- Parameterize `setup_postgres()` to accept PG version via `PGMOLD_TEST_PG_VERSION` env var
- Add CI matrix job running all integration tests against PG 13, 14, 15, 16, 17 (alpine images)
- Default behavior unchanged (no env var = testcontainers default)

## Test plan

- [x] Compiles clean
- [x] Smoke test with `PGMOLD_TEST_PG_VERSION=13-alpine` passes locally
- [ ] CI matrix runs all 5 PG versions