### PR TITLE
chore(deps): bump pgmold-sqlparser to 0.60.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1612,9 +1612,9 @@ dependencies = [
 
 [[package]]
 name = "pgmold-sqlparser"
-version = "0.60.6"
+version = "0.60.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6abe4eaef0491924fbc74efecd8ffc28c31df5d5f9754a753fa5a095664d"
+checksum = "4defe72e2992767ad64aed06c057969eb76166d4fbacdba860755b9cc98a06b8"
 dependencies = [
  "log",
  "recursive",
@@ -2398,9 +2398,9 @@ dependencies = [
 
 [[package]]
 name = "sqlparser_derive"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "028e551d5e270b31b9f3ea271778d9d827148d4287a5d96167b6bb9787f5cc38"
+checksum = "a6dd45d8fc1c79299bfbb7190e42ccbbdf6a5f52e4a6ad98d92357ea965bd289"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2613,7 +2613,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.52.0",
  "windows-sys 0.59.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["command-line-utilities", "database"]
 clap = { version = "4.5", features = ["derive", "env"] }
 tokio = { version = "1.35", features = ["full"] }
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres"] }
-sqlparser = { package = "pgmold-sqlparser", version = "0.60.6", features = ["visitor"] }
+sqlparser = { package = "pgmold-sqlparser", version = "0.60.7", features = ["visitor"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 anyhow = "1.0"
@@ -43,4 +43,4 @@ name = "performance"
 harness = false
 
 [build-dependencies]
-sqlparser = { package = "pgmold-sqlparser", version = "0.60.6", features = ["visitor"] }
+sqlparser = { package = "pgmold-sqlparser", version = "0.60.7", features = ["visitor"] }

--- a/src/parser/functions.rs
+++ b/src/parser/functions.rs
@@ -2,8 +2,8 @@ use crate::model::*;
 use crate::pg::sqlgen::strip_ident_quotes;
 use crate::util::{Result, SchemaError};
 use sqlparser::ast::{
-    ArgMode as SqlArgMode, CreateFunctionBody, DataType, FunctionBehavior,
-    FunctionDefinitionSetParam, FunctionSecurity, FunctionSetValue, Ident, OperateFunctionArg,
+    ArgMode as SqlArgMode, CreateFunctionBody, FunctionBehavior, FunctionDefinitionSetParam,
+    FunctionReturnType, FunctionSecurity, FunctionSetValue, Ident, OperateFunctionArg,
 };
 
 use crate::util::strip_dollar_quotes;
@@ -13,7 +13,7 @@ pub(super) fn parse_create_function(
     schema: &str,
     name: &str,
     args: Option<&[OperateFunctionArg]>,
-    return_type: Option<&DataType>,
+    return_type: Option<&FunctionReturnType>,
     function_body: Option<&CreateFunctionBody>,
     language: Option<&Ident>,
     behavior: Option<&FunctionBehavior>,
@@ -70,6 +70,7 @@ pub(super) fn parse_create_function(
                         Some(SqlArgMode::In) => ArgMode::In,
                         Some(SqlArgMode::Out) => ArgMode::Out,
                         Some(SqlArgMode::InOut) => ArgMode::InOut,
+                        Some(SqlArgMode::Variadic) => ArgMode::In,
                         None => ArgMode::In,
                     };
                     FunctionArg {
@@ -94,6 +95,7 @@ pub(super) fn parse_create_function(
                     .collect::<Vec<_>>()
                     .join(", "),
                 FunctionSetValue::FromCurrent => "FROM CURRENT".to_string(),
+                FunctionSetValue::Default => "DEFAULT".to_string(),
             };
             (key, value)
         })

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -154,7 +154,7 @@ pub fn parse_sql_string(sql: &str) -> Result<Schema> {
                 let key = qualified_name(&enum_schema, &enum_name);
                 schema.enums.insert(key, enum_type);
             }
-            Statement::CreatePolicy {
+            Statement::CreatePolicy(sqlparser::ast::CreatePolicy {
                 name,
                 table_name,
                 command,
@@ -162,7 +162,7 @@ pub fn parse_sql_string(sql: &str) -> Result<Schema> {
                 using,
                 with_check,
                 ..
-            } => {
+            }) => {
                 let (tbl_schema, tbl_name) = extract_qualified_name(&table_name);
                 let policy = Policy {
                     name: unquote_ident(&name.to_string()).to_string(),
@@ -172,7 +172,7 @@ pub fn parse_sql_string(sql: &str) -> Result<Schema> {
                     roles: {
                         let parsed_roles: Vec<String> = to
                             .iter()
-                            .flat_map(|owners| {
+                            .flat_map(|owners: &Vec<sqlparser::ast::Owner>| {
                                 owners.iter().map(|o| strip_ident_quotes(&o.to_string()))
                             })
                             .collect();
@@ -182,8 +182,8 @@ pub fn parse_sql_string(sql: &str) -> Result<Schema> {
                             parsed_roles
                         }
                     },
-                    using_expr: using.as_ref().map(|e| normalize_expr(&e.to_string())),
-                    check_expr: with_check.as_ref().map(|e| normalize_expr(&e.to_string())),
+                    using_expr: using.as_ref().map(|e: &sqlparser::ast::Expr| normalize_expr(&e.to_string())),
+                    check_expr: with_check.as_ref().map(|e: &sqlparser::ast::Expr| normalize_expr(&e.to_string())),
                 };
                 schema.pending_policies.push(policy);
             }
@@ -432,9 +432,10 @@ pub fn parse_sql_string(sql: &str) -> Result<Schema> {
                         | AlterTableOperation::DropClusteringKey
                         | AlterTableOperation::SuspendRecluster
                         | AlterTableOperation::ResumeRecluster
-                        | AlterTableOperation::Refresh
+                        | AlterTableOperation::Refresh { .. }
                         | AlterTableOperation::Suspend
-                        | AlterTableOperation::Resume => {}
+                        | AlterTableOperation::Resume
+                        | AlterTableOperation::AlterSortKey { .. } => {}
                     }
                 }
             }
@@ -611,7 +612,9 @@ pub fn parse_sql_string(sql: &str) -> Result<Schema> {
                         | TableConstraint::ForeignKey(_)
                         | TableConstraint::Index(_)
                         | TableConstraint::FulltextOrSpatial(_)
-                        | TableConstraint::Exclusion(_) => {
+                        | TableConstraint::Exclusion(_)
+                        | TableConstraint::PrimaryKeyUsingIndex(_)
+                        | TableConstraint::UniqueUsingIndex(_) => {
                             let constraint_str = constraint.to_string().to_uppercase();
                             if constraint_str.contains("NOT NULL") {
                                 not_null = true;
@@ -835,7 +838,8 @@ pub fn parse_sql_string(sql: &str) -> Result<Schema> {
                         | ObjectType::Role
                         | ObjectType::User
                         | ObjectType::Stage
-                        | ObjectType::Stream => {}
+                        | ObjectType::Stream
+                        | ObjectType::Collation => {}
                     }
                 }
             }
@@ -880,9 +884,9 @@ pub fn parse_sql_string(sql: &str) -> Result<Schema> {
                 schema.triggers.remove(&trigger_key);
             }
             Statement::DropTrigger(DropTrigger { .. }) => {}
-            Statement::DropPolicy {
+            Statement::DropPolicy(sqlparser::ast::DropPolicy {
                 name, table_name, ..
-            } => {
+            }) => {
                 let (tbl_schema, tbl_name) = extract_qualified_name(&table_name);
                 let tbl_key = qualified_name(&tbl_schema, &tbl_name);
                 let policy_name = unquote_ident(&name.to_string()).to_string();
@@ -1074,7 +1078,17 @@ pub fn parse_sql_string(sql: &str) -> Result<Schema> {
             // form) are currently dropped. This is a real pgmold gap tracked
             // separately; the previously wildcarded behaviour is preserved
             // here.
-            | Statement::CreateType { .. } => {}
+            | Statement::CreateType { .. }
+            | Statement::AlterFunction(_)
+            | Statement::AlterCollation(_)
+            | Statement::AlterOperatorFamily(_)
+            | Statement::AlterOperatorClass(_)
+            | Statement::CreateCollation(_)
+            | Statement::ShowCatalogs { .. }
+            | Statement::ShowProcessList { .. }
+            | Statement::Lock(_)
+            | Statement::Throw(_)
+            | Statement::WaitFor(_) => {}
             Statement::CreateServer(stmt) => {
                 parse_create_server(stmt, &mut schema);
             }

--- a/src/parser/tables.rs
+++ b/src/parser/tables.rs
@@ -307,7 +307,10 @@ pub(super) fn parse_create_table(
             // MySQL-specific constraints that have no PostgreSQL equivalent.
             // Listed explicitly (instead of a bare `_`) so adding a new
             // `TableConstraint` variant upstream forces a compile-time review.
-            TableConstraint::Index(_) | TableConstraint::FulltextOrSpatial(_) => {}
+            TableConstraint::Index(_)
+            | TableConstraint::FulltextOrSpatial(_)
+            | TableConstraint::PrimaryKeyUsingIndex(_)
+            | TableConstraint::UniqueUsingIndex(_) => {}
         }
     }
 
@@ -611,7 +614,9 @@ fn parse_partition_by(expr: &Expr) -> Option<PartitionKey> {
                 // emit. Ignored, but enumerated so upstream additions force
                 // review.
                 SqlFunctionArg::Unnamed(
-                    FunctionArgExpr::QualifiedWildcard(_) | FunctionArgExpr::Wildcard,
+                    FunctionArgExpr::QualifiedWildcard(_)
+                    | FunctionArgExpr::Wildcard
+                    | FunctionArgExpr::WildcardWithOptions(_),
                 )
                 | SqlFunctionArg::Named { .. }
                 | SqlFunctionArg::ExprNamed { .. } => None,

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -540,7 +540,7 @@ fn normalize_query(query: &Query) -> Query {
                     alias: cte.alias.clone(),
                     query: Box::new(normalize_query(&cte.query)),
                     from: cte.from.clone(),
-                    materialized: cte.materialized.clone(),
+                    materialized: cte.materialized,
                     closing_paren_token: cte.closing_paren_token.clone(),
                 })
                 .collect(),

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -811,6 +811,7 @@ fn normalize_table_factor(factor: &sqlparser::ast::TableFactor) -> sqlparser::as
             lateral,
             subquery,
             alias,
+            sample,
         } => TableFactor::Derived {
             lateral: *lateral,
             subquery: Box::new(normalize_query(subquery)),
@@ -819,6 +820,7 @@ fn normalize_table_factor(factor: &sqlparser::ast::TableFactor) -> sqlparser::as
                 explicit: a.explicit,
                 columns: a.columns.clone(),
             }),
+            sample: sample.clone(),
         },
         // Handle nested/parenthesized JOINs - PostgreSQL often wraps JOINs in parens
         // We unwrap by normalizing the inner TableWithJoins and returning the relation directly
@@ -1022,6 +1024,8 @@ fn normalize_select(select: &Select) -> Select {
         value_table_mode: select.value_table_mode,
         connect_by: select.connect_by.clone(),
         flavor: select.flavor.clone(),
+        optimizer_hints: select.optimizer_hints.clone(),
+        select_modifiers: select.select_modifiers.clone(),
     }
 }
 
@@ -1168,6 +1172,7 @@ fn normalize_expr(expr: &Expr) -> Expr {
                 kind: CastKind::DoubleColon,
                 expr: Box::new(norm_inner),
                 data_type: norm_data_type,
+                array: false,
                 format: format.clone(),
             }
         }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1023,7 +1023,7 @@ fn normalize_select(select: &Select) -> Select {
         window_before_qualify: select.window_before_qualify,
         value_table_mode: select.value_table_mode,
         connect_by: select.connect_by.clone(),
-        flavor: select.flavor.clone(),
+        flavor: select.flavor,
         optimizer_hints: select.optimizer_hints.clone(),
         select_modifiers: select.select_modifiers.clone(),
     }


### PR DESCRIPTION
## Summary

Bumps pgmold-sqlparser from 0.60.6 to 0.60.7. Picks up 133 upstream commits from apache/datafusion-sqlparser-rs including:

- CREATE COLLATION support (closes pgmold-90)
- ALTER FUNCTION SET/RESET support (closes pgmold-111)
- ALTER AGGREGATE support (closes pgmold-117)

## API migration

16 compilation errors fixed across 4 files:
- New Statement/AlterTableOperation/TableConstraint variants added to match arms
- CreatePolicy/DropPolicy struct-ified (moved from inline enum fields)
- CreateFunction.return_type changed to FunctionReturnType
- Select gained optimizer_hints + select_modifiers fields
- Expr::Cast gained array field

## Test plan

- [ ] All existing tests pass (API changes are mechanical, no behavioral changes)
- [ ] CI green across PG 13-17