### PR TITLE
feat(parser): accept Bool as alias for boolean

### DIFF
--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -2951,6 +2951,15 @@ CREATE TABLE settings (
 }
 
 #[test]
+fn parse_bool_alias_column() {
+    let sql = "CREATE TABLE t (col Bool NOT NULL);";
+    let schema = parse_sql_string(sql).unwrap();
+    let col = schema.tables["public.t"].columns.get("col").unwrap();
+    assert_eq!(col.data_type, PgType::Boolean);
+    assert!(!col.nullable);
+}
+
+#[test]
 fn parse_integer_array_column() {
     let sql = "CREATE TABLE data (id BIGINT PRIMARY KEY, scores INTEGER[]);";
     let schema = parse_sql_string(sql).unwrap();

--- a/src/parser/util.rs
+++ b/src/parser/util.rs
@@ -114,7 +114,7 @@ pub(super) fn parse_data_type(dt: &DataType) -> Result<PgType> {
             Ok(PgType::Char(size))
         }
         DataType::Text => Ok(PgType::Text),
-        DataType::Boolean => Ok(PgType::Boolean),
+        DataType::Bool | DataType::Boolean => Ok(PgType::Boolean),
         DataType::Timestamp(_, tz) => {
             if *tz == TimezoneInfo::WithTimeZone || *tz == TimezoneInfo::Tz {
                 Ok(PgType::TimestampTz)

--- a/tests/corpus/handcrafted_type_aliases.sql
+++ b/tests/corpus/handcrafted_type_aliases.sql
@@ -1,4 +1,3 @@
--- IGNORE: pgmold-253 parser does not support Bool type alias
 -- Source: hand-crafted for pgmold
 -- Commit: n/a
 -- License: Apache-2.0


### PR DESCRIPTION
## Summary

- sqlparser has two distinct variants — `DataType::Bool` (for the `BOOL` keyword) and `DataType::Boolean` (for the `BOOLEAN` keyword). pgmold only handled the latter.
- Adds `DataType::Bool` to the existing `DataType::Boolean` arm in `parse_data_type`.
- Un-ignores `tests/corpus/handcrafted_type_aliases.sql` which now converges.

Closes pgmold-253. Stacked on #203 — merge #203 first.

## Test plan

- [ ] New `parse_bool_alias_column` unit test passes
- [ ] `handcrafted_type_aliases.sql` runs to PASS in the Corpus Convergence CI job after #203 merges and main is merged forward