### PR TITLE
fix(normalize): canonicalize view query for convergence

### DIFF
--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -223,6 +223,14 @@ fn is_numeric_type(dt: &DataType) -> bool {
     )
 }
 
+/// Check if a DataType is a date/time type.
+/// PostgreSQL implicitly casts DATE columns to TIMESTAMP when calling
+/// functions like date_trunc that require a timestamp argument.
+/// These implicit casts should be stripped during normalization.
+fn is_datetime_type(dt: &DataType) -> bool {
+    matches!(dt, DataType::Date | DataType::Timestamp(_, _))
+}
+
 /// Applies the normalization steps shared by both `normalize_expression_regex` and
 /// `normalize_view_query`: operator aliases, type cast lowercasing, whitespace collapse,
 /// and paren-spacing normalization.
@@ -1064,7 +1072,8 @@ fn normalize_expr(expr: &Expr) -> Expr {
                 norm_inner,
                 Expr::Identifier(_) | Expr::CompoundIdentifier(_)
             ) && (matches!(norm_data_type, DataType::CharacterVarying(None))
-                || is_numeric_type(&norm_data_type))
+                || is_numeric_type(&norm_data_type)
+                || is_datetime_type(&norm_data_type))
             {
                 return norm_inner;
             }
@@ -2599,5 +2608,18 @@ fn expressions_equal_empty_array_literal_vs_uuid_array_cast() {
     assert!(
         expressions_semantically_equal(schema_form, db_form),
         "Empty array literal should equal uuid[] typed cast form.\nSchema: {schema_form}\nDB: {db_form}"
+    );
+}
+
+#[test]
+fn materialized_view_date_trunc_with_implicit_timestamp_cast() {
+    // PostgreSQL rewrites DATE_TRUNC('month', period) when period is a DATE column.
+    // It adds an implicit cast to timestamp with time zone and lowercases the function name.
+    // The string arg also gets a ::text cast.
+    let schema_form = r#"SELECT tenant_id, resource, DATE_TRUNC('month', period) AS month, SUM(quantity) AS total_quantity FROM public.resource_usage GROUP BY tenant_id, resource, DATE_TRUNC('month', period)"#;
+    let db_form = r#"SELECT tenant_id, resource, date_trunc('month'::text, (period)::timestamp with time zone) AS month, sum(quantity) AS total_quantity FROM resource_usage GROUP BY tenant_id, resource, date_trunc('month'::text, (period)::timestamp with time zone)"#;
+    assert!(
+        views_semantically_equal(schema_form, db_form),
+        "date_trunc with implicit timestamp cast should match source form.\nSchema: {schema_form}\nDB: {db_form}"
     );
 }

--- a/tests/corpus/handcrafted_views_and_functions.sql
+++ b/tests/corpus/handcrafted_views_and_functions.sql
@@ -1,4 +1,3 @@
--- IGNORE: pgmold-254 materialized view convergence failure
 -- Source: hand-crafted for pgmold
 -- Commit: n/a
 -- License: Apache-2.0


### PR DESCRIPTION
## Summary

PostgreSQL implicitly casts the `period` column (type `DATE`) to `timestamp with time zone` when resolving the `date_trunc` function overload (there is no `date_trunc(text, date)` overload). The introspected view text contained `date_trunc('month'::text, (period)::timestamp with time zone)` while the source had `DATE_TRUNC('month', period)`.

The `'month'::text` part was already stripped by existing cast normalization. The `(period)::timestamp with time zone` part was not — the `Nested` unwrapper strips the outer parens, but `Cast { expr: Identifier, data_type: Timestamp(...) }` had no normalization path.

- Extends identifier-cast stripping in `normalize_expr` to drop `DATE` and `Timestamp` casts
- New `is_datetime_type` helper for consistent detection
- Unit test for the specific pattern
- Un-ignores `tests/corpus/handcrafted_views_and_functions.sql`

Closes pgmold-254. Stacked on #203.

## Test plan

- [ ] New normalize unit test passes
- [ ] `handcrafted_views_and_functions.sql` runs to PASS in Corpus Convergence after #203 merges + main merge-forward