### PR TITLE
parser: bump sqlparser to 0.60.10, close pgmold-84 epic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["command-line-utilities", "database"]
 clap = { version = "4.5", features = ["derive", "env"] }
 tokio = { version = "1.35", features = ["full"] }
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres"] }
-sqlparser = { package = "pgmold-sqlparser", version = "0.60.9", features = ["visitor"] }
+sqlparser = { package = "pgmold-sqlparser", version = "0.60.10", features = ["visitor"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 anyhow = "1.0"
@@ -37,11 +37,11 @@ sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres"] }
 tokio = { version = "1.35", features = ["full"] }
 assert_cmd = "2"
 criterion = { version = "0.5", features = ["html_reports"] }
-sqlparser = { package = "pgmold-sqlparser", version = "0.60.9", features = ["visitor"] }
+sqlparser = { package = "pgmold-sqlparser", version = "0.60.10", features = ["visitor"] }
 
 [[bench]]
 name = "performance"
 harness = false
 
 [build-dependencies]
-sqlparser = { package = "pgmold-sqlparser", version = "0.60.9", features = ["visitor"] }
+sqlparser = { package = "pgmold-sqlparser", version = "0.60.10", features = ["visitor"] }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1011,7 +1011,18 @@ pub fn parse_sql_string(sql: &str) -> Result<Schema> {
             | Statement::CreateSubscription(_)
             | Statement::AlterDomain(_)
             | Statement::AlterTrigger(_)
-            | Statement::AlterExtension(_) => {}
+            | Statement::AlterExtension(_)
+            | Statement::CreateCast(_)
+            | Statement::CreateConversion(_)
+            | Statement::CreateLanguage(_)
+            | Statement::CreateRule(_)
+            | Statement::CreateStatistics(_)
+            | Statement::CreateAccessMethod(_)
+            | Statement::CreateEventTrigger(_)
+            | Statement::CreateTransform(_)
+            | Statement::SecurityLabel(_)
+            | Statement::CreateUserMapping(_)
+            | Statement::CreateTablespace(_) => {}
             Statement::AlterIndex { name, operation } => {
                 let (idx_schema, idx_name) = extract_qualified_name(&name);
                 match operation {


### PR DESCRIPTION
## Summary

Bumps \`pgmold-sqlparser\` from 0.60.9 to 0.60.10 and wires pass-through arms for the 11 new DDL variants introduced in that version. Closes the final batch of pgmold-84 sub-tickets at the parse-through-OK level.

## Tickets closed

- pgmold-89 — CREATE CAST
- pgmold-91 — CREATE CONVERSION
- pgmold-92 — CREATE LANGUAGE
- pgmold-93 — CREATE RULE
- pgmold-103 — CREATE STATISTICS
- pgmold-104 — CREATE ACCESS METHOD
- pgmold-105 — CREATE EVENT TRIGGER
- pgmold-106 — CREATE TRANSFORM
- pgmold-115 — SECURITY LABEL
- pgmold-119 — CREATE USER MAPPING
- pgmold-120 — CREATE TABLESPACE

## Upstream

Grammar landed in \`pgmold-sqlparser 0.60.10\` via fork PRs #14 (security-storage), #15 (catalog-extended), and #16 (catalog-small).

## Scope

- \`Cargo.toml\` / dev / build deps: 0.60.9 → 0.60.10
- \`src/parser/mod.rs\`: 11 new top-level \`Statement\` variants added to the existing pass-through block.

## pgmold-84 status after this lands

The parser-coverage epic has one remaining concern: the dashboard harness in \`tests/parser_coverage_triage.rs\`. After this PR, every probe entry should flip from \`needs_fork\` to \`arm_gap\` (parses, but no schema effect). Deeper modelling (introspection / diff / apply round-trips) for any of these objects is a separate concern that gets filed when a real schema needs it.

## Test plan

- [x] CI goes green (format, clippy, build, test, integration, corpus, PG 13–17 matrix)
- [x] \`Parser Coverage Triage\` job bucket totals should now be \`arm_gap: 25\`, \`needs_fork: 0\`