### PR TITLE
chore(deps): patch rustls-webpki for RUSTSEC-2026-0098 and 0099

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -4,4 +4,6 @@ ignore = [
     "RUSTSEC-2023-0071",
     # tokio-tar file smuggling — dev-only dependency via testcontainers
     "RUSTSEC-2025-0111",
+    # rand unsound with custom global logger — pgmold does not register a custom logger
+    "RUSTSEC-2026-0097",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2097,9 +2097,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary

- Bumps transitive `rustls-webpki` from 0.103.10 to 0.103.12 via `cargo update`
- Only 1 package in Cargo.lock changes (rustls-webpki itself)
- Silences `RUSTSEC-2026-0097` (rand custom-logger unsoundness) in `.cargo/audit.toml` — not applicable, pgmold uses no custom global logger

## CVEs fixed

- [RUSTSEC-2026-0098](https://rustsec.org/advisories/RUSTSEC-2026-0098) / GHSA-965h-392x-2mh5 — name constraints for URI names were incorrectly accepted
- [RUSTSEC-2026-0099](https://rustsec.org/advisories/RUSTSEC-2026-0099) / GHSA-xgp8-3hg3-c2mh — name constraints accepted for certificates asserting a wildcard name

Both are reachable only after signature verification and require misissued certificates to exploit, but the `Security Audit` CI check treats them as critical and fails the check.

## Not addressed here

- `rustls-pemfile` RUSTSEC-2025-0134 (unmaintained) — informational, `rustsec/audit-check@v2` does not fail the check for unmaintained advisories.

## Test plan

- [ ] `Security Audit` job passes on this PR
- [ ] All other CI checks remain green (no breakage from dep bump)