### PR TITLE
chore: bump version to 0.30.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1566,7 +1566,7 @@ dependencies = [
 
 [[package]]
 name = "pgmold"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "pgmold"
-version = "0.30.0"
+version = "0.30.1"
 edition = "2021"
 exclude = [".auto-claude/", ".auto-claude-security.json", ".claude_settings.json"]
 description = "PostgreSQL schema-as-code management tool"


### PR DESCRIPTION
## Summary

- Bump version to 0.30.1 for patch release

## Changelog

- fix: strip SQL comments before preprocessing to prevent parse failures (#156)