### PR TITLE
fix(parser): accept ALTER TABLE ATTACH/DETACH PARTITION

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1613,7 +1613,8 @@ dependencies = [
 [[package]]
 name = "pgmold-sqlparser"
 version = "0.60.12"
-source = "git+https://github.com/fmguerreiro/datafusion-sqlparser-rs.git?branch=feat%2Falter-table-attach-detach-partition#898e884c3508933d067e94bedb5085289ec0d12d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "127f7a3ab1ab356c3a6a016e345ac2ea8239f8bf0e0984560003081d807adfd9"
 dependencies = [
  "log",
  "recursive",
@@ -2398,7 +2399,8 @@ dependencies = [
 [[package]]
 name = "sqlparser_derive"
 version = "0.5.0"
-source = "git+https://github.com/fmguerreiro/datafusion-sqlparser-rs.git?branch=feat%2Falter-table-attach-detach-partition#898e884c3508933d067e94bedb5085289ec0d12d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6dd45d8fc1c79299bfbb7190e42ccbbdf6a5f52e4a6ad98d92357ea965bd289"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2611,6 +2613,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
+ "windows-sys 0.52.0",
  "windows-sys 0.59.0",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1612,9 +1612,8 @@ dependencies = [
 
 [[package]]
 name = "pgmold-sqlparser"
-version = "0.60.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b96e8d796f79745142c82d2891ef586a2dcb62baae7bddeda3bf6be82b5b51"
+version = "0.60.12"
+source = "git+https://github.com/fmguerreiro/datafusion-sqlparser-rs.git?branch=feat%2Falter-table-attach-detach-partition#898e884c3508933d067e94bedb5085289ec0d12d"
 dependencies = [
  "log",
  "recursive",
@@ -2399,8 +2398,7 @@ dependencies = [
 [[package]]
 name = "sqlparser_derive"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6dd45d8fc1c79299bfbb7190e42ccbbdf6a5f52e4a6ad98d92357ea965bd289"
+source = "git+https://github.com/fmguerreiro/datafusion-sqlparser-rs.git?branch=feat%2Falter-table-attach-detach-partition#898e884c3508933d067e94bedb5085289ec0d12d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2613,7 +2611,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.52.0",
  "windows-sys 0.59.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["command-line-utilities", "database"]
 clap = { version = "4.5", features = ["derive", "env"] }
 tokio = { version = "1.35", features = ["full"] }
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres"] }
-sqlparser = { package = "pgmold-sqlparser", version = "0.60.11", features = ["visitor"] }
+sqlparser = { package = "pgmold-sqlparser", git = "https://github.com/fmguerreiro/datafusion-sqlparser-rs.git", branch = "feat/alter-table-attach-detach-partition", features = ["visitor"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 anyhow = "1.0"
@@ -37,11 +37,11 @@ sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres"] }
 tokio = { version = "1.35", features = ["full"] }
 assert_cmd = "2"
 criterion = { version = "0.5", features = ["html_reports"] }
-sqlparser = { package = "pgmold-sqlparser", version = "0.60.11", features = ["visitor"] }
+sqlparser = { package = "pgmold-sqlparser", git = "https://github.com/fmguerreiro/datafusion-sqlparser-rs.git", branch = "feat/alter-table-attach-detach-partition", features = ["visitor"] }
 
 [[bench]]
 name = "performance"
 harness = false
 
 [build-dependencies]
-sqlparser = { package = "pgmold-sqlparser", version = "0.60.11", features = ["visitor"] }
+sqlparser = { package = "pgmold-sqlparser", git = "https://github.com/fmguerreiro/datafusion-sqlparser-rs.git", branch = "feat/alter-table-attach-detach-partition", features = ["visitor"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["command-line-utilities", "database"]
 clap = { version = "4.5", features = ["derive", "env"] }
 tokio = { version = "1.35", features = ["full"] }
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres"] }
-sqlparser = { package = "pgmold-sqlparser", git = "https://github.com/fmguerreiro/datafusion-sqlparser-rs.git", branch = "feat/alter-table-attach-detach-partition", features = ["visitor"] }
+sqlparser = { package = "pgmold-sqlparser", version = "0.60.12", features = ["visitor"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 anyhow = "1.0"
@@ -37,11 +37,11 @@ sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres"] }
 tokio = { version = "1.35", features = ["full"] }
 assert_cmd = "2"
 criterion = { version = "0.5", features = ["html_reports"] }
-sqlparser = { package = "pgmold-sqlparser", git = "https://github.com/fmguerreiro/datafusion-sqlparser-rs.git", branch = "feat/alter-table-attach-detach-partition", features = ["visitor"] }
+sqlparser = { package = "pgmold-sqlparser", version = "0.60.12", features = ["visitor"] }
 
 [[bench]]
 name = "performance"
 harness = false
 
 [build-dependencies]
-sqlparser = { package = "pgmold-sqlparser", git = "https://github.com/fmguerreiro/datafusion-sqlparser-rs.git", branch = "feat/alter-table-attach-detach-partition", features = ["visitor"] }
+sqlparser = { package = "pgmold-sqlparser", version = "0.60.12", features = ["visitor"] }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -49,7 +49,7 @@ use sequences::parse_create_sequence;
 use tables::{parse_column_with_serial, parse_create_table, parse_referential_action};
 use util::{
     extract_qualified_name, normalize_expr, parse_data_type, parse_for_values,
-    parse_policy_command, truncate_identifier, unquote_ident,
+    parse_for_values_required, parse_policy_command, truncate_identifier, unquote_ident,
 };
 
 pub fn parse_sql_file(path: &str) -> Result<Schema> {
@@ -388,6 +388,36 @@ pub fn parse_sql_string(sql: &str) -> Result<Schema> {
                                     }
                                 }
                             }
+                        }
+                        AlterTableOperation::AttachPartitionOf {
+                            partition_name,
+                            partition_bound,
+                        } => {
+                            let (child_schema, child_name) =
+                                extract_qualified_name(&partition_name);
+                            let child_key = qualified_name(&child_schema, &child_name);
+                            let bound = parse_for_values_required(&partition_bound)?;
+                            let partition = Partition {
+                                schema: child_schema,
+                                name: child_name,
+                                parent_schema: tbl_schema.clone(),
+                                parent_name: tbl_name.clone(),
+                                bound,
+                                indexes: Vec::new(),
+                                check_constraints: Vec::new(),
+                                owner: None,
+                            };
+                            schema.partitions.insert(child_key, partition);
+                        }
+                        AlterTableOperation::DetachPartitionOf {
+                            partition_name,
+                            concurrently: _,
+                            finalize: _,
+                        } => {
+                            let (child_schema, child_name) =
+                                extract_qualified_name(&partition_name);
+                            let child_key = qualified_name(&child_schema, &child_name);
+                            schema.partitions.remove(&child_key);
                         }
                         // PostgreSQL `ALTER TABLE` variants pgmold does not yet
                         // consume. Tracked as future work; listed explicitly

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -4092,7 +4092,9 @@ ALTER TABLE public.measurement DETACH PARTITION public.measurement_y2021m01;
     let schema = parse_sql_string(sql).expect("Should parse DETACH PARTITION");
 
     assert!(
-        !schema.partitions.contains_key("public.measurement_y2021m01"),
+        !schema
+            .partitions
+            .contains_key("public.measurement_y2021m01"),
         "Detached partition should not appear in schema"
     );
 }
@@ -4112,7 +4114,9 @@ ALTER TABLE public.measurement DETACH PARTITION public.measurement_y2021m01 CONC
     let schema = parse_sql_string(sql).expect("Should parse DETACH PARTITION CONCURRENTLY");
 
     assert!(
-        !schema.partitions.contains_key("public.measurement_y2021m01"),
+        !schema
+            .partitions
+            .contains_key("public.measurement_y2021m01"),
         "Concurrently detached partition should not appear in schema"
     );
 }

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -3982,3 +3982,137 @@ CREATE MATERIALIZED VIEW public.rental_by_category AS
     assert_eq!(view.name, "rental_by_category");
     assert!(view.materialized);
 }
+
+#[test]
+fn attach_partition_range_via_alter_table() {
+    let sql = r#"
+CREATE TABLE public.payment (
+    payment_id BIGINT NOT NULL
+) PARTITION BY RANGE (payment_id);
+
+ALTER TABLE ONLY public.payment ATTACH PARTITION public.payment_p2022_01 FOR VALUES FROM ('2022-01-01 00:00:00+00') TO ('2022-02-01 00:00:00+00');
+"#;
+    let schema = parse_sql_string(sql).expect("Should parse ATTACH PARTITION");
+
+    let partition = schema
+        .partitions
+        .get("public.payment_p2022_01")
+        .expect("partition should exist");
+    assert_eq!(partition.parent_schema, "public");
+    assert_eq!(partition.parent_name, "payment");
+    assert_eq!(partition.schema, "public");
+    assert_eq!(partition.name, "payment_p2022_01");
+    match &partition.bound {
+        PartitionBound::Range { from, to } => {
+            assert_eq!(from, &vec!["'2022-01-01 00:00:00+00'".to_string()]);
+            assert_eq!(to, &vec!["'2022-02-01 00:00:00+00'".to_string()]);
+        }
+        _ => panic!("Expected Range bound"),
+    }
+}
+
+#[test]
+fn attach_partition_list_via_alter_table() {
+    let sql = r#"
+CREATE TABLE public.cities (
+    city_name TEXT NOT NULL
+) PARTITION BY LIST (city_name);
+
+ALTER TABLE public.cities ATTACH PARTITION public.cities_ab FOR VALUES IN ('a', 'b');
+"#;
+    let schema = parse_sql_string(sql).expect("Should parse ATTACH PARTITION list");
+
+    let partition = schema
+        .partitions
+        .get("public.cities_ab")
+        .expect("partition should exist");
+    assert_eq!(partition.parent_name, "cities");
+    match &partition.bound {
+        PartitionBound::List { values } => {
+            assert_eq!(values, &vec!["'a'".to_string(), "'b'".to_string()]);
+        }
+        _ => panic!("Expected List bound"),
+    }
+}
+
+#[test]
+fn attach_partition_hash_via_alter_table() {
+    let sql = r#"
+CREATE TABLE public.orders (
+    id INT NOT NULL
+) PARTITION BY HASH (id);
+
+ALTER TABLE public.orders ATTACH PARTITION public.orders_p1 FOR VALUES WITH (MODULUS 4, REMAINDER 0);
+"#;
+    let schema = parse_sql_string(sql).expect("Should parse ATTACH PARTITION hash");
+
+    let partition = schema
+        .partitions
+        .get("public.orders_p1")
+        .expect("partition should exist");
+    match &partition.bound {
+        PartitionBound::Hash { modulus, remainder } => {
+            assert_eq!(*modulus, 4);
+            assert_eq!(*remainder, 0);
+        }
+        _ => panic!("Expected Hash bound"),
+    }
+}
+
+#[test]
+fn attach_partition_default_via_alter_table() {
+    let sql = r#"
+CREATE TABLE public.logs (
+    level TEXT NOT NULL
+) PARTITION BY LIST (level);
+
+ALTER TABLE public.logs ATTACH PARTITION public.logs_other DEFAULT;
+"#;
+    let schema = parse_sql_string(sql).expect("Should parse ATTACH PARTITION default");
+
+    let partition = schema
+        .partitions
+        .get("public.logs_other")
+        .expect("partition should exist");
+    assert_eq!(partition.bound, PartitionBound::Default);
+}
+
+#[test]
+fn detach_partition_via_alter_table() {
+    let sql = r#"
+CREATE TABLE public.measurement (
+    logdate DATE NOT NULL
+) PARTITION BY RANGE (logdate);
+
+CREATE TABLE public.measurement_y2021m01 PARTITION OF public.measurement
+FOR VALUES FROM ('2021-01-01') TO ('2021-02-01');
+
+ALTER TABLE public.measurement DETACH PARTITION public.measurement_y2021m01;
+"#;
+    let schema = parse_sql_string(sql).expect("Should parse DETACH PARTITION");
+
+    assert!(
+        !schema.partitions.contains_key("public.measurement_y2021m01"),
+        "Detached partition should not appear in schema"
+    );
+}
+
+#[test]
+fn detach_partition_concurrently_via_alter_table() {
+    let sql = r#"
+CREATE TABLE public.measurement (
+    logdate DATE NOT NULL
+) PARTITION BY RANGE (logdate);
+
+CREATE TABLE public.measurement_y2021m01 PARTITION OF public.measurement
+FOR VALUES FROM ('2021-01-01') TO ('2021-02-01');
+
+ALTER TABLE public.measurement DETACH PARTITION public.measurement_y2021m01 CONCURRENTLY;
+"#;
+    let schema = parse_sql_string(sql).expect("Should parse DETACH PARTITION CONCURRENTLY");
+
+    assert!(
+        !schema.partitions.contains_key("public.measurement_y2021m01"),
+        "Concurrently detached partition should not appear in schema"
+    );
+}

--- a/src/parser/util.rs
+++ b/src/parser/util.rs
@@ -55,24 +55,30 @@ pub(super) fn parse_policy_command(cmd: &Option<CreatePolicyCommand>) -> PolicyC
 
 pub(super) fn parse_for_values(for_values: &Option<ForValues>) -> Result<PartitionBound> {
     match for_values {
-        Some(ForValues::In(values)) => Ok(PartitionBound::List {
+        Some(bound) => parse_for_values_required(bound),
+        None => Err(SchemaError::ParseError(
+            "PARTITION OF requires FOR VALUES clause".into(),
+        )),
+    }
+}
+
+pub(super) fn parse_for_values_required(for_values: &ForValues) -> Result<PartitionBound> {
+    match for_values {
+        ForValues::In(values) => Ok(PartitionBound::List {
             values: values
                 .iter()
                 .map(|e| normalize_expr(&e.to_string()))
                 .collect(),
         }),
-        Some(ForValues::From { from, to }) => Ok(PartitionBound::Range {
+        ForValues::From { from, to } => Ok(PartitionBound::Range {
             from: from.iter().map(partition_bound_value_to_string).collect(),
             to: to.iter().map(partition_bound_value_to_string).collect(),
         }),
-        Some(ForValues::With { modulus, remainder }) => Ok(PartitionBound::Hash {
+        ForValues::With { modulus, remainder } => Ok(PartitionBound::Hash {
             modulus: *modulus as u32,
             remainder: *remainder as u32,
         }),
-        Some(ForValues::Default) => Ok(PartitionBound::Default),
-        None => Err(SchemaError::ParseError(
-            "PARTITION OF requires FOR VALUES clause".into(),
-        )),
+        ForValues::Default => Ok(PartitionBound::Default),
     }
 }
 

--- a/tests/corpus/pagila.sql
+++ b/tests/corpus/pagila.sql
@@ -1,4 +1,3 @@
--- IGNORE: pgmold-258 parser rejects ALTER TABLE ... ATTACH PARTITION
 -- Source: https://github.com/devrimgunduz/pagila/blob/master/pagila-schema.sql
 -- Commit: 5ba5a57aeb159f75f02aca2432d3c262186d13d3
 -- License: MIT

--- a/tests/corpus/pagila.sql
+++ b/tests/corpus/pagila.sql
@@ -1,3 +1,4 @@
+-- IGNORE: pgmold-259 parser rejects 'fulltext' keyword as column identifier
 -- Source: https://github.com/devrimgunduz/pagila/blob/master/pagila-schema.sql
 -- Commit: 5ba5a57aeb159f75f02aca2432d3c262186d13d3
 -- License: MIT


### PR DESCRIPTION
## Summary

- Parse `ALTER TABLE parent ATTACH PARTITION child { FOR VALUES <spec> | DEFAULT }` into a `Partition` model entry, identical to the inline `CREATE TABLE child PARTITION OF parent` path (pgmold-254).
- Parse `ALTER TABLE parent DETACH PARTITION child [ CONCURRENTLY | FINALIZE ]` by removing the partition from the schema model. In a desired-state schema file, DETACH means the attachment is absent.
- Add `parse_for_values_required` helper shared by both the PARTITION OF and ATTACH PARTITION code paths.
- Remove `-- IGNORE: pgmold-258` from `tests/corpus/pagila.sql`.

Depends on: https://github.com/fmguerreiro/datafusion-sqlparser-rs/pull/20 (pgmold-sqlparser 0.60.12)

## Merge sequence

1. Merge sqlparser PR https://github.com/fmguerreiro/datafusion-sqlparser-rs/pull/20 into `main`.
2. Publish `pgmold-sqlparser 0.60.12` to crates.io (`cargo publish` in the fork).
3. Flip `Cargo.toml` from the git dep to `version = "0.60.12"` (three occurrences), run `cargo update -p pgmold-sqlparser`, commit.
4. Merge this PR.

## Test plan

- Parser unit tests: ATTACH range (pagila shape), list, hash, default; DETACH plain, DETACH CONCURRENTLY.
- `tests/corpus/pagila.sql` IGNORE removed — corpus convergence test will now exercise all 8 pagila ATTACH PARTITION statements end-to-end.