### PR TITLE
parser: bump sqlparser to 0.60.8, pass through 7 new DDL variants

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["command-line-utilities", "database"]
 clap = { version = "4.5", features = ["derive", "env"] }
 tokio = { version = "1.35", features = ["full"] }
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres"] }
-sqlparser = { package = "pgmold-sqlparser", version = "0.60.7", features = ["visitor"] }
+sqlparser = { package = "pgmold-sqlparser", version = "0.60.8", features = ["visitor"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 anyhow = "1.0"
@@ -37,11 +37,11 @@ sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres"] }
 tokio = { version = "1.35", features = ["full"] }
 assert_cmd = "2"
 criterion = { version = "0.5", features = ["html_reports"] }
-sqlparser = { package = "pgmold-sqlparser", version = "0.60.7", features = ["visitor"] }
+sqlparser = { package = "pgmold-sqlparser", version = "0.60.8", features = ["visitor"] }
 
 [[bench]]
 name = "performance"
 harness = false
 
 [build-dependencies]
-sqlparser = { package = "pgmold-sqlparser", version = "0.60.7", features = ["visitor"] }
+sqlparser = { package = "pgmold-sqlparser", version = "0.60.8", features = ["visitor"] }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -983,8 +983,10 @@ pub fn parse_sql_string(sql: &str) -> Result<Schema> {
             | Statement::AlterUser(_)
             | Statement::CreateDatabase { .. }
             | Statement::AttachDatabase { .. }
-            // Procedures, macros, operators, domains-as-alter — pgmold does
-            // not yet model these. Tracked as future work.
+            // Procedures, macros, operators, aggregates, text search,
+            // foreign tables / FDWs, domains-as-alter — pgmold does not yet
+            // model these. Parse-through keeps the rest of the schema valid;
+            // deeper modelling is tracked as future work.
             | Statement::CreateProcedure { .. }
             | Statement::DropProcedure { .. }
             | Statement::CreateMacro { .. }
@@ -994,7 +996,14 @@ pub fn parse_sql_string(sql: &str) -> Result<Schema> {
             | Statement::AlterOperator(_)
             | Statement::DropOperator(_)
             | Statement::DropOperatorClass(_)
-            | Statement::DropOperatorFamily(_) => {}
+            | Statement::DropOperatorFamily(_)
+            | Statement::CreateAggregate(_)
+            | Statement::CreateTextSearchConfiguration(_)
+            | Statement::CreateTextSearchDictionary(_)
+            | Statement::CreateTextSearchParser(_)
+            | Statement::CreateTextSearchTemplate(_)
+            | Statement::CreateForeignTable(_)
+            | Statement::CreateForeignDataWrapper(_) => {}
             Statement::AlterIndex { name, operation } => {
                 let (idx_schema, idx_name) = extract_qualified_name(&name);
                 match operation {


### PR DESCRIPTION
## Summary

Bumps \`pgmold-sqlparser\` from 0.60.7 to 0.60.8 and adds no-op match arms for the seven new \`Statement\` variants the bump introduces. Closes seven pgmold-84 sub-tickets at the parse-through-OK level, matching the precedent set by pgmold-86 (CREATE OPERATOR).

## Tickets closed

- pgmold-85 — CREATE AGGREGATE
- pgmold-94 — CREATE TEXT SEARCH CONFIGURATION
- pgmold-95 — CREATE TEXT SEARCH DICTIONARY
- pgmold-96 — CREATE TEXT SEARCH PARSER
- pgmold-97 — CREATE TEXT SEARCH TEMPLATE
- pgmold-98 — CREATE FOREIGN TABLE
- pgmold-100 — CREATE FOREIGN DATA WRAPPER

## Upstream

Grammar for these object types landed in \`pgmold-sqlparser 0.60.8\` via fork PRs #6, #7, #8 and a spans fix in fork PR #10.

## Scope

- \`Cargo.toml\` / dev / build deps: 0.60.7 → 0.60.8
- \`src/parser/mod.rs\`: extend the existing pass-through block to cover all seven new \`Statement\` variants

Deeper modelling (introspection, sqlgen, diff, apply round-trips) for any of these would be filed as separate tickets when a real schema needs it.

## Test plan

- [x] CI goes green (format, clippy, build, test, integration, corpus, PG 13–17 matrix)
- [x] \`Parser Coverage Triage\` job should still pass; its bucket totals will flip from 24 \`needs_fork\` to 17 once this lands