### PR TITLE
perf(model): return Cow from normalize_pg_type

### DIFF
--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -2045,10 +2045,7 @@ mod tests {
     fn normalize_pg_type_allocates_only_when_case_folding_needed() {
         assert!(matches!(normalize_pg_type("Integer"), Cow::Owned(_)));
         assert!(matches!(normalize_pg_type("INT4"), Cow::Borrowed(_)));
-        assert!(matches!(
-            normalize_pg_type("TABLE(a int)"),
-            Cow::Owned(_)
-        ));
+        assert!(matches!(normalize_pg_type("TABLE(a int)"), Cow::Owned(_)));
     }
 
     #[test]

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1,5 +1,6 @@
 use crate::util::{expressions_semantically_equal, views_semantically_equal};
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 
@@ -1316,7 +1317,11 @@ impl Function {
 ///
 /// For `TABLE(...)` return types, quoted column names are preserved verbatim
 /// (they are case-sensitive in PostgreSQL), while type keywords are normalized.
-pub fn normalize_pg_type(type_name: &str) -> String {
+///
+/// Returns `Cow::Borrowed` when the input is already canonical (no `public.` prefix,
+/// no uppercase, and either already a canonical alias target or a non-alias identifier),
+/// which lets hot comparison paths skip an allocation.
+pub fn normalize_pg_type(type_name: &str) -> Cow<'_, str> {
     let trimmed = type_name.trim();
 
     if trimmed.len() >= 6 && trimmed[..6].eq_ignore_ascii_case("table(") && trimmed.ends_with(')') {
@@ -1328,32 +1333,42 @@ pub fn normalize_pg_type(type_name: &str) -> String {
                     .expect("BUG: unclosed quote in TABLE column definition")
             })
             .collect();
-        return format!("table({})", normalized_cols.join(", "));
+        return Cow::Owned(format!("table({})", normalized_cols.join(", ")));
     }
 
     // Strip public. schema prefix — PostgreSQL qualifies user-defined types
     // in function signatures but SQL declarations typically omit it
     let trimmed = trimmed.strip_prefix("public.").unwrap_or(trimmed);
 
-    let lower: std::borrow::Cow<str> = if trimmed.bytes().any(|b| b.is_ascii_uppercase()) {
-        std::borrow::Cow::Owned(trimmed.to_lowercase())
-    } else {
-        std::borrow::Cow::Borrowed(trimmed)
-    };
-    match lower.as_ref() {
-        "int" | "int4" => "integer".to_string(),
-        "int8" => "bigint".to_string(),
-        "int2" => "smallint".to_string(),
-        "float4" => "real".to_string(),
-        "float8" => "double precision".to_string(),
-        "bool" => "boolean".to_string(),
-        "varchar" => "character varying".to_string(),
-        "timestamp" => "timestamp without time zone".to_string(),
-        "timestamptz" => "timestamp with time zone".to_string(),
-        "time" => "time without time zone".to_string(),
-        "timetz" => "time with time zone".to_string(),
-        _ => lower.into_owned(),
+    if !trimmed.bytes().any(|b| b.is_ascii_uppercase()) {
+        return match canonical_alias(trimmed) {
+            Some(canon) => Cow::Borrowed(canon),
+            None => Cow::Borrowed(trimmed),
+        };
     }
+
+    let lower = trimmed.to_lowercase();
+    match canonical_alias(&lower) {
+        Some(canon) => Cow::Borrowed(canon),
+        None => Cow::Owned(lower),
+    }
+}
+
+fn canonical_alias(lowercase: &str) -> Option<&'static str> {
+    Some(match lowercase {
+        "int" | "int4" => "integer",
+        "int8" => "bigint",
+        "int2" => "smallint",
+        "float4" => "real",
+        "float8" => "double precision",
+        "bool" => "boolean",
+        "varchar" => "character varying",
+        "timestamp" => "timestamp without time zone",
+        "timestamptz" => "timestamp with time zone",
+        "time" => "time without time zone",
+        "timetz" => "time with time zone",
+        _ => return None,
+    })
 }
 
 /// Normalizes a single column definition within a `TABLE(...)` return type.
@@ -2011,6 +2026,29 @@ mod tests {
             normalize_pg_type("time(3) with time zone"),
             "time(3) with time zone"
         );
+    }
+
+    #[test]
+    fn normalize_pg_type_borrows_for_already_canonical_input() {
+        assert!(matches!(normalize_pg_type("integer"), Cow::Borrowed(_)));
+        assert!(matches!(normalize_pg_type("text"), Cow::Borrowed(_)));
+        assert!(matches!(normalize_pg_type("uuid"), Cow::Borrowed(_)));
+        assert!(matches!(
+            normalize_pg_type("timestamp with time zone"),
+            Cow::Borrowed(_)
+        ));
+        assert!(matches!(normalize_pg_type("int"), Cow::Borrowed(_)));
+        assert!(matches!(normalize_pg_type("float8"), Cow::Borrowed(_)));
+    }
+
+    #[test]
+    fn normalize_pg_type_allocates_only_when_case_folding_needed() {
+        assert!(matches!(normalize_pg_type("Integer"), Cow::Owned(_)));
+        assert!(matches!(normalize_pg_type("INT4"), Cow::Borrowed(_)));
+        assert!(matches!(
+            normalize_pg_type("TABLE(a int)"),
+            Cow::Owned(_)
+        ));
     }
 
     #[test]
@@ -3084,13 +3122,13 @@ fn function_timestamp_param_no_perpetual_diff() {
         arguments: vec![
             FunctionArg {
                 name: Some("event_time".to_string()),
-                data_type: normalize_pg_type("timestamp"),
+                data_type: normalize_pg_type("timestamp").into_owned(),
                 mode: ArgMode::In,
                 default: None,
             },
             FunctionArg {
                 name: Some("log_time".to_string()),
-                data_type: normalize_pg_type("time"),
+                data_type: normalize_pg_type("time").into_owned(),
                 mode: ArgMode::In,
                 default: None,
             },

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1318,9 +1318,18 @@ impl Function {
 /// For `TABLE(...)` return types, quoted column names are preserved verbatim
 /// (they are case-sensitive in PostgreSQL), while type keywords are normalized.
 ///
-/// Returns `Cow::Borrowed` when the input is already canonical (no `public.` prefix,
-/// no uppercase, and either already a canonical alias target or a non-alias identifier),
-/// which lets hot comparison paths skip an allocation.
+/// The return value is `Cow::Borrowed` on two paths:
+///   - Input is already ASCII-lowercase and not an alias → borrow the input slice.
+///   - Input (lower- or upper-case) resolves to a known alias → borrow the `'static`
+///     canonical target. Uppercase inputs still allocate transiently to lowercase,
+///     but the returned `Cow` does not own that buffer.
+/// Otherwise (uppercase non-alias, or `TABLE(...)` expansion) the return is `Cow::Owned`.
+///
+/// The main perf win is at comparison sites (`Function::semantically_equals`,
+/// `FunctionArg::semantically_equals`), which compare two `Cow`s via `PartialEq`
+/// without ever owning: canonical-on-both-sides comparisons now allocate zero times
+/// vs. two times previously. Sites that immediately `.into_owned()` (struct field
+/// assignments in `pg/introspect.rs`, `parser/functions.rs`) see no net change.
 pub fn normalize_pg_type(type_name: &str) -> Cow<'_, str> {
     let trimmed = type_name.trim();
 
@@ -2029,7 +2038,10 @@ mod tests {
     }
 
     #[test]
-    fn normalize_pg_type_borrows_for_already_canonical_input() {
+    fn normalize_pg_type_zero_alloc_path_for_lowercase_input() {
+        // Inputs that are already ASCII-lowercase take the zero-allocation fast path
+        // (no transient to_lowercase), and return Borrowed — either into the input
+        // slice (non-alias) or into a 'static canonical target (alias).
         assert!(matches!(normalize_pg_type("integer"), Cow::Borrowed(_)));
         assert!(matches!(normalize_pg_type("text"), Cow::Borrowed(_)));
         assert!(matches!(normalize_pg_type("uuid"), Cow::Borrowed(_)));
@@ -2042,9 +2054,20 @@ mod tests {
     }
 
     #[test]
-    fn normalize_pg_type_allocates_only_when_case_folding_needed() {
-        assert!(matches!(normalize_pg_type("Integer"), Cow::Owned(_)));
+    fn normalize_pg_type_borrows_static_for_uppercase_alias() {
+        // Uppercase alias input still allocates for to_lowercase(), but the returned
+        // Cow borrows the 'static canonical target rather than owning a copy.
         assert!(matches!(normalize_pg_type("INT4"), Cow::Borrowed(_)));
+        assert_eq!(normalize_pg_type("INT4"), "integer");
+        assert!(matches!(normalize_pg_type("FLOAT8"), Cow::Borrowed(_)));
+        assert_eq!(normalize_pg_type("FLOAT8"), "double precision");
+    }
+
+    #[test]
+    fn normalize_pg_type_owned_when_no_borrow_possible() {
+        // Uppercase non-alias must own the lowercased result; TABLE(...) must own
+        // the re-materialized expansion.
+        assert!(matches!(normalize_pg_type("Integer"), Cow::Owned(_)));
         assert!(matches!(normalize_pg_type("TABLE(a int)"), Cow::Owned(_)));
     }
 

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1318,16 +1318,15 @@ impl Function {
 /// For `TABLE(...)` return types, quoted column names are preserved verbatim
 /// (they are case-sensitive in PostgreSQL), while type keywords are normalized.
 ///
-/// The return value is `Cow::Borrowed` on two paths:
-///   - Input is already ASCII-lowercase and not an alias → borrow the input slice.
-///   - Input (lower- or upper-case) resolves to a known alias → borrow the `'static`
-///     canonical target. Uppercase inputs still allocate transiently to lowercase,
-///     but the returned `Cow` does not own that buffer.
-/// Otherwise (uppercase non-alias, or `TABLE(...)` expansion) the return is `Cow::Owned`.
+/// Returns `Cow::Borrowed` in two cases: an ASCII-lowercase non-alias input
+/// borrows the input slice, and any alias (upper- or lower-case) borrows the
+/// `'static` canonical target. Uppercase alias inputs still allocate transiently
+/// for case folding, but the returned `Cow` does not own that buffer. Uppercase
+/// non-alias and `TABLE(...)` expansion return `Cow::Owned`.
 ///
 /// The main perf win is at comparison sites (`Function::semantically_equals`,
 /// `FunctionArg::semantically_equals`), which compare two `Cow`s via `PartialEq`
-/// without ever owning: canonical-on-both-sides comparisons now allocate zero times
+/// without ever owning: canonical-on-both-sides comparisons allocate zero times
 /// vs. two times previously. Sites that immediately `.into_owned()` (struct field
 /// assignments in `pg/introspect.rs`, `parser/functions.rs`) see no net change.
 pub fn normalize_pg_type(type_name: &str) -> Cow<'_, str> {

--- a/src/parser/functions.rs
+++ b/src/parser/functions.rs
@@ -21,7 +21,7 @@ pub(super) fn parse_create_function(
     set_params: &[FunctionDefinitionSetParam],
 ) -> Result<Function> {
     let return_type_str = return_type
-        .map(|rt| normalize_pg_type(&rt.to_string()))
+        .map(|rt| normalize_pg_type(&rt.to_string()).into_owned())
         .ok_or_else(|| {
             SchemaError::ParseError(format!(
                 "Function {schema}.{name} is missing RETURNS clause"
@@ -75,7 +75,7 @@ pub(super) fn parse_create_function(
                     };
                     FunctionArg {
                         name: arg.name.as_ref().map(|n| strip_ident_quotes(&n.value)),
-                        data_type: normalize_pg_type(&arg.data_type.to_string()),
+                        data_type: normalize_pg_type(&arg.data_type.to_string()).into_owned(),
                         mode,
                         default: arg.default_expr.as_ref().map(|e| e.to_string()),
                     }

--- a/src/parser/grants.rs
+++ b/src/parser/grants.rs
@@ -610,7 +610,7 @@ fn normalize_args(args: &str) -> String {
         return trimmed.to_string();
     };
 
-    let normalized: Vec<String> = split_top_level_commas(inner)
+    let normalized: Vec<_> = split_top_level_commas(inner)
         .into_iter()
         .map(|arg| normalize_pg_type(arg.trim()))
         .collect();

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -856,7 +856,7 @@ pub fn parse_sql_string(sql: &str) -> Result<Schema> {
                             args.iter()
                                 .map(|a| {
                                     let type_str = a.data_type.to_string();
-                                    normalize_pg_type(&type_str)
+                                    normalize_pg_type(&type_str).into_owned()
                                 })
                                 .collect::<Vec<_>>()
                                 .join(", ")

--- a/src/pg/introspect.rs
+++ b/src/pg/introspect.rs
@@ -1633,7 +1633,7 @@ async fn introspect_functions(
             name: name.clone(),
             schema: schema.clone(),
             arguments,
-            return_type: crate::model::normalize_pg_type(&return_type),
+            return_type: crate::model::normalize_pg_type(&return_type).into_owned(),
             language,
             body: body.trim().to_string(),
             volatility,
@@ -1733,14 +1733,14 @@ fn parse_function_arguments(args_str: &str) -> Vec<FunctionArg> {
             if parts.len() == 2 {
                 FunctionArg {
                     name: Some(strip_ident_quotes(parts[0])),
-                    data_type: crate::model::normalize_pg_type(parts[1]),
+                    data_type: crate::model::normalize_pg_type(parts[1]).into_owned(),
                     mode,
                     default,
                 }
             } else {
                 FunctionArg {
                     name: None,
-                    data_type: crate::model::normalize_pg_type(arg_rest.trim()),
+                    data_type: crate::model::normalize_pg_type(arg_rest.trim()).into_owned(),
                     mode,
                     default,
                 }


### PR DESCRIPTION
## Summary

- `normalize_pg_type` previously returned `String`, allocating on every call even when the input was already canonical. Every `Function::semantically_equals` and `requires_drop_recreate` comparison paid for two heap allocations to compare two already-normalized strings.
- Change the return type to `Cow<'_, str>`:
  - No uppercase and not a known alias → `Cow::Borrowed(input)` (zero alloc).
  - No uppercase and a known alias (`int` → `integer`) → `Cow::Borrowed(&'static str)` (zero alloc).
  - Has uppercase → `to_lowercase()` is still required, but a lowercased-alias match returns `Cow::Borrowed(&'static str)` instead of re-allocating the target.
  - `TABLE(...)` return types stay `Cow::Owned` (inherently re-materialized).
- Factor the alias table out into a private `canonical_alias` helper for clarity and reuse between the fast and slow paths.

## Call-site changes

- Sites that assign into a `String` field (`Function.return_type`, `FunctionArg.data_type`) in `pg/introspect.rs` and `parser/functions.rs` append `.into_owned()`.
- `parser/mod.rs` signature building uses `.into_owned()` to escape the local `to_string()` temporary.
- Comparison sites (`==`/`!=`) and `[..].collect::<Vec<_>>().join(\", \")` sites work unchanged — `Cow<str>` implements `PartialEq`, `Borrow<str>`, and `Display`.

## Test plan

- [x] New unit test pins `Cow::Borrowed` on already-canonical and alias-only inputs
- [x] New unit test pins `Cow::Owned` on inputs needing case folding or `TABLE(...)` expansion
- [x] Existing `assert_eq!(normalize_pg_type(...), \"literal\")` assertions keep passing via `PartialEq<&str> for Cow<str>`
- [ ] CI: build, clippy, test, corpus convergence, PG 13–17 integration

Closes pgmold-202