### PR TITLE
chore: bump version to 0.33.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1587,7 +1587,7 @@ dependencies = [
 
 [[package]]
 name = "pgmold"
-version = "0.33.4"
+version = "0.33.5"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "pgmold"
-version = "0.33.4"
+version = "0.33.5"
 edition = "2021"
 exclude = [".auto-claude/", ".auto-claude-security.json", ".claude_settings.json"]
 description = "PostgreSQL schema-as-code management tool"


### PR DESCRIPTION
## Summary
- Bump version to 0.33.5 for patch release

### Bug fixes included since 0.33.4
- Normalize INNER JOIN to JOIN and LEFT/RIGHT OUTER to LEFT/RIGHT in view comparison
- Fix expression index convergence for varchar columns (strip pg_get_indexdef ::character varying casts)
- Fix view convergence for COALESCE with varchar columns (strip ::character varying casts on string literals)
- Expanded proptest generators for normalization-heavy DDL

## Test plan
- [ ] CI green
- [ ] `cargo publish` succeeds