### PR TITLE
chore: bump version to 0.31.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1566,7 +1566,7 @@ dependencies = [
 
 [[package]]
 name = "pgmold"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "pgmold"
-version = "0.31.1"
+version = "0.31.2"
 edition = "2021"
 exclude = [".auto-claude/", ".auto-claude-security.json", ".claude_settings.json"]
 description = "PostgreSQL schema-as-code management tool"


### PR DESCRIPTION
## Summary

- Bump version to 0.31.2

## Changes since v0.31.1

- Fix: unquote column identifiers in trigger UPDATE OF clause (#163)