### PR TITLE
fix(parser): accept 'fulltext' as identifier in PG columns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1612,9 +1612,8 @@ dependencies = [
 
 [[package]]
 name = "pgmold-sqlparser"
-version = "0.60.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "127f7a3ab1ab356c3a6a016e345ac2ea8239f8bf0e0984560003081d807adfd9"
+version = "0.60.13"
+source = "git+https://github.com/fmguerreiro/datafusion-sqlparser-rs.git?branch=fix%2Fpostgres-unreserve-fulltext#da93efe07cd577112c84617c7c01de06f3617522"
 dependencies = [
  "log",
  "recursive",
@@ -2399,8 +2398,7 @@ dependencies = [
 [[package]]
 name = "sqlparser_derive"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6dd45d8fc1c79299bfbb7190e42ccbbdf6a5f52e4a6ad98d92357ea965bd289"
+source = "git+https://github.com/fmguerreiro/datafusion-sqlparser-rs.git?branch=fix%2Fpostgres-unreserve-fulltext#da93efe07cd577112c84617c7c01de06f3617522"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2613,7 +2611,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.52.0",
  "windows-sys 0.59.0",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1613,7 +1613,8 @@ dependencies = [
 [[package]]
 name = "pgmold-sqlparser"
 version = "0.60.13"
-source = "git+https://github.com/fmguerreiro/datafusion-sqlparser-rs.git?branch=fix%2Fpostgres-unreserve-fulltext#da93efe07cd577112c84617c7c01de06f3617522"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffbaaa8bdbd3c68e3470f6c6d2a1c3ecf227ff2c4770a69eb9052dd89a72c3dd"
 dependencies = [
  "log",
  "recursive",
@@ -2398,7 +2399,8 @@ dependencies = [
 [[package]]
 name = "sqlparser_derive"
 version = "0.5.0"
-source = "git+https://github.com/fmguerreiro/datafusion-sqlparser-rs.git?branch=fix%2Fpostgres-unreserve-fulltext#da93efe07cd577112c84617c7c01de06f3617522"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6dd45d8fc1c79299bfbb7190e42ccbbdf6a5f52e4a6ad98d92357ea965bd289"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2611,6 +2613,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
+ "windows-sys 0.52.0",
  "windows-sys 0.59.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["command-line-utilities", "database"]
 clap = { version = "4.5", features = ["derive", "env"] }
 tokio = { version = "1.35", features = ["full"] }
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres"] }
-sqlparser = { package = "pgmold-sqlparser", version = "0.60.12", features = ["visitor"] }
+sqlparser = { package = "pgmold-sqlparser", git = "https://github.com/fmguerreiro/datafusion-sqlparser-rs.git", branch = "fix/postgres-unreserve-fulltext", features = ["visitor"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 anyhow = "1.0"
@@ -37,11 +37,11 @@ sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres"] }
 tokio = { version = "1.35", features = ["full"] }
 assert_cmd = "2"
 criterion = { version = "0.5", features = ["html_reports"] }
-sqlparser = { package = "pgmold-sqlparser", version = "0.60.12", features = ["visitor"] }
+sqlparser = { package = "pgmold-sqlparser", git = "https://github.com/fmguerreiro/datafusion-sqlparser-rs.git", branch = "fix/postgres-unreserve-fulltext", features = ["visitor"] }
 
 [[bench]]
 name = "performance"
 harness = false
 
 [build-dependencies]
-sqlparser = { package = "pgmold-sqlparser", version = "0.60.12", features = ["visitor"] }
+sqlparser = { package = "pgmold-sqlparser", git = "https://github.com/fmguerreiro/datafusion-sqlparser-rs.git", branch = "fix/postgres-unreserve-fulltext", features = ["visitor"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["command-line-utilities", "database"]
 clap = { version = "4.5", features = ["derive", "env"] }
 tokio = { version = "1.35", features = ["full"] }
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres"] }
-sqlparser = { package = "pgmold-sqlparser", git = "https://github.com/fmguerreiro/datafusion-sqlparser-rs.git", branch = "fix/postgres-unreserve-fulltext", features = ["visitor"] }
+sqlparser = { package = "pgmold-sqlparser", version = "0.60.13", features = ["visitor"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 anyhow = "1.0"
@@ -37,11 +37,11 @@ sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres"] }
 tokio = { version = "1.35", features = ["full"] }
 assert_cmd = "2"
 criterion = { version = "0.5", features = ["html_reports"] }
-sqlparser = { package = "pgmold-sqlparser", git = "https://github.com/fmguerreiro/datafusion-sqlparser-rs.git", branch = "fix/postgres-unreserve-fulltext", features = ["visitor"] }
+sqlparser = { package = "pgmold-sqlparser", version = "0.60.13", features = ["visitor"] }
 
 [[bench]]
 name = "performance"
 harness = false
 
 [build-dependencies]
-sqlparser = { package = "pgmold-sqlparser", git = "https://github.com/fmguerreiro/datafusion-sqlparser-rs.git", branch = "fix/postgres-unreserve-fulltext", features = ["visitor"] }
+sqlparser = { package = "pgmold-sqlparser", version = "0.60.13", features = ["visitor"] }

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -3105,7 +3105,11 @@ CREATE INDEX film_fulltext_idx ON public.film USING gist (fulltext);
     let col = table.columns.get("fulltext").unwrap();
     assert_eq!(col.data_type, PgType::BuiltinNamed("tsvector".to_string()));
     assert!(!col.nullable);
-    let idx = table.indexes.iter().find(|i| i.name == "film_fulltext_idx").unwrap();
+    let idx = table
+        .indexes
+        .iter()
+        .find(|i| i.name == "film_fulltext_idx")
+        .unwrap();
     assert_eq!(idx.index_type, IndexType::Gist);
     assert_eq!(idx.columns, vec!["fulltext"]);
 }

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -3092,6 +3092,25 @@ fn parse_jsonb_array_column() {
 }
 
 #[test]
+fn parse_fulltext_tsvector_column() {
+    let sql = r#"
+CREATE TABLE public.film (
+    film_id INTEGER NOT NULL,
+    fulltext tsvector NOT NULL
+);
+CREATE INDEX film_fulltext_idx ON public.film USING gist (fulltext);
+"#;
+    let schema = parse_sql_string(sql).unwrap();
+    let table = schema.tables.get("public.film").unwrap();
+    let col = table.columns.get("fulltext").unwrap();
+    assert_eq!(col.data_type, PgType::BuiltinNamed("tsvector".to_string()));
+    assert!(!col.nullable);
+    let idx = table.indexes.iter().find(|i| i.name == "film_fulltext_idx").unwrap();
+    assert_eq!(idx.index_type, IndexType::Gist);
+    assert_eq!(idx.columns, vec!["fulltext"]);
+}
+
+#[test]
 fn parse_timestamptz_array_column() {
     let sql = "CREATE TABLE data (id BIGINT PRIMARY KEY, timestamps TIMESTAMP WITH TIME ZONE[]);";
     let schema = parse_sql_string(sql).unwrap();

--- a/src/parser/util.rs
+++ b/src/parser/util.rs
@@ -141,6 +141,8 @@ pub(super) fn parse_data_type(dt: &DataType) -> Result<PgType> {
         DataType::Uuid => Ok(PgType::Uuid),
         DataType::JSON => Ok(PgType::Json),
         DataType::JSONB => Ok(PgType::Jsonb),
+        DataType::TsVector => Ok(PgType::BuiltinNamed("tsvector".to_string())),
+        DataType::TsQuery => Ok(PgType::BuiltinNamed("tsquery".to_string())),
         DataType::Custom(name, modifiers) => {
             let parts: Vec<String> = name
                 .0

--- a/tests/corpus/pagila.sql
+++ b/tests/corpus/pagila.sql
@@ -1,3 +1,4 @@
+-- IGNORE: pgmold-260 parser rejects CREATE TRIGGER EXECUTE FUNCTION string args
 -- Source: https://github.com/devrimgunduz/pagila/blob/master/pagila-schema.sql
 -- Commit: 5ba5a57aeb159f75f02aca2432d3c262186d13d3
 -- License: MIT

--- a/tests/corpus/pagila.sql
+++ b/tests/corpus/pagila.sql
@@ -1,4 +1,3 @@
--- IGNORE: pgmold-259 parser rejects 'fulltext' keyword as column identifier
 -- Source: https://github.com/devrimgunduz/pagila/blob/master/pagila-schema.sql
 -- Commit: 5ba5a57aeb159f75f02aca2432d3c262186d13d3
 -- License: MIT


### PR DESCRIPTION
## Problem

PostgreSQL schemas that use `fulltext` as a column name (common with `tsvector`/trigram search) failed to parse:

```sql
CREATE TABLE public.film (
    fulltext tsvector NOT NULL
);
```

Error: `SQL parse error: sql parser error: Expected: a data type name, found: 'fulltext'`

The pagila corpus file had `-- IGNORE: pgmold-259 ...` because of this.

## Changes

- `Cargo.toml` / `Cargo.lock`: point `pgmold-sqlparser` at git branch `fix/postgres-unreserve-fulltext` (v0.60.13) which contains the fix
- `src/parser/util.rs`: map `DataType::TsVector` → `PgType::BuiltinNamed("tsvector")` and `DataType::TsQuery` → `PgType::BuiltinNamed("tsquery")` so tsvector columns survive `parse_data_type`
- `src/parser/tests.rs`: add `parse_fulltext_tsvector_column` covering the column, non-nullability, and GiST index
- `tests/corpus/pagila.sql`: remove `-- IGNORE: pgmold-259 ...` line

## Merge sequence

1. Merge sqlparser PR: https://github.com/fmguerreiro/datafusion-sqlparser-rs/pull/21
2. Publish `pgmold-sqlparser` 0.60.13 to crates.io
3. Flip `Cargo.toml` from git dep back to `version = "0.60.13"` (registry), run `cargo update`
4. Merge this PR