### PR TITLE
fix(parser): parse CREATE TRIGGER EXECUTE FUNCTION call-site args

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1612,9 +1612,8 @@ dependencies = [
 
 [[package]]
 name = "pgmold-sqlparser"
-version = "0.60.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffbaaa8bdbd3c68e3470f6c6d2a1c3ecf227ff2c4770a69eb9052dd89a72c3dd"
+version = "0.60.14"
+source = "git+https://github.com/fmguerreiro/datafusion-sqlparser-rs.git?branch=fix%2Ftrigger-exec-body-call-args#748d1d92ab271b508c4675b780556d2fcf63bb7d"
 dependencies = [
  "log",
  "recursive",
@@ -2399,8 +2398,7 @@ dependencies = [
 [[package]]
 name = "sqlparser_derive"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6dd45d8fc1c79299bfbb7190e42ccbbdf6a5f52e4a6ad98d92357ea965bd289"
+source = "git+https://github.com/fmguerreiro/datafusion-sqlparser-rs.git?branch=fix%2Ftrigger-exec-body-call-args#748d1d92ab271b508c4675b780556d2fcf63bb7d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2613,7 +2611,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.52.0",
  "windows-sys 0.59.0",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1613,7 +1613,8 @@ dependencies = [
 [[package]]
 name = "pgmold-sqlparser"
 version = "0.60.14"
-source = "git+https://github.com/fmguerreiro/datafusion-sqlparser-rs.git?branch=fix%2Ftrigger-exec-body-call-args#748d1d92ab271b508c4675b780556d2fcf63bb7d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "635386e668ee7420b6c375cb81edf8c7be7616c2cffae7a32f56c109034e88a0"
 dependencies = [
  "log",
  "recursive",
@@ -2398,7 +2399,8 @@ dependencies = [
 [[package]]
 name = "sqlparser_derive"
 version = "0.5.0"
-source = "git+https://github.com/fmguerreiro/datafusion-sqlparser-rs.git?branch=fix%2Ftrigger-exec-body-call-args#748d1d92ab271b508c4675b780556d2fcf63bb7d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6dd45d8fc1c79299bfbb7190e42ccbbdf6a5f52e4a6ad98d92357ea965bd289"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2611,6 +2613,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
+ "windows-sys 0.52.0",
  "windows-sys 0.59.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["command-line-utilities", "database"]
 clap = { version = "4.5", features = ["derive", "env"] }
 tokio = { version = "1.35", features = ["full"] }
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres"] }
-sqlparser = { package = "pgmold-sqlparser", version = "0.60.13", features = ["visitor"] }
+sqlparser = { package = "pgmold-sqlparser", git = "https://github.com/fmguerreiro/datafusion-sqlparser-rs.git", branch = "fix/trigger-exec-body-call-args", features = ["visitor"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 anyhow = "1.0"
@@ -37,11 +37,11 @@ sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres"] }
 tokio = { version = "1.35", features = ["full"] }
 assert_cmd = "2"
 criterion = { version = "0.5", features = ["html_reports"] }
-sqlparser = { package = "pgmold-sqlparser", version = "0.60.13", features = ["visitor"] }
+sqlparser = { package = "pgmold-sqlparser", git = "https://github.com/fmguerreiro/datafusion-sqlparser-rs.git", branch = "fix/trigger-exec-body-call-args", features = ["visitor"] }
 
 [[bench]]
 name = "performance"
 harness = false
 
 [build-dependencies]
-sqlparser = { package = "pgmold-sqlparser", version = "0.60.13", features = ["visitor"] }
+sqlparser = { package = "pgmold-sqlparser", git = "https://github.com/fmguerreiro/datafusion-sqlparser-rs.git", branch = "fix/trigger-exec-body-call-args", features = ["visitor"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["command-line-utilities", "database"]
 clap = { version = "4.5", features = ["derive", "env"] }
 tokio = { version = "1.35", features = ["full"] }
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres"] }
-sqlparser = { package = "pgmold-sqlparser", git = "https://github.com/fmguerreiro/datafusion-sqlparser-rs.git", branch = "fix/trigger-exec-body-call-args", features = ["visitor"] }
+sqlparser = { package = "pgmold-sqlparser", version = "0.60.14", features = ["visitor"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 anyhow = "1.0"
@@ -37,11 +37,11 @@ sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres"] }
 tokio = { version = "1.35", features = ["full"] }
 assert_cmd = "2"
 criterion = { version = "0.5", features = ["html_reports"] }
-sqlparser = { package = "pgmold-sqlparser", git = "https://github.com/fmguerreiro/datafusion-sqlparser-rs.git", branch = "fix/trigger-exec-body-call-args", features = ["visitor"] }
+sqlparser = { package = "pgmold-sqlparser", version = "0.60.14", features = ["visitor"] }
 
 [[bench]]
 name = "performance"
 harness = false
 
 [build-dependencies]
-sqlparser = { package = "pgmold-sqlparser", git = "https://github.com/fmguerreiro/datafusion-sqlparser-rs.git", branch = "fix/trigger-exec-body-call-args", features = ["visitor"] }
+sqlparser = { package = "pgmold-sqlparser", version = "0.60.14", features = ["visitor"] }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -689,7 +689,7 @@ pub fn parse_sql_string(sql: &str) -> Result<Schema> {
                         "Trigger '{trigger_name}' missing EXECUTE clause"
                     ))
                 })?;
-                let (func_schema, func_name) = extract_qualified_name(&exec.func_desc.name);
+                let (func_schema, func_name) = extract_qualified_name(&exec.func_name);
 
                 let timing = match period {
                     Some(TriggerPeriod::Before) => TriggerTiming::Before,
@@ -781,7 +781,6 @@ pub fn parse_sql_string(sql: &str) -> Result<Schema> {
                 }
 
                 let function_args = exec
-                    .func_desc
                     .args
                     .as_ref()
                     .map(|args| args.iter().map(|a| a.to_string()).collect())

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -609,7 +609,12 @@ EXECUTE FUNCTION tsvector_update_trigger('fulltext', 'pg_catalog.english', 'titl
     assert_eq!(trigger.function_name, "tsvector_update_trigger");
     assert_eq!(
         trigger.function_args,
-        vec!["'fulltext'", "'pg_catalog.english'", "'title'", "'description'"]
+        vec![
+            "'fulltext'",
+            "'pg_catalog.english'",
+            "'title'",
+            "'description'"
+        ]
     );
 }
 

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -590,6 +590,30 @@ EXECUTE FUNCTION insert_active_user_fn();
 }
 
 #[test]
+fn parses_trigger_with_string_literal_args() {
+    // Reproduces the pagila film_fulltext_trigger pattern where EXECUTE FUNCTION
+    // receives string literal arguments, not bare identifiers.
+    let sql = r#"
+CREATE TRIGGER film_fulltext_trigger
+BEFORE INSERT OR UPDATE ON public.film
+FOR EACH ROW
+EXECUTE FUNCTION tsvector_update_trigger('fulltext', 'pg_catalog.english', 'title', 'description');
+"#;
+    let schema = parse_sql_string(sql).unwrap();
+    let trigger = schema
+        .triggers
+        .get("public.film.film_fulltext_trigger")
+        .unwrap();
+
+    assert_eq!(trigger.name, "film_fulltext_trigger");
+    assert_eq!(trigger.function_name, "tsvector_update_trigger");
+    assert_eq!(
+        trigger.function_args,
+        vec!["'fulltext'", "'pg_catalog.english'", "'title'", "'description'"]
+    );
+}
+
+#[test]
 fn instead_of_trigger_rejects_for_each_statement() {
     let sql = r#"
 CREATE VIEW active_users AS SELECT * FROM users WHERE active = true;

--- a/tests/corpus/pagila.sql
+++ b/tests/corpus/pagila.sql
@@ -1,4 +1,3 @@
--- IGNORE: pgmold-260 parser rejects CREATE TRIGGER EXECUTE FUNCTION string args
 -- Source: https://github.com/devrimgunduz/pagila/blob/master/pagila-schema.sql
 -- Commit: 5ba5a57aeb159f75f02aca2432d3c262186d13d3
 -- License: MIT

--- a/tests/corpus/pagila.sql
+++ b/tests/corpus/pagila.sql
@@ -1,3 +1,4 @@
+-- IGNORE: pgmold-261 planner raises circular dependency on full pagila graph
 -- Source: https://github.com/devrimgunduz/pagila/blob/master/pagila-schema.sql
 -- Commit: 5ba5a57aeb159f75f02aca2432d3c262186d13d3
 -- License: MIT


### PR DESCRIPTION
## Problem

`tsvector_update_trigger` and similar built-in PostgreSQL functions are
called from CREATE TRIGGER with string literal arguments:

```sql
CREATE TRIGGER film_fulltext_trigger BEFORE INSERT OR UPDATE ON public.film
    FOR EACH ROW EXECUTE FUNCTION
    tsvector_update_trigger('fulltext', 'pg_catalog.english', 'title', 'description');
```

pgmold-sqlparser's `parse_trigger_exec_body` delegated to
`parse_function_desc`, which parses args as CREATE-FUNCTION-style
parameter declarations (`argname argtype`). The first `'fulltext'`
token is a `SingleQuotedString`, not a `Word`, so `parse_data_type_helper`
raised: `Expected: a data type name, found: 'fulltext'`.

## Solution

Upgrade `pgmold-sqlparser` to `0.60.14` (fork branch
`fix/trigger-exec-body-call-args`), which replaces `func_desc:
FunctionDesc` on `TriggerExecBody` with:

```rust
pub struct TriggerExecBody {
    pub exec_type: TriggerExecBodyType,
    pub func_name: ObjectName,
    pub args: Option<Vec<Expr>>,
}
```

`parse_trigger_exec_body` now calls `parse_object_name` +
`parse_comma_separated(Parser::parse_expr)`, treating args as call-site
expressions.

Update the two call sites in `src/parser/mod.rs`:
- `exec.func_desc.name` → `exec.func_name`
- `exec.func_desc.args` → `exec.args`

## Changes

- `Cargo.toml` / `Cargo.lock`: point all three sqlparser sections at git
  dep on `fix/trigger-exec-body-call-args`
- `src/parser/mod.rs`: adapt to new `TriggerExecBody` fields
- `src/parser/tests.rs`: add `parses_trigger_with_string_literal_args`
  asserting the pagila shape parses and stores all four string args
- `tests/corpus/pagila.sql`: remove `IGNORE: pgmold-260` line

## Merge sequence

1. Merge sqlparser PR https://github.com/fmguerreiro/datafusion-sqlparser-rs/pull/22
2. Publish `pgmold-sqlparser` 0.60.14 to crates.io
3. Flip Cargo.toml to `version = "0.60.14"` registry dep (remove git dep)
4. Merge this PR

Steps 2-4 are handled by the maintainer after step 1 merges.