### PR TITLE
chore(parser): ban wildcard match arms on upstream sqlparser enums

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -258,6 +258,31 @@ Filters apply to both source and target schemas before diffing.
 
 Lock hazard detection warns about operations that acquire exclusive locks.
 
+## Match Arm Discipline
+
+Parser modules that destructure enums from the upstream `sqlparser` crate
+(`ColumnOption`, `TableConstraint`, `FunctionArg`, etc.) must never terminate
+a `match` with a bare `_ => ...` wildcard. The `parser::tables` module opts
+into `#![warn(clippy::wildcard_enum_match_arm)]` at the top of the file so
+that when `sqlparser` ships a new variant, `cargo clippy` surfaces a warning
+forcing explicit triage rather than silently swallowing it.
+
+This rule exists because the original `ColumnOption` match dropped
+`Unique`, `ForeignKey`, and `Check` column-level constraints for months
+without anyone noticing — a bare `_ => {}` arm will always compile, even
+after upstream breaks the enum apart.
+
+When adding a new upstream-enum match in parser code:
+
+1. Enumerate every variant by name (or use `|`-alternates to group
+   dialect-specific variants into a single ignored arm).
+2. Add a comment naming why a variant is intentionally ignored (MySQL-only,
+   Snowflake-only, deferred to a later pass, etc.).
+3. For genuinely huge upstream enums (`Expr`, `Statement`, `DataType`) the
+   cost of listing every variant outweighs the benefit. In those narrow
+   cases use `#[allow(clippy::wildcard_enum_match_arm)]` directly above the
+   single match, with a comment explaining the exemption.
+
 ## Module Dependencies
 
 ```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1587,7 +1587,7 @@ dependencies = [
 
 [[package]]
 name = "pgmold"
-version = "0.33.5"
+version = "0.33.6"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/src/parser/dependencies.rs
+++ b/src/parser/dependencies.rs
@@ -1,3 +1,9 @@
+// TODO: replace the `_ =>` wildcards on `Statement`, `SetExpr`,
+// `TableFactor`, and `Expr` in this file with explicit variant listings
+// (see tables.rs / mod.rs for the pattern). Out of scope for the initial
+// ban-wildcards pass; tracked as follow-up.
+#![allow(clippy::wildcard_enum_match_arm)]
+
 /// Extract dependencies from SQL statements.
 ///
 /// This module parses SQL DDL to identify object references, enabling

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -489,7 +489,15 @@ pub fn parse_sql_string(sql: &str) -> Result<Schema> {
                                 expression: normalize_expr(&chk.expr.to_string()),
                             });
                         }
-                        _ => {
+                        // Every remaining variant is passed through the
+                        // NOT-NULL string fallback. Listed explicitly so
+                        // additions to `TableConstraint` upstream force a
+                        // review here instead of being silently swallowed.
+                        TableConstraint::Unique(_)
+                        | TableConstraint::PrimaryKey(_)
+                        | TableConstraint::ForeignKey(_)
+                        | TableConstraint::Index(_)
+                        | TableConstraint::FulltextOrSpatial(_) => {
                             let constraint_str = constraint.to_string().to_uppercase();
                             if constraint_str.contains("NOT NULL") {
                                 not_null = true;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,3 +1,10 @@
+#![warn(clippy::wildcard_enum_match_arm)]
+//! Enums from the upstream `sqlparser` crate (`Statement`, `ObjectType`,
+//! `AlterTableOperation`, etc.) must never be matched with a bare `_ => ...`
+//! wildcard. When sqlparser adds a variant we want a compile-time warning
+//! forcing explicit triage, not silent data loss. See ARCHITECTURE.md §
+//! "Match arm discipline".
+
 mod comments;
 mod dependencies;
 mod functions;
@@ -379,7 +386,52 @@ pub fn parse_sql_string(sql: &str) -> Result<Schema> {
                                 }
                             }
                         }
-                        _ => {}
+                        // PostgreSQL `ALTER TABLE` variants pgmold does not yet
+                        // consume. Tracked as future work; listed explicitly
+                        // so an upstream addition to `AlterTableOperation`
+                        // does not silently slip past.
+                        AlterTableOperation::AlterColumn { .. }
+                        | AlterTableOperation::DropConstraint { .. }
+                        | AlterTableOperation::ValidateConstraint { .. }
+                        | AlterTableOperation::DropPrimaryKey { .. }
+                        | AlterTableOperation::ReplicaIdentity { .. }
+                        | AlterTableOperation::OwnerTo { .. }
+                        | AlterTableOperation::SetOptionsParens { .. }
+                        | AlterTableOperation::EnableRule { .. }
+                        | AlterTableOperation::DisableRule { .. }
+                        | AlterTableOperation::EnableAlwaysRule { .. }
+                        | AlterTableOperation::EnableReplicaRule { .. }
+                        // ClickHouse-specific: projections and partition ops
+                        // have no PostgreSQL equivalent.
+                        | AlterTableOperation::AddProjection { .. }
+                        | AlterTableOperation::DropProjection { .. }
+                        | AlterTableOperation::MaterializeProjection { .. }
+                        | AlterTableOperation::ClearProjection { .. }
+                        | AlterTableOperation::AttachPartition { .. }
+                        | AlterTableOperation::DetachPartition { .. }
+                        | AlterTableOperation::FreezePartition { .. }
+                        | AlterTableOperation::UnfreezePartition { .. }
+                        | AlterTableOperation::AddPartitions { .. }
+                        | AlterTableOperation::DropPartitions { .. }
+                        | AlterTableOperation::RenamePartitions { .. }
+                        // MySQL-specific: no PostgreSQL equivalent.
+                        | AlterTableOperation::DropForeignKey { .. }
+                        | AlterTableOperation::DropIndex { .. }
+                        | AlterTableOperation::ChangeColumn { .. }
+                        | AlterTableOperation::ModifyColumn { .. }
+                        | AlterTableOperation::Algorithm { .. }
+                        | AlterTableOperation::Lock { .. }
+                        | AlterTableOperation::AutoIncrement { .. }
+                        // Snowflake-specific: dynamic-table and clustering ops.
+                        | AlterTableOperation::SwapWith { .. }
+                        | AlterTableOperation::SetTblProperties { .. }
+                        | AlterTableOperation::ClusterBy { .. }
+                        | AlterTableOperation::DropClusteringKey
+                        | AlterTableOperation::SuspendRecluster
+                        | AlterTableOperation::ResumeRecluster
+                        | AlterTableOperation::Refresh
+                        | AlterTableOperation::Suspend
+                        | AlterTableOperation::Resume => {}
                     }
                 }
             }
@@ -712,7 +764,16 @@ pub fn parse_sql_string(sql: &str) -> Result<Schema> {
                                 partition.indexes.retain(|idx| idx.name != obj_name);
                             }
                         }
-                        _ => {}
+                        // Cluster-level objects (Database, Role, User) and
+                        // Snowflake-specific objects (Stage, Stream) are not
+                        // part of the schema model pgmold tracks. Listed
+                        // explicitly so an upstream `ObjectType` addition
+                        // forces a compile-time review.
+                        ObjectType::Database
+                        | ObjectType::Role
+                        | ObjectType::User
+                        | ObjectType::Stage
+                        | ObjectType::Stream => {}
                     }
                 }
             }
@@ -780,7 +841,148 @@ pub fn parse_sql_string(sql: &str) -> Result<Schema> {
                     schema.extensions.remove(&ext_name);
                 }
             }
-            _ => {}
+            // Non-DDL and dialect-specific statements that pgmold does not
+            // model. Listed explicitly (instead of a bare `_`) so adding a
+            // new `Statement` variant upstream triggers a clippy warning and
+            // forces triage. See ARCHITECTURE.md § "Match arm discipline".
+
+            // Data-manipulation and query statements.
+            Statement::Query(_)
+            | Statement::Insert(_)
+            | Statement::Update(_)
+            | Statement::Delete(_)
+            | Statement::Merge(_)
+            | Statement::Truncate(_)
+            | Statement::Copy { .. }
+            | Statement::CopyIntoSnowflake { .. }
+            // Session / transaction control.
+            | Statement::Set(_)
+            | Statement::Commit { .. }
+            | Statement::Rollback { .. }
+            | Statement::StartTransaction { .. }
+            | Statement::Savepoint { .. }
+            | Statement::ReleaseSavepoint { .. }
+            | Statement::Discard { .. }
+            | Statement::Use(_)
+            | Statement::AlterSession { .. }
+            | Statement::Reset(_)
+            // PL/pgSQL control-flow statements (parsed inside function bodies
+            // via a separate code path; ignored at the top level).
+            | Statement::Case(_)
+            | Statement::If(_)
+            | Statement::While(_)
+            | Statement::Raise(_)
+            | Statement::Return(_)
+            | Statement::Declare { .. }
+            | Statement::Fetch { .. }
+            | Statement::Open(_)
+            | Statement::Close { .. }
+            | Statement::Call(_)
+            | Statement::Assert { .. }
+            | Statement::Print(_)
+            // Prepared-statement plumbing.
+            | Statement::Prepare { .. }
+            | Statement::Execute { .. }
+            | Statement::Deallocate { .. }
+            // Introspection / SHOW commands.
+            | Statement::ShowFunctions { .. }
+            | Statement::ShowVariable { .. }
+            | Statement::ShowStatus { .. }
+            | Statement::ShowVariables { .. }
+            | Statement::ShowCreate { .. }
+            | Statement::ShowColumns { .. }
+            | Statement::ShowDatabases { .. }
+            | Statement::ShowSchemas { .. }
+            | Statement::ShowCharset(_)
+            | Statement::ShowObjects(_)
+            | Statement::ShowTables { .. }
+            | Statement::ShowViews { .. }
+            | Statement::ShowCollation { .. }
+            | Statement::Explain { .. }
+            | Statement::ExplainTable { .. }
+            // Authorization (handled via separate `parse_grant_statements`
+            // pass that re-parses the raw SQL, so the AST-level variants are
+            // intentionally ignored here).
+            | Statement::Grant { .. }
+            | Statement::Revoke { .. }
+            | Statement::Deny(_)
+            // Comments are processed by `parse_comment_statements` on the
+            // raw SQL below; ignore the AST-level variant here.
+            | Statement::Comment { .. }
+            // Cluster-level and role / user management — not part of the
+            // schema model pgmold tracks.
+            | Statement::CreateRole(_)
+            | Statement::AlterRole { .. }
+            | Statement::CreateUser(_)
+            | Statement::AlterUser(_)
+            | Statement::CreateDatabase { .. }
+            | Statement::AttachDatabase { .. }
+            // Procedures, macros, operators, domains-as-alter — pgmold does
+            // not yet model these. Tracked as future work.
+            | Statement::CreateProcedure { .. }
+            | Statement::DropProcedure { .. }
+            | Statement::CreateMacro { .. }
+            | Statement::CreateOperator(_)
+            | Statement::CreateOperatorClass(_)
+            | Statement::CreateOperatorFamily(_)
+            | Statement::AlterOperator(_)
+            | Statement::DropOperator(_)
+            | Statement::DropOperatorClass(_)
+            | Statement::DropOperatorFamily(_)
+            // pgmold consumes `AlterTable` (above) but not these sibling
+            // ALTER variants yet.
+            | Statement::AlterIndex { .. }
+            | Statement::AlterView { .. }
+            | Statement::AlterType(_)
+            | Statement::AlterSchema(_)
+            | Statement::AlterPolicy { .. }
+            | Statement::RenameTable(_)
+            // Maintenance ops (VACUUM / ANALYZE / LOCK TABLE, etc.).
+            | Statement::Analyze(_)
+            | Statement::Vacuum(_)
+            | Statement::OptimizeTable { .. }
+            | Statement::LockTables { .. }
+            | Statement::UnlockTables
+            | Statement::Flush { .. }
+            | Statement::Cache { .. }
+            | Statement::UNCache { .. }
+            // LISTEN / NOTIFY — runtime messaging, not schema.
+            | Statement::LISTEN { .. }
+            | Statement::UNLISTEN { .. }
+            | Statement::NOTIFY { .. }
+            // Data loading / export.
+            | Statement::Load { .. }
+            | Statement::LoadData { .. }
+            | Statement::Install { .. }
+            | Statement::Directory { .. }
+            | Statement::Unload { .. }
+            | Statement::ExportData(_)
+            | Statement::Msck(_)
+            // Error-raising variants from dialect extensions.
+            | Statement::RaisError { .. }
+            | Statement::Kill { .. }
+            // Dialect-specific connectors, secrets, servers, stages, virtual
+            // tables, and DuckDB / Snowflake / ClickHouse / MSSQL-specific
+            // plumbing.
+            | Statement::CreateVirtualTable { .. }
+            | Statement::CreateSecret { .. }
+            | Statement::DropSecret { .. }
+            | Statement::CreateServer(_)
+            | Statement::CreateConnector(_)
+            | Statement::AlterConnector { .. }
+            | Statement::DropConnector { .. }
+            | Statement::AttachDuckDBDatabase { .. }
+            | Statement::DetachDuckDBDatabase { .. }
+            | Statement::CreateStage { .. }
+            | Statement::List(_)
+            | Statement::Remove(_)
+            | Statement::Pragma { .. }
+            // `CreateType` representations other than `Enum` (Composite /
+            // Range / SqlDefinition, and the bare `representation: None`
+            // form) are currently dropped. This is a real pgmold gap tracked
+            // separately; the previously wildcarded behaviour is preserved
+            // here.
+            | Statement::CreateType { .. } => {}
         }
     }
 

--- a/src/parser/sequences.rs
+++ b/src/parser/sequences.rs
@@ -1,3 +1,8 @@
+// TODO: replace the `_ =>` wildcards in this file with explicit variant
+// listings (see tables.rs / mod.rs for the pattern). Out of scope for the
+// initial ban-wildcards pass; tracked as follow-up.
+#![allow(clippy::wildcard_enum_match_arm)]
+
 use crate::model::*;
 use crate::util::Result;
 use sqlparser::ast::{DataType, Expr, ObjectName, SequenceOptions, UnaryOperator, Value};

--- a/src/parser/tables.rs
+++ b/src/parser/tables.rs
@@ -154,9 +154,6 @@ pub(super) fn parse_create_table(
             // MySQL-specific constraints that have no PostgreSQL equivalent.
             // Listed explicitly (instead of a bare `_`) so adding a new
             // `TableConstraint` variant upstream forces a compile-time review.
-            // MySQL-specific constraints that have no PostgreSQL equivalent.
-            // Listed explicitly (instead of a bare `_`) so adding a new
-            // `TableConstraint` variant upstream forces a compile-time review.
             TableConstraint::Index(_) | TableConstraint::FulltextOrSpatial(_) => {}
         }
     }

--- a/src/parser/tables.rs
+++ b/src/parser/tables.rs
@@ -1,3 +1,10 @@
+#![warn(clippy::wildcard_enum_match_arm)]
+//! Enums from the upstream `sqlparser` crate (`ColumnOption`, `TableConstraint`,
+//! `DataType`, `Expr`, etc.) must never be matched with a bare `_ => ...`
+//! wildcard. When sqlparser adds a variant we want a compile-time warning
+//! forcing explicit triage, not silent data loss. See ARCHITECTURE.md §
+//! "Match arm discipline".
+
 use crate::model::*;
 use crate::util::Result;
 use sqlparser::ast::{
@@ -144,7 +151,13 @@ pub(super) fn parse_create_table(
                     is_constraint: true,
                 });
             }
-            _ => {}
+            // MySQL-specific constraints that have no PostgreSQL equivalent.
+            // Listed explicitly (instead of a bare `_`) so adding a new
+            // `TableConstraint` variant upstream forces a compile-time review.
+            // MySQL-specific constraints that have no PostgreSQL equivalent.
+            // Listed explicitly (instead of a bare `_`) so adding a new
+            // `TableConstraint` variant upstream forces a compile-time review.
+            TableConstraint::Index(_) | TableConstraint::FulltextOrSpatial(_) => {}
         }
     }
 
@@ -170,7 +183,36 @@ pub(super) fn parse_column_with_serial(
             ColumnOption::Default(expr) => {
                 default = Some(normalize_expr(&expr.to_string()));
             }
-            _ => {}
+            // `PrimaryKey` is applied in a second pass on the caller in
+            // `parse_create_table` and intentionally not handled here.
+            ColumnOption::PrimaryKey(_)
+            // `Unique`, `ForeignKey`, and `Check` inline on a column are
+            // currently dropped. The fix lives on a separate branch
+            // (`fix/parser-inline-column-constraints`) — do NOT inline it
+            // here. This arm exists only so the variants are listed by name
+            // and an upstream addition triggers the clippy lint above.
+            | ColumnOption::Unique(_)
+            | ColumnOption::ForeignKey(_)
+            | ColumnOption::Check(_)
+            // Postgres-relevant annotations we don't yet consume.
+            | ColumnOption::Generated { .. }
+            | ColumnOption::Identity(_)
+            | ColumnOption::Comment(_)
+            | ColumnOption::Collation(_)
+            | ColumnOption::CharacterSet(_)
+            // Dialect-specific variants (ClickHouse, BigQuery, Snowflake,
+            // MySQL, MSSQL, SQLite) that have no PostgreSQL meaning.
+            | ColumnOption::DialectSpecific(_)
+            | ColumnOption::OnUpdate(_)
+            | ColumnOption::OnConflict(_)
+            | ColumnOption::Materialized(_)
+            | ColumnOption::Ephemeral(_)
+            | ColumnOption::Alias(_)
+            | ColumnOption::Options(_)
+            | ColumnOption::Policy(_)
+            | ColumnOption::Tags(_)
+            | ColumnOption::Srid(_)
+            | ColumnOption::Invisible => {}
         }
     }
 
@@ -242,6 +284,8 @@ pub(super) fn parse_column_with_serial(
 pub(super) fn detect_serial_type(dt: &DataType) -> Option<SequenceDataType> {
     if let DataType::Custom(name, _) = dt {
         let type_name = name.to_string().to_lowercase();
+        // String match on the rendered type name; not an enum match, so the
+        // `_` arm here is intentional and unaffected by the module lint.
         match type_name.as_str() {
             "serial" => Some(SequenceDataType::Integer),
             "bigserial" => Some(SequenceDataType::BigInt),
@@ -265,39 +309,52 @@ pub(super) fn parse_referential_action(action: &Option<SqlReferentialAction>) ->
 }
 
 fn parse_partition_by(expr: &Expr) -> Option<PartitionKey> {
-    match expr {
-        Expr::Function(func) => {
-            let strategy_name = func.name.to_string().to_uppercase();
-            let strategy = match strategy_name.as_str() {
-                "RANGE" => PartitionStrategy::Range,
-                "LIST" => PartitionStrategy::List,
-                "HASH" => PartitionStrategy::Hash,
-                _ => return None,
-            };
+    // `Expr` is one of the largest upstream enums (100+ variants spanning
+    // many SQL dialects). Listing every variant here would be obnoxious and
+    // unstable across sqlparser releases, so we opt out of the lint on this
+    // single match and rely on `if let Expr::Function(_) = ...` semantics.
+    #[allow(clippy::wildcard_enum_match_arm)]
+    let func = match expr {
+        Expr::Function(func) => func,
+        _ => return None,
+    };
 
-            let columns: Vec<String> = match &func.args {
-                FunctionArguments::List(args) => args
-                    .args
-                    .iter()
-                    .filter_map(|arg| match arg {
-                        SqlFunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Identifier(ident))) => {
-                            Some(ident.value.clone())
-                        }
-                        SqlFunctionArg::Unnamed(FunctionArgExpr::Expr(expr)) => {
-                            Some(expr.to_string())
-                        }
-                        _ => None,
-                    })
-                    .collect(),
-                _ => Vec::new(),
-            };
+    let strategy_name = func.name.to_string().to_uppercase();
+    let strategy = match strategy_name.as_str() {
+        "RANGE" => PartitionStrategy::Range,
+        "LIST" => PartitionStrategy::List,
+        "HASH" => PartitionStrategy::Hash,
+        _ => return None,
+    };
 
-            Some(PartitionKey {
-                strategy,
-                columns,
-                expressions: Vec::new(),
+    let columns: Vec<String> = match &func.args {
+        FunctionArguments::List(args) => args
+            .args
+            .iter()
+            .filter_map(|arg| match arg {
+                SqlFunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Identifier(ident))) => {
+                    Some(ident.value.clone())
+                }
+                SqlFunctionArg::Unnamed(FunctionArgExpr::Expr(expr)) => Some(expr.to_string()),
+                // `FunctionArgExpr` has `QualifiedWildcard` and `Wildcard`
+                // variants that never appear in a PARTITION BY expression,
+                // and `FunctionArg::Named`/`ExprNamed` are dialect features
+                // (MSSQL/BigQuery) PostgreSQL's partition key syntax can't
+                // emit. Ignored, but enumerated so upstream additions force
+                // review.
+                SqlFunctionArg::Unnamed(
+                    FunctionArgExpr::QualifiedWildcard(_) | FunctionArgExpr::Wildcard,
+                )
+                | SqlFunctionArg::Named { .. }
+                | SqlFunctionArg::ExprNamed { .. } => None,
             })
-        }
-        _ => None,
-    }
+            .collect(),
+        FunctionArguments::None | FunctionArguments::Subquery(_) => Vec::new(),
+    };
+
+    Some(PartitionKey {
+        strategy,
+        columns,
+        expressions: Vec::new(),
+    })
 }

--- a/src/parser/tables.rs
+++ b/src/parser/tables.rs
@@ -137,7 +137,23 @@ pub(super) fn parse_create_table(
                         expression: normalize_expr(&chk.expr.to_string()),
                     });
                 }
-                _ => {}
+                ColumnOption::Null | ColumnOption::NotNull | ColumnOption::Default(_) => {}
+                ColumnOption::Generated { .. }
+                | ColumnOption::Identity(_)
+                | ColumnOption::Comment(_)
+                | ColumnOption::Collation(_)
+                | ColumnOption::OnUpdate(_)
+                | ColumnOption::OnConflict(_)
+                | ColumnOption::CharacterSet(_)
+                | ColumnOption::Materialized(_)
+                | ColumnOption::Ephemeral(_)
+                | ColumnOption::Alias(_)
+                | ColumnOption::DialectSpecific(_)
+                | ColumnOption::Options(_)
+                | ColumnOption::Policy(_)
+                | ColumnOption::Tags(_)
+                | ColumnOption::Srid(_)
+                | ColumnOption::Invisible => {}
             }
         }
     }
@@ -405,6 +421,12 @@ fn collect_referenced_columns(expr: &Expr, known_columns: &[&str]) -> Vec<String
     seen
 }
 
+// `Expr` has 100+ variants across many SQL dialects; enumerating every
+// irrelevant one here would be noisy and unstable across sqlparser upgrades.
+// The arms below cover every AST shape we care about for CHECK-expression
+// naming; unknown shapes fall through to "no column referenced" and the
+// constraint name collapses to `{table}_check`.
+#[allow(clippy::wildcard_enum_match_arm)]
 fn walk_expr_identifiers<F: FnMut(&str)>(expr: &Expr, visit: &mut F) {
     use sqlparser::ast::Expr as E;
     match expr {
@@ -461,8 +483,6 @@ fn walk_expr_identifiers<F: FnMut(&str)>(expr: &Expr, visit: &mut F) {
             // backend only uses `{column}_check` for single-column references in the
             // pg_get_constraintdef sense. Revisit if convergence failures surface.
         }
-        // TODO: extend walker as needed (Array, Subquery, etc.) for richer CHECK
-        // expressions. Out of scope for the current iteration.
         _ => {}
     }
 }

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -1,3 +1,8 @@
+// TODO: replace the `_ =>` wildcards on `PartitionBound` in this file with
+// explicit variant listings. Test-only assertions; low priority but tracked
+// with the same follow-up as parser/sequences.rs and parser/util.rs.
+#![allow(clippy::wildcard_enum_match_arm)]
+
 use super::*;
 use std::collections::BTreeMap;
 

--- a/src/parser/util.rs
+++ b/src/parser/util.rs
@@ -1,3 +1,8 @@
+// TODO: replace the `other =>` wildcard on `DataType` in this file with an
+// explicit variant listing (see tables.rs / mod.rs for the pattern). Out of
+// scope for the initial ban-wildcards pass; tracked as follow-up.
+#![allow(clippy::wildcard_enum_match_arm)]
+
 use crate::model::*;
 use crate::util::{normalize_type_casts, Result, SchemaError};
 use sqlparser::ast::{


### PR DESCRIPTION
## Summary

The bug fixed in #200 was caused by a `_ => {}` match arm on `sqlparser::ColumnOption` silently swallowing `Unique`, `ForeignKey`, and `Check` variants. This PR removes that whole class of bug:

1. Enables `#![warn(clippy::wildcard_enum_match_arm)]` on `src/parser/tables.rs` and `src/parser/mod.rs` — the two files that carry the highest risk of silently-dropped SQL.
2. Replaces every wildcard match arm on upstream enums in those files with explicit variant listings grouped by category (MySQL-specific, Snowflake-specific, non-DDL, etc.) with comments explaining why each group is ignored.
3. Gates the `Expr` enum (100+ variants across dialects) behind a function-level `#[allow]` + explanatory comment — explicit listing would be noisy and unstable.
4. Sibling parser modules (`dependencies.rs`, `sequences.rs`, `tests.rs`, `util.rs`) get file-level `#![allow]` + TODO, since their wildcards are on similarly-large upstream enums and fixing them is out of scope.
5. Adds "Match Arm Discipline" section to `ARCHITECTURE.md` documenting the policy.

When sqlparser adds a new variant in a future release, these matches will now produce a compile-time warning instead of silent data loss.

## Notable variants surfaced during enumeration (not fixed here — filed for triage)

- `Statement::CreateType` with composite/range representations silently dropped.
- `AlterTableOperation::{AlterColumn, DropConstraint, ValidateConstraint, ReplicaIdentity, OwnerTo, SetOptionsParens}` — real Postgres DDL pgmold doesn't consume yet.
- `ColumnOption::{Generated, Identity, Comment, Collation, CharacterSet}` — modern Postgres schemas use these.

## Test plan

- [x] `cargo test --lib` — 1044 passed, 0 failed
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Lint-fires-on-regression: verified by reintroducing `_ => {}` on `ObjectType` and `TableConstraint`; clippy errors as expected. Reverted.