### PR TITLE
fix: handle multi-byte UTF-8 characters in dollar-quoted strings

### DIFF
--- a/src/parser/preprocess.rs
+++ b/src/parser/preprocess.rs
@@ -480,7 +480,8 @@ $$;"
 
     #[test]
     fn multibyte_char_adjacent_to_dollar_tag() {
-        let sql = "SELECT '\u{2014}';\nCREATE FUNCTION f() RETURNS void AS $$\nBEGIN NULL; END;\n$$;";
+        let sql =
+            "SELECT '\u{2014}';\nCREATE FUNCTION f() RETURNS void AS $$\nBEGIN NULL; END;\n$$;";
         let result = strip_comments(sql);
         assert_eq!(result, sql);
     }


### PR DESCRIPTION
## Summary

- Fix panic in `strip_comments` when dollar-quoted string bodies contain multi-byte UTF-8 characters (em-dash, en-dash, etc.)
- Replace byte-by-byte scanning loop with `str::find` for UTF-8-safe tag matching
- Add 7 test cases covering multi-byte characters in comments, dollar-quoted bodies, and adjacent to dollar tags

Closes #161