### PR TITLE
chore(deps): cutover sqlparser from git dep to 0.60.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1613,7 +1613,8 @@ dependencies = [
 [[package]]
 name = "pgmold-sqlparser"
 version = "0.60.6"
-source = "git+https://github.com/fmguerreiro/datafusion-sqlparser-rs.git?branch=feat%2Fexclude-constraint#d819ea0cdde3def62fd4ee163ff030c20acff6b2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6abe4eaef0491924fbc74efecd8ffc28c31df5d5f9754a753fa5a095664d"
 dependencies = [
  "log",
  "recursive",
@@ -2398,7 +2399,8 @@ dependencies = [
 [[package]]
 name = "sqlparser_derive"
 version = "0.4.0"
-source = "git+https://github.com/fmguerreiro/datafusion-sqlparser-rs.git?branch=feat%2Fexclude-constraint#d819ea0cdde3def62fd4ee163ff030c20acff6b2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "028e551d5e270b31b9f3ea271778d9d827148d4287a5d96167b6bb9787f5cc38"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2611,6 +2613,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
+ "windows-sys 0.52.0",
  "windows-sys 0.59.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["command-line-utilities", "database"]
 clap = { version = "4.5", features = ["derive", "env"] }
 tokio = { version = "1.35", features = ["full"] }
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres"] }
-sqlparser = { package = "pgmold-sqlparser", git = "https://github.com/fmguerreiro/datafusion-sqlparser-rs.git", branch = "feat/exclude-constraint", features = ["visitor"] }
+sqlparser = { package = "pgmold-sqlparser", version = "0.60.6", features = ["visitor"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 anyhow = "1.0"
@@ -43,4 +43,4 @@ name = "performance"
 harness = false
 
 [build-dependencies]
-sqlparser = { package = "pgmold-sqlparser", git = "https://github.com/fmguerreiro/datafusion-sqlparser-rs.git", branch = "feat/exclude-constraint", features = ["visitor"] }
+sqlparser = { package = "pgmold-sqlparser", version = "0.60.6", features = ["visitor"] }


### PR DESCRIPTION
## Summary

`pgmold-sqlparser 0.60.6` is now published on crates.io. Switch `Cargo.toml` from the `feat/exclude-constraint` git dep back to a version-pinned dep.

- Depends on the EXCLUDE constraint work merged in pgmold#205 + fmguerreiro/datafusion-sqlparser-rs#4

## Test plan

- [ ] Cargo.lock diff shows only the dep source swap (git → registry), no transitive churn
- [ ] CI passes (all 13 checks)