### PR TITLE
fix: place USING clause after ON in CREATE INDEX SQL generation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "pgmold"
-version = "0.33.0"
+version = "0.33.1"
 edition = "2021"
 exclude = [".auto-claude/", ".auto-claude-security.json", ".claude_settings.json"]
 description = "PostgreSQL schema-as-code management tool"

--- a/src/pg/sqlgen.rs
+++ b/src/pg/sqlgen.rs
@@ -709,11 +709,11 @@ fn generate_create_index(schema: &str, table: &str, index: &Index) -> String {
         .unwrap_or_default();
 
     format!(
-        "CREATE {}INDEX {}{} ON {} ({}){};",
+        "CREATE {}INDEX {} ON {}{} ({}){};",
         unique,
         quote_ident(&index.name),
-        index_type,
         quote_qualified(schema, table),
+        index_type,
         format_index_column_list(&index.columns),
         where_clause
     )
@@ -4051,7 +4051,7 @@ mod tests {
         let sql = generate_create_index("mrv", "Polygon", &index);
         assert_eq!(
             sql,
-            "CREATE INDEX \"polygon_geometry_idx\" USING gist ON \"mrv\".\"Polygon\" ((geometry::geography)) WHERE (geometry IS NOT NULL);"
+            "CREATE INDEX \"polygon_geometry_idx\" ON \"mrv\".\"Polygon\" USING gist ((geometry::geography)) WHERE (geometry IS NOT NULL);"
         );
     }
 
@@ -4068,7 +4068,7 @@ mod tests {
         let sql = generate_create_index("public", "documents", &index);
         assert_eq!(
             sql,
-            "CREATE INDEX \"documents_content_idx\" USING gin ON \"public\".\"documents\" (\"content\");"
+            "CREATE INDEX \"documents_content_idx\" ON \"public\".\"documents\" USING gin (\"content\");"
         );
     }
 
@@ -4085,7 +4085,7 @@ mod tests {
         let sql = generate_create_index("public", "users", &index);
         assert_eq!(
             sql,
-            "CREATE INDEX \"users_session_idx\" USING hash ON \"public\".\"users\" (\"session_token\");"
+            "CREATE INDEX \"users_session_idx\" ON \"public\".\"users\" USING hash (\"session_token\");"
         );
     }
 


### PR DESCRIPTION
## Summary

- Fixes `syntax error at or near "USING"` during `pgmold apply` for GIN/GIST/HASH indexes
- The USING method clause was placed between the index name and ON keyword, producing invalid SQL
- Bumps version to 0.33.1

## Test plan

- [x] All 1016 unit tests pass (including the 4 index type tests with corrected assertions)
- [ ] CI database-tests pass (pgmold-apply succeeds)
- [ ] CI e2e-tests pass