### PR TITLE
fix(parser): treat DEFAULT NULL as no default

### DIFF
--- a/src/lint/locks.rs
+++ b/src/lint/locks.rs
@@ -42,17 +42,15 @@ pub fn detect_lock_hazards(ops: &[MigrationOp]) -> Vec<LockWarning> {
                 table,
                 column,
                 changes,
-            } => {
-                if changes.data_type.is_some() || changes.nullable == Some(false) {
-                    warnings.push(LockWarning {
-                        operation: "AlterColumn".to_string(),
-                        table: table.to_string(),
-                        lock_level: LockLevel::AccessExclusive,
-                        message: format!(
-                            "ALTER COLUMN acquires ACCESS EXCLUSIVE lock on table {table} (column {column})"
-                        ),
-                    });
-                }
+            } if changes.data_type.is_some() || changes.nullable == Some(false) => {
+                warnings.push(LockWarning {
+                    operation: "AlterColumn".to_string(),
+                    table: table.to_string(),
+                    lock_level: LockLevel::AccessExclusive,
+                    message: format!(
+                        "ALTER COLUMN acquires ACCESS EXCLUSIVE lock on table {table} (column {column})"
+                    ),
+                });
             }
             MigrationOp::AddIndex { table, .. } => {
                 warnings.push(LockWarning {

--- a/src/parser/tables.rs
+++ b/src/parser/tables.rs
@@ -10,7 +10,7 @@ use crate::util::Result;
 use sqlparser::ast::{
     ColumnDef, ColumnOption, DataType, Expr, FunctionArg as SqlFunctionArg, FunctionArgExpr,
     FunctionArguments, GeneratedAs, GeneratedExpressionMode,
-    ReferentialAction as SqlReferentialAction, TableConstraint,
+    ReferentialAction as SqlReferentialAction, TableConstraint, Value,
 };
 use std::collections::BTreeMap;
 
@@ -333,7 +333,9 @@ pub(super) fn parse_column_with_serial(
             ColumnOption::NotNull => nullable = false,
             ColumnOption::Null => nullable = true,
             ColumnOption::Default(expr) => {
-                default = Some(normalize_expr(&expr.to_string()));
+                if !is_null_expr(expr) {
+                    default = Some(normalize_expr(&expr.to_string()));
+                }
             }
             ColumnOption::Generated {
                 generated_as,
@@ -562,6 +564,15 @@ fn walk_expr_identifiers<F: FnMut(&str)>(expr: &Expr, visit: &mut F) {
             // pg_get_constraintdef sense. Revisit if convergence failures surface.
         }
         _ => {}
+    }
+}
+
+#[allow(clippy::wildcard_enum_match_arm)]
+fn is_null_expr(expr: &Expr) -> bool {
+    match expr {
+        Expr::Value(v) => matches!(v.value, Value::Null),
+        Expr::Cast { expr: inner, .. } => is_null_expr(inner),
+        _ => false,
     }
 }
 

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -1709,7 +1709,10 @@ fn default_coalesce_with_null_preserved() {
     let sql = "CREATE TABLE t (col TEXT DEFAULT COALESCE(NULL, 'x'));";
     let schema = parse_sql_string(sql).unwrap();
     let col = schema.tables["public.t"].columns.get("col").unwrap();
-    assert!(col.default.is_some(), "COALESCE(NULL, 'x') is not a null default");
+    assert!(
+        col.default.is_some(),
+        "COALESCE(NULL, 'x') is not a null default"
+    );
 }
 
 #[test]

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -1673,6 +1673,46 @@ fn type_casts_normalized_to_lowercase() {
 }
 
 #[test]
+fn default_null_uppercase_stored_as_no_default() {
+    let sql = "CREATE TABLE t (col TEXT[] DEFAULT NULL);";
+    let schema = parse_sql_string(sql).unwrap();
+    let col = schema.tables["public.t"].columns.get("col").unwrap();
+    assert_eq!(col.default, None);
+}
+
+#[test]
+fn default_null_lowercase_stored_as_no_default() {
+    let sql = "CREATE TABLE t (col TEXT[] DEFAULT null);";
+    let schema = parse_sql_string(sql).unwrap();
+    let col = schema.tables["public.t"].columns.get("col").unwrap();
+    assert_eq!(col.default, None);
+}
+
+#[test]
+fn default_null_cast_stored_as_no_default() {
+    let sql = "CREATE TABLE t (col TEXT[] DEFAULT NULL::text[]);";
+    let schema = parse_sql_string(sql).unwrap();
+    let col = schema.tables["public.t"].columns.get("col").unwrap();
+    assert_eq!(col.default, None);
+}
+
+#[test]
+fn default_string_null_literal_preserved() {
+    let sql = "CREATE TABLE t (col TEXT DEFAULT 'NULL'::text);";
+    let schema = parse_sql_string(sql).unwrap();
+    let col = schema.tables["public.t"].columns.get("col").unwrap();
+    assert_eq!(col.default, Some("'NULL'::text".to_string()));
+}
+
+#[test]
+fn default_coalesce_with_null_preserved() {
+    let sql = "CREATE TABLE t (col TEXT DEFAULT COALESCE(NULL, 'x'));";
+    let schema = parse_sql_string(sql).unwrap();
+    let col = schema.tables["public.t"].columns.get("col").unwrap();
+    assert!(col.default.is_some(), "COALESCE(NULL, 'x') is not a null default");
+}
+
+#[test]
 fn parses_trigger_on_cross_schema_table_with_qualified_function() {
     // Bug: triggers on non-public schema tables are not parsed correctly
     // when the function is also in a non-public schema

--- a/src/pg/introspect.rs
+++ b/src/pg/introspect.rs
@@ -1537,7 +1537,7 @@ async fn introspect_functions(
         let arguments = if let Some(modes) = arg_modes_raw {
             arguments
                 .into_iter()
-                .zip(modes.into_iter())
+                .zip(modes)
                 .map(|(mut arg, mode)| {
                     arg.mode = match pg_char(mode) {
                         'o' => crate::model::ArgMode::Out,

--- a/tests/corpus/handcrafted_type_aliases.sql
+++ b/tests/corpus/handcrafted_type_aliases.sql
@@ -1,4 +1,3 @@
--- IGNORE: pgmold-255 DEFAULT NULL normalization loops on labels column
 -- Source: hand-crafted for pgmold
 -- Commit: n/a
 -- License: Apache-2.0


### PR DESCRIPTION
Closes pgmold-255. Parser stored default=Some(NULL) but PostgreSQL treats DEFAULT NULL as no-op, causing convergence loops. Now parser unwraps Cast and detects Value::Null, storing None. Tests for upper/lower/cast NULL plus preserved 'NULL'::text and COALESCE(NULL, 'x'). Un-ignores type_aliases corpus entry.