### PR TITLE
fix(proptest): dedupe enum and table names to unblock convergence flake

### DIFF
--- a/tests/common/strategies.rs
+++ b/tests/common/strategies.rs
@@ -1027,8 +1027,11 @@ pub fn rich_schema_sql_strategy(schema_name: String) -> BoxedStrategy<String> {
     proptest::collection::vec(enum_type_strategy(schema_name.clone()), 0..3)
         .prop_flat_map(move |enum_defs| {
             let schema_name = schema_name.clone();
-            let (enum_ddls, enum_infos): (Vec<String>, Vec<EnumInfo>) =
-                enum_defs.into_iter().unzip();
+            let mut seen_enum_names = std::collections::HashSet::new();
+            let (enum_ddls, enum_infos): (Vec<String>, Vec<EnumInfo>) = enum_defs
+                .into_iter()
+                .filter(|(_, info)| seen_enum_names.insert(info.qualified_name.clone()))
+                .unzip();
 
             (
                 proptest::collection::vec(
@@ -1042,8 +1045,11 @@ pub fn rich_schema_sql_strategy(schema_name: String) -> BoxedStrategy<String> {
                     let enum_ddls = enum_ddls.clone();
                     let enum_infos = enum_infos.clone();
 
-                    let (table_ddls, table_infos): (Vec<String>, Vec<TableInfo>) =
-                        table_results.into_iter().unzip();
+                    let mut seen_table_names = std::collections::HashSet::new();
+                    let (table_ddls, table_infos): (Vec<String>, Vec<TableInfo>) = table_results
+                        .into_iter()
+                        .filter(|(_, info)| seen_table_names.insert(info.name.clone()))
+                        .unzip();
 
                     let trigger_fn_name = format!("{trigger_fn_base}_fn");
                     let trigger_fn_qualified = format!("{schema_name}.{trigger_fn_name}");

--- a/tests/property_generator_invariants.rs
+++ b/tests/property_generator_invariants.rs
@@ -1,0 +1,68 @@
+mod common;
+use common::*;
+
+use proptest::prelude::*;
+use proptest::strategy::ValueTree;
+use proptest::test_runner::TestRunner;
+use std::collections::HashSet;
+
+fn extract_create_type_enum_names(sql: &str) -> Vec<String> {
+    let mut names = Vec::new();
+    for line in sql.lines() {
+        let trimmed = line.trim_start();
+        if let Some(rest) = trimmed.strip_prefix("CREATE TYPE ") {
+            if let Some(as_index) = rest.find(" AS ENUM") {
+                names.push(rest[..as_index].trim().to_string());
+            }
+        }
+    }
+    names
+}
+
+fn extract_create_table_names(sql: &str) -> Vec<String> {
+    let mut names = Vec::new();
+    for line in sql.lines() {
+        let trimmed = line.trim_start();
+        if let Some(rest) = trimmed.strip_prefix("CREATE TABLE ") {
+            let name_end = rest.find(['(', ' ']).unwrap_or(rest.len());
+            names.push(rest[..name_end].trim().to_string());
+        }
+    }
+    names
+}
+
+#[test]
+fn rich_schema_generator_never_produces_duplicate_enum_names() {
+    let mut runner = TestRunner::deterministic();
+    let strategy = rich_schema_sql_strategy("s_fixed".to_string());
+
+    for _ in 0..2000 {
+        let value = strategy.new_tree(&mut runner).unwrap().current();
+        let enum_names = extract_create_type_enum_names(&value);
+        let mut seen = HashSet::new();
+        for name in &enum_names {
+            assert!(
+                seen.insert(name.clone()),
+                "generator produced duplicate CREATE TYPE name {name} in single schema.\n\nSQL:\n{value}"
+            );
+        }
+    }
+}
+
+#[test]
+fn rich_schema_generator_never_produces_duplicate_table_names() {
+    let mut runner = TestRunner::deterministic();
+    let strategy = rich_schema_sql_strategy("s_fixed".to_string());
+
+    for _ in 0..2000 {
+        let value = strategy.new_tree(&mut runner).unwrap().current();
+        let table_names = extract_create_table_names(&value);
+        let mut seen = HashSet::new();
+        for name in &table_names {
+            assert!(
+                seen.insert(name.clone()),
+                "generator produced duplicate CREATE TABLE name {name} in single schema.\n\nSQL:\n{value}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
Closes pgmold-257.

## Summary
- The proptest_roundtrip_convergence generator could produce two `CREATE TYPE` statements with the same qualified name inside a single generated schema, because `enum_type_strategy` samples from `identifier_strategy` (which frequently returns short names like `p`) and the `Vec<(ddl, EnumInfo)>` was unzipped without a uniqueness pass.
- Postgres rejected the second `CREATE TYPE` with `type "..." already exists`, failing the convergence test on random seeds across the PG-version matrix.
- Dedupe by `qualified_name` immediately after the enum unzip; symmetrically dedupe by table name after the table unzip so two tables colliding on `identifier_strategy` cannot cause `relation already exists` either.

## Changes
- `tests/common/strategies.rs` — dedupe enums and tables inside `rich_schema_sql_strategy`.
- `tests/property_generator_invariants.rs` (new) — 2000-sample invariant test asserting no duplicate enum or table qualified names.

## Test plan
- [ ] CI matrix passes on all PG versions (the flake rotated across versions, so a single green run is weak evidence; let CI rerun a few times before judging)
- [ ] `property_generator_invariants` catches any future regression in the generator