### PR TITLE
chore: bump version to 0.33.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1587,7 +1587,7 @@ dependencies = [
 
 [[package]]
 name = "pgmold"
-version = "0.33.6"
+version = "0.33.7"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "pgmold"
-version = "0.33.6"
+version = "0.33.7"
 edition = "2021"
 exclude = [".auto-claude/", ".auto-claude-security.json", ".claude_settings.json"]
 description = "PostgreSQL schema-as-code management tool"


### PR DESCRIPTION
Release 0.33.7.

## Changes since 0.33.6

- fix(parser): normalize type aliases in GRANT function signatures (#207) — GRANTs using `float8`, `int4`, `varchar`, `timestamptz`, `bool`, etc. were silently dropped on a fresh apply because the parsed signature key didn't match the function map key (which uses normalized types). Now normalized on both sides.