### PR TITLE
chore: bump version to 0.30.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1566,7 +1566,7 @@ dependencies = [
 
 [[package]]
 name = "pgmold"
-version = "0.30.0-rc.1"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "pgmold"
-version = "0.30.0-rc.1"
+version = "0.30.0"
 edition = "2021"
 exclude = [".auto-claude/", ".auto-claude-security.json", ".claude_settings.json"]
 description = "PostgreSQL schema-as-code management tool"


### PR DESCRIPTION
## Summary

Bump version from 0.30.0-rc.1 to 0.30.0 stable.

### Changes since 0.29.4

**Bug fixes:**
- Fix 7 convergence bugs (expression indexes, sequence syntax, grant dedup, view/matview normalization, enum params, IN clause)
- Fix drift fingerprint false positives
- Fix NOT EXISTS paren normalization in view comparison

**Features:**
- Add TIME, INTERVAL, BYTEA, CHAR, POINT, XML column type support

**Testing:**
- 72 new tests across 6 tiers (convergence, property-based, error paths, CLI E2E, edge cases, performance benchmarks)
- PostgreSQL version matrix CI (PG 13-17)
- Validated against staging: zero convergence failures

**Refactoring:**
- 8 rounds of code smell cleanup
- Batch domain constraint queries (N+1 → single query)
- Various type and API improvements