### PR TITLE
chore: bump version to 0.31.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1566,7 +1566,7 @@ dependencies = [
 
 [[package]]
 name = "pgmold"
-version = "0.30.1"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "pgmold"
-version = "0.30.1"
+version = "0.31.0"
 edition = "2021"
 exclude = [".auto-claude/", ".auto-claude-security.json", ".claude_settings.json"]
 description = "PostgreSQL schema-as-code management tool"


### PR DESCRIPTION
## Summary

- Bump version to 0.31.0

## Changes in this release

- Fix: order CREATE POLICY / ALTER POLICY after CREATE TABLE for tables referenced in USING/WITH CHECK expressions (#158)
- Fix: parse policy expressions as boolean predicates for table reference extraction
- Fix: handle Expr::Nested and Expr::UnaryOp in table reference extraction (covers parenthesized and NOT EXISTS patterns)