### PR TITLE
parser: bump sqlparser to 0.60.9, pass through 7 more DDL variants

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["command-line-utilities", "database"]
 clap = { version = "4.5", features = ["derive", "env"] }
 tokio = { version = "1.35", features = ["full"] }
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres"] }
-sqlparser = { package = "pgmold-sqlparser", version = "0.60.8", features = ["visitor"] }
+sqlparser = { package = "pgmold-sqlparser", version = "0.60.9", features = ["visitor"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 anyhow = "1.0"
@@ -37,11 +37,11 @@ sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres"] }
 tokio = { version = "1.35", features = ["full"] }
 assert_cmd = "2"
 criterion = { version = "0.5", features = ["html_reports"] }
-sqlparser = { package = "pgmold-sqlparser", version = "0.60.8", features = ["visitor"] }
+sqlparser = { package = "pgmold-sqlparser", version = "0.60.9", features = ["visitor"] }
 
 [[bench]]
 name = "performance"
 harness = false
 
 [build-dependencies]
-sqlparser = { package = "pgmold-sqlparser", version = "0.60.8", features = ["visitor"] }
+sqlparser = { package = "pgmold-sqlparser", version = "0.60.9", features = ["visitor"] }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -435,7 +435,10 @@ pub fn parse_sql_string(sql: &str) -> Result<Schema> {
                         | AlterTableOperation::Refresh { .. }
                         | AlterTableOperation::Suspend
                         | AlterTableOperation::Resume
-                        | AlterTableOperation::AlterSortKey { .. } => {}
+                        | AlterTableOperation::AlterSortKey { .. }
+                        // Changing tablespace is a storage move, not a
+                        // schema change — pgmold does not track tablespaces.
+                        | AlterTableOperation::SetTablespace { .. } => {}
                     }
                 }
             }
@@ -1003,7 +1006,12 @@ pub fn parse_sql_string(sql: &str) -> Result<Schema> {
             | Statement::CreateTextSearchParser(_)
             | Statement::CreateTextSearchTemplate(_)
             | Statement::CreateForeignTable(_)
-            | Statement::CreateForeignDataWrapper(_) => {}
+            | Statement::CreateForeignDataWrapper(_)
+            | Statement::CreatePublication(_)
+            | Statement::CreateSubscription(_)
+            | Statement::AlterDomain(_)
+            | Statement::AlterTrigger(_)
+            | Statement::AlterExtension(_) => {}
             Statement::AlterIndex { name, operation } => {
                 let (idx_schema, idx_name) = extract_qualified_name(&name);
                 match operation {
@@ -1035,6 +1043,9 @@ pub fn parse_sql_string(sql: &str) -> Result<Schema> {
                             )));
                         }
                     }
+                    // Changing tablespace is a storage move, not a schema
+                    // change — pgmold does not track tablespaces.
+                    AlterIndexOperation::SetTablespace { .. } => {}
                 }
             }
             // pgmold consumes `AlterTable` (above) but not these sibling


### PR DESCRIPTION
## Summary

Bumps \`pgmold-sqlparser\` from 0.60.8 to 0.60.9 and wires pass-through arms for the new DDL variants. Closes seven more pgmold-84 sub-tickets at the parse-through-OK level.

## Tickets closed

- pgmold-101 — CREATE PUBLICATION
- pgmold-102 — CREATE SUBSCRIPTION
- pgmold-109 — ALTER TABLE SET TABLESPACE
- pgmold-113 — ALTER DOMAIN ADD/DROP CONSTRAINT (and OWNER TO / RENAME / SET SCHEMA / SET DEFAULT / VALIDATE CONSTRAINT)
- pgmold-124 — ALTER TRIGGER RENAME
- pgmold-126 — ALTER EXTENSION UPDATE / SET SCHEMA / OWNER TO / RENAME
- pgmold-130 — ALTER PROCEDURE (via \`AlterFunctionKind::Procedure\`)

## Upstream

Grammar landed in \`pgmold-sqlparser 0.60.9\` via fork PRs #11 (logical replication) and #12 (alter-set group).

## Scope

- \`Cargo.toml\` / dev / build deps: 0.60.8 → 0.60.9
- \`src/parser/mod.rs\`:
  - Five new top-level Statement arms added to the existing pass-through block: \`CreatePublication\`, \`CreateSubscription\`, \`AlterDomain\`, \`AlterTrigger\`, \`AlterExtension\`.
  - Two new inner-enum arms (pgmold already enumerates these): \`AlterTableOperation::SetTablespace\` and \`AlterIndexOperation::SetTablespace\`.
  - ALTER PROCEDURE is covered for free by the existing \`Statement::AlterFunction\` no-op arm via the new \`AlterFunctionKind::Procedure\` variant.

Deeper modelling (introspection, sqlgen, diff, apply round-trips) for any of these would be filed as separate tickets when a real schema needs it.

## Test plan

- [x] CI goes green (format, clippy, build, test, integration, corpus, PG 13–17 matrix)
- [x] \`Parser Coverage Triage\` job bucket totals should flip 7 more tickets from \`needs_fork\` to \`arm_gap\`