### PR TITLE
pgmold-263/264/265: small-PR cleanup for planner/parser gaps

### DIFF
--- a/src/diff/planner.rs
+++ b/src/diff/planner.rs
@@ -715,6 +715,41 @@ impl MigrationGraph {
                     }
                 }
 
+                // AddExclusionConstraint depends on table and functions in element
+                // expressions / WHERE clause. Mirrors AddCheckConstraint — if the
+                // referenced function has a concrete table dep, its tier blanket
+                // (function→table) is suppressed, so this walk is the only edge
+                // ordering the function ahead of the constraint.
+                OpKey::AddExclusionConstraint { table, .. } => {
+                    edges_to_add.push((OpKey::CreateTable(table.to_string()), key.clone()));
+
+                    if let Some(MigrationOp::AddExclusionConstraint {
+                        table,
+                        exclusion_constraint,
+                    }) = self.get_op(key)
+                    {
+                        let schema = &table.schema;
+                        for element in &exclusion_constraint.elements {
+                            push_function_ref_edges(
+                                &mut edges_to_add,
+                                &keys,
+                                &element.column_or_expression,
+                                schema,
+                                key,
+                            );
+                        }
+                        if let Some(where_clause) = &exclusion_constraint.where_clause {
+                            push_function_ref_edges(
+                                &mut edges_to_add,
+                                &keys,
+                                where_clause,
+                                schema,
+                                key,
+                            );
+                        }
+                    }
+                }
+
                 // NOTE: CreateDomain can reference functions in CHECK constraints and
                 // defaults, but adding function→domain edges would conflict with the
                 // phase-level domain→function ordering (domains are types used in function
@@ -5957,6 +5992,79 @@ mod tests {
         assert!(
             pos_func < pos_check,
             "CreateFunction must precede AddCheckConstraint that references it (func at {pos_func}, check at {pos_check})"
+        );
+    }
+
+    #[test]
+    fn add_exclusion_constraint_with_setof_function_ordered_after_function() {
+        // Mirror of add_check_constraint_with_setof_function_ordered_after_function
+        // for exclusion constraints. The function has a SETOF table dep, so the
+        // function→table tier blanket is suppressed. The AddExclusionConstraint
+        // content-aware walk of element expressions and the WHERE clause is the
+        // only thing ordering the function ahead of the constraint.
+        let items = simple_table_with_fks("items", vec![]);
+        let widgets = simple_table_with_fks("widgets", vec![]);
+
+        let validate = Function {
+            name: "validate_amount".to_string(),
+            schema: "public".to_string(),
+            arguments: vec![],
+            return_type: "SETOF public.items".to_string(),
+            language: "plpgsql".to_string(),
+            body: "BEGIN RETURN; END;".to_string(),
+            volatility: Volatility::Stable,
+            security: SecurityType::Invoker,
+            config_params: vec![],
+            owner: None,
+            grants: Vec::new(),
+            comment: None,
+        };
+
+        let ops = vec![
+            MigrationOp::AddExclusionConstraint {
+                table: QualifiedName::new("public", "widgets"),
+                exclusion_constraint: ExclusionConstraint {
+                    name: "widgets_no_overlap".to_string(),
+                    index_method: "gist".to_string(),
+                    // Function reference in both the element expression and the
+                    // WHERE clause exercises the element-walk and where_clause
+                    // branches in the new content-aware arm.
+                    elements: vec![ExclusionElement {
+                        column_or_expression: "validate_amount(1)".to_string(),
+                        operator: "=".to_string(),
+                    }],
+                    where_clause: Some("validate_amount(1) IS NOT NULL".to_string()),
+                    deferrable: false,
+                    initially_deferred: false,
+                },
+            },
+            MigrationOp::CreateTable(widgets),
+            MigrationOp::CreateFunction(validate),
+            MigrationOp::CreateTable(items),
+        ];
+
+        let planned = plan_migration(ops);
+
+        let pos_items = planned
+            .iter()
+            .position(|op| matches!(op, MigrationOp::CreateTable(t) if t.name == "items"))
+            .unwrap();
+        let pos_func = planned
+            .iter()
+            .position(|op| matches!(op, MigrationOp::CreateFunction(_)))
+            .unwrap();
+        let pos_exclusion = planned
+            .iter()
+            .position(|op| matches!(op, MigrationOp::AddExclusionConstraint { .. }))
+            .unwrap();
+
+        assert!(
+            pos_items < pos_func,
+            "CreateTable(items) must precede CreateFunction via the SETOF content-aware edge (items at {pos_items}, func at {pos_func})"
+        );
+        assert!(
+            pos_func < pos_exclusion,
+            "CreateFunction must precede AddExclusionConstraint that references it (func at {pos_func}, exclusion at {pos_exclusion})"
         );
     }
 

--- a/src/parser/dependencies.rs
+++ b/src/parser/dependencies.rs
@@ -107,16 +107,54 @@ pub fn extract_table_references(body: &str, default_schema: &str) -> HashSet<Obj
     let sql_as_where = format!("SELECT 1 WHERE {body}");
     let sql_as_subquery = format!("SELECT * FROM ({body}) AS subq");
 
-    let statements = Parser::parse_sql(&dialect, &sql_as_where)
+    let statements = match Parser::parse_sql(&dialect, &sql_as_where)
         .or_else(|_| Parser::parse_sql(&dialect, &sql_as_subquery))
         .or_else(|_| Parser::parse_sql(&dialect, body))
-        .unwrap_or_default();
+    {
+        Ok(stmts) => stmts,
+        Err(err) => {
+            // A load-bearing caller — the planner — uses this to compute hard
+            // body-relation deps for LANGUAGE sql functions. A silent empty
+            // result there produces a wrong migration order that only surfaces
+            // later as `relation does not exist` at apply time.
+            //
+            // Some non-SQL bodies (empty, comments-only, pg-specific syntax
+            // sqlparser doesn't grok) legitimately fail all three strategies,
+            // so we degrade gracefully rather than erroring — but leave a
+            // greppable trail in CI so corpus regressions are diagnosable.
+            if let Some(message) =
+                format_extract_table_references_failure(body, default_schema, &err.to_string())
+            {
+                eprintln!("{message}");
+            }
+            return refs;
+        }
+    };
 
     for statement in &statements {
         extract_tables_from_statement(statement, default_schema, &mut refs);
     }
 
     refs
+}
+
+/// Build the warning message for a total parse failure in
+/// `extract_table_references`. Returns `None` for trivially empty bodies
+/// (nothing worth logging). Broken out so the formatting is unit-testable
+/// without having to capture stderr.
+fn format_extract_table_references_failure(
+    body: &str,
+    default_schema: &str,
+    last_error: &str,
+) -> Option<String> {
+    if body.trim().is_empty() {
+        return None;
+    }
+    let snippet: String = body.chars().take(120).collect();
+    let truncated = if body.len() > snippet.len() { "..." } else { "" };
+    Some(format!(
+        "[pgmold:parser] extract_table_references: all parse strategies failed (schema={default_schema}, last_error={last_error}, body={snippet:?}{truncated})"
+    ))
 }
 
 fn extract_functions_from_statement(
@@ -842,5 +880,70 @@ mod tests {
             refs.contains(&ObjectRef::new("public", "enterprise_suppliers")),
             "expected enterprise_suppliers in refs, got: {refs:?}"
         );
+    }
+
+    #[test]
+    fn format_parse_failure_names_schema_error_and_body() {
+        let message = format_extract_table_references_failure(
+            "this is not sql >>> nonsense",
+            "my_schema",
+            "unexpected token at line 1",
+        )
+        .expect("non-empty body must produce a warning message");
+
+        assert!(
+            message.contains("extract_table_references"),
+            "message must name the function: {message}"
+        );
+        assert!(
+            message.contains("schema=my_schema"),
+            "message must name the default schema: {message}"
+        );
+        assert!(
+            message.contains("unexpected token at line 1"),
+            "message must include the parse error: {message}"
+        );
+        assert!(
+            message.contains("this is not sql"),
+            "message must include a body snippet: {message}"
+        );
+    }
+
+    #[test]
+    fn format_parse_failure_truncates_long_bodies() {
+        let long_body = "x".repeat(300);
+        let message = format_extract_table_references_failure(&long_body, "public", "err")
+            .expect("non-empty body must produce a warning message");
+
+        assert!(
+            message.contains("\"xxxxxxxxxxxxxxxxxxxx"),
+            "long bodies must appear as a snippet: {message}"
+        );
+        assert!(
+            message.contains("..."),
+            "long bodies must be marked as truncated: {message}"
+        );
+    }
+
+    #[test]
+    fn format_parse_failure_skips_empty_bodies() {
+        assert!(
+            format_extract_table_references_failure("", "public", "err").is_none(),
+            "empty bodies must not produce a warning"
+        );
+        assert!(
+            format_extract_table_references_failure("   \n\t ", "public", "err").is_none(),
+            "whitespace-only bodies must not produce a warning"
+        );
+    }
+
+    #[test]
+    fn extract_table_references_returns_empty_on_unparseable_body() {
+        // Paired with the `format_*` tests: the unparseable-body path must
+        // still return an empty HashSet (degrade gracefully) while the
+        // warning above keeps the failure diagnosable.
+        let refs =
+            extract_table_references("this is not sql at all >>> complete nonsense", "public");
+        assert!(refs.is_empty(), "unparseable bodies must degrade to empty");
     }
 }

--- a/src/parser/dependencies.rs
+++ b/src/parser/dependencies.rs
@@ -113,15 +113,9 @@ pub fn extract_table_references(body: &str, default_schema: &str) -> HashSet<Obj
     {
         Ok(stmts) => stmts,
         Err(err) => {
-            // A load-bearing caller — the planner — uses this to compute hard
-            // body-relation deps for LANGUAGE sql functions. A silent empty
-            // result there produces a wrong migration order that only surfaces
-            // later as `relation does not exist` at apply time.
-            //
-            // Some non-SQL bodies (empty, comments-only, pg-specific syntax
-            // sqlparser doesn't grok) legitimately fail all three strategies,
-            // so we degrade gracefully rather than erroring — but leave a
-            // greppable trail in CI so corpus regressions are diagnosable.
+            // Degrade gracefully so legitimate non-SQL (empty, comments-only,
+            // pg-specific syntax) returns empty. Warn to stderr so the planner's
+            // body-relation-deps path has a greppable trail in CI.
             if let Some(message) =
                 format_extract_table_references_failure(body, default_schema, &err.to_string())
             {
@@ -150,8 +144,13 @@ fn format_extract_table_references_failure(
     if body.trim().is_empty() {
         return None;
     }
-    let snippet: String = body.chars().take(120).collect();
-    let truncated = if body.len() > snippet.len() { "..." } else { "" };
+    // Collect the first 120 chars and then ask the iterator if anything is
+    // left — a char-aware truncation check. A byte-based comparison would
+    // mis-classify multibyte bodies whose byte-length happens to match the
+    // snippet's byte-length despite having more codepoints.
+    let mut chars = body.chars();
+    let snippet: String = chars.by_ref().take(120).collect();
+    let truncated = if chars.next().is_some() { "..." } else { "" };
     Some(format!(
         "[pgmold:parser] extract_table_references: all parse strategies failed (schema={default_schema}, last_error={last_error}, body={snippet:?}{truncated})"
     ))
@@ -922,6 +921,22 @@ mod tests {
         assert!(
             message.contains("..."),
             "long bodies must be marked as truncated: {message}"
+        );
+    }
+
+    #[test]
+    fn format_parse_failure_truncates_multibyte_body_by_chars_not_bytes() {
+        // A byte-based truncation check would mis-classify multibyte bodies.
+        // 200 copies of a 3-byte char (Japanese 'あ') — 200 codepoints total,
+        // well past the 120-char snippet limit, so the message must be marked
+        // truncated.
+        let multibyte_body = "あ".repeat(200);
+        let message = format_extract_table_references_failure(&multibyte_body, "public", "err")
+            .expect("non-empty body must produce a warning message");
+
+        assert!(
+            message.contains("..."),
+            "multibyte bodies exceeding the char limit must be marked truncated: {message}"
         );
     }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -242,74 +242,119 @@ pub fn parse_sql_string(sql: &str) -> Result<Schema> {
                         }
                         AlterTableOperation::AddConstraint { constraint, .. } => {
                             if let Some(table) = schema.tables.get_mut(&tbl_key) {
-                                if let TableConstraint::PrimaryKey(pk) = constraint {
-                                    apply_primary_key(table, &pk);
-                                } else if let TableConstraint::ForeignKey(fk) = constraint {
-                                    let fk_name = fk
-                                        .name
-                                        .as_ref()
-                                        .map(|n| unquote_ident(&n.to_string()).to_string())
-                                        .unwrap_or_else(|| {
-                                            format!(
-                                                "{}_{}_fkey",
-                                                tbl_name,
-                                                unquote_ident(&fk.columns[0].to_string())
-                                            )
+                                match constraint {
+                                    TableConstraint::PrimaryKey(pk) => {
+                                        apply_primary_key(table, &pk);
+                                    }
+                                    TableConstraint::ForeignKey(fk) => {
+                                        let fk_name = fk
+                                            .name
+                                            .as_ref()
+                                            .map(|n| unquote_ident(&n.to_string()).to_string())
+                                            .unwrap_or_else(|| {
+                                                format!(
+                                                    "{}_{}_fkey",
+                                                    tbl_name,
+                                                    unquote_ident(&fk.columns[0].to_string())
+                                                )
+                                            });
+                                        let (ref_schema, ref_table) =
+                                            extract_qualified_name(&fk.foreign_table);
+                                        table.foreign_keys.push(ForeignKey {
+                                            name: truncate_identifier(&fk_name),
+                                            columns: fk
+                                                .columns
+                                                .iter()
+                                                .map(|c| unquote_ident(&c.to_string()).to_string())
+                                                .collect(),
+                                            referenced_schema: ref_schema,
+                                            referenced_table: ref_table,
+                                            referenced_columns: fk
+                                                .referred_columns
+                                                .iter()
+                                                .map(|c| unquote_ident(&c.to_string()).to_string())
+                                                .collect(),
+                                            on_delete: parse_referential_action(&fk.on_delete),
+                                            on_update: parse_referential_action(&fk.on_update),
                                         });
-                                    let (ref_schema, ref_table) =
-                                        extract_qualified_name(&fk.foreign_table);
-                                    table.foreign_keys.push(ForeignKey {
-                                        name: truncate_identifier(&fk_name),
-                                        columns: fk
-                                            .columns
-                                            .iter()
-                                            .map(|c| unquote_ident(&c.to_string()).to_string())
-                                            .collect(),
-                                        referenced_schema: ref_schema,
-                                        referenced_table: ref_table,
-                                        referenced_columns: fk
-                                            .referred_columns
-                                            .iter()
-                                            .map(|c| unquote_ident(&c.to_string()).to_string())
-                                            .collect(),
-                                        on_delete: parse_referential_action(&fk.on_delete),
-                                        on_update: parse_referential_action(&fk.on_update),
-                                    });
-                                } else if let TableConstraint::Check(chk) = constraint {
-                                    let constraint_name = chk
-                                        .name
-                                        .as_ref()
-                                        .map(|n| unquote_ident(&n.to_string()).to_string())
-                                        .unwrap_or_else(|| format!("{tbl_name}_check"));
+                                    }
+                                    TableConstraint::Check(chk) => {
+                                        let constraint_name = chk
+                                            .name
+                                            .as_ref()
+                                            .map(|n| unquote_ident(&n.to_string()).to_string())
+                                            .unwrap_or_else(|| format!("{tbl_name}_check"));
 
-                                    table.check_constraints.push(CheckConstraint {
-                                        name: constraint_name,
-                                        expression: normalize_expr(&chk.expr.to_string()),
-                                    });
-                                    table.check_constraints.sort();
-                                } else if let TableConstraint::Unique(uniq) = constraint {
-                                    let constraint_name = uniq
-                                        .name
-                                        .as_ref()
-                                        .map(|n| unquote_ident(&n.to_string()).to_string())
-                                        .unwrap_or_else(|| format!("{tbl_name}_unique"));
+                                        table.check_constraints.push(CheckConstraint {
+                                            name: constraint_name,
+                                            expression: normalize_expr(&chk.expr.to_string()),
+                                        });
+                                        table.check_constraints.sort();
+                                    }
+                                    TableConstraint::Unique(uniq) => {
+                                        let constraint_name = uniq
+                                            .name
+                                            .as_ref()
+                                            .map(|n| unquote_ident(&n.to_string()).to_string())
+                                            .unwrap_or_else(|| format!("{tbl_name}_unique"));
 
-                                    table.indexes.push(Index {
-                                        name: constraint_name,
-                                        columns: uniq
-                                            .columns
-                                            .iter()
-                                            .map(|c| {
-                                                unquote_ident(&c.column.expr.to_string())
-                                                    .to_string()
-                                            })
-                                            .collect(),
-                                        unique: true,
-                                        index_type: IndexType::BTree,
-                                        predicate: None,
-                                        is_constraint: true,
-                                    });
-                                    table.indexes.sort();
+                                        table.indexes.push(Index {
+                                            name: constraint_name,
+                                            columns: uniq
+                                                .columns
+                                                .iter()
+                                                .map(|c| {
+                                                    unquote_ident(&c.column.expr.to_string())
+                                                        .to_string()
+                                                })
+                                                .collect(),
+                                            unique: true,
+                                            index_type: IndexType::BTree,
+                                            predicate: None,
+                                            is_constraint: true,
+                                        });
+                                        table.indexes.sort();
+                                    }
+                                    // PostgreSQL emits `PRIMARY KEY USING INDEX <idx>` /
+                                    // `UNIQUE USING INDEX <idx>` when a standalone unique index
+                                    // is being promoted to a constraint. Recording the promotion
+                                    // would require `Table.primary_key` (and the index model) to
+                                    // carry the source index name. Until that model change lands,
+                                    // fail loudly rather than silently dropping the constraint —
+                                    // a silent drop would cause sqlgen to emit a CREATE TABLE
+                                    // without the PK/UNIQUE, and downstream FKs targeting those
+                                    // columns would fail to apply.
+                                    TableConstraint::PrimaryKeyUsingIndex(pk) => {
+                                        let name = pk
+                                            .name
+                                            .as_ref()
+                                            .map(|n| unquote_ident(&n.to_string()).to_string())
+                                            .unwrap_or_else(|| format!("{tbl_name}_pkey"));
+                                        return Err(SchemaError::ParseError(format!(
+                                            "ALTER TABLE {tbl_key} ADD CONSTRAINT {name} PRIMARY KEY USING INDEX is not yet supported"
+                                        )));
+                                    }
+                                    TableConstraint::UniqueUsingIndex(uniq) => {
+                                        let name = uniq
+                                            .name
+                                            .as_ref()
+                                            .map(|n| unquote_ident(&n.to_string()).to_string())
+                                            .unwrap_or_else(|| format!("{tbl_name}_unique"));
+                                        return Err(SchemaError::ParseError(format!(
+                                            "ALTER TABLE {tbl_key} ADD CONSTRAINT {name} UNIQUE USING INDEX is not yet supported"
+                                        )));
+                                    }
+                                    // ALTER TABLE ADD CONSTRAINT does not accept EXCLUDE in
+                                    // PostgreSQL in the same shape as inline EXCLUDE in CREATE
+                                    // TABLE — sqlparser still surfaces the variant, so we listed
+                                    // it explicitly to force an upstream review if this changes.
+                                    TableConstraint::Exclusion(_)
+                                    // MySQL-specific: no PostgreSQL equivalent in ALTER TABLE
+                                    // ADD CONSTRAINT. Listed explicitly so adding a new
+                                    // TableConstraint variant upstream forces a compile-time
+                                    // review here instead of silent fallthrough.
+                                    | TableConstraint::Index(_)
+                                    | TableConstraint::FulltextOrSpatial(_) => {}
                                 }
                             }
                         }

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -4066,6 +4066,33 @@ ALTER TABLE ONLY public.language ADD CONSTRAINT language_pkey PRIMARY KEY (langu
 }
 
 #[test]
+fn alter_table_add_constraint_primary_key_using_index_errors_loudly() {
+    // PostgreSQL emits this form when a standalone unique index is promoted
+    // to a PRIMARY KEY. The model does not yet carry the source-index name,
+    // so silently dropping it would produce a CREATE TABLE with no PK and
+    // later FK failures. Fail with a clear error instead.
+    let sql = r#"
+CREATE TABLE public.users (
+    id INTEGER NOT NULL,
+    email TEXT
+);
+
+ALTER TABLE ONLY public.users ADD CONSTRAINT users_pkey PRIMARY KEY USING INDEX users_pkey_idx;
+"#;
+    let error = parse_sql_string(sql)
+        .expect_err("PRIMARY KEY USING INDEX must fail rather than silently drop");
+    let message = error.to_string();
+    assert!(
+        message.contains("PRIMARY KEY USING INDEX"),
+        "error should name the unsupported DDL shape, got: {message}"
+    );
+    assert!(
+        message.contains("public.users"),
+        "error should name the target table, got: {message}"
+    );
+}
+
+#[test]
 fn attach_partition_range_via_alter_table() {
     let sql = r#"
 CREATE TABLE public.payment (


### PR DESCRIPTION
Three small cleanup fixes surfaced during PR #229 review of pgmold-261. Bundled because each is narrow and touches a different file.

## pgmold-263 — planner: AddExclusionConstraint content-aware walk

`add_content_aware_edges` had arms for `AddCheckConstraint`, `AddIndex`, `CreateTable` etc. that walk expressions for function references and emit `function → constraint` edges. `AddExclusionConstraint` had no such arm. If an exclusion constraint's element expression or `WHERE` clause references a function whose `function → table` tier blanket is suppressed by pgmold-261 (because the function has a concrete table dep), there was no edge ordering the function ahead of the constraint.

Mirrors the `AddCheckConstraint` arm: walk every `element.column_or_expression` and the optional `where_clause`. Latent today — no corpus fixture exercises it.

## pgmold-264 — parser: fail loudly on `PRIMARY KEY / UNIQUE USING INDEX`

`AlterTableOperation::AddConstraint` matched `TableConstraint` via an `if-let/else-if` chain that silently dropped anything outside `ForeignKey / Check / Unique / PrimaryKey`. `TableConstraint::PrimaryKeyUsingIndex` and `UniqueUsingIndex` are emitted by PostgreSQL when a standalone unique index is promoted to a constraint — a silent drop would produce a `CREATE TABLE` with no PK/UNIQUE, and downstream FKs against those columns would fail to apply.

Converted the chain to an exhaustive `match` so future `TableConstraint` variants force a compile-time review, and raised a clear `ParseError` for the `USING INDEX` forms. Recording the promotion in the model would require `Table.primary_key` to carry the source index name; deferred until a corpus fixture exercises it.

## pgmold-265 — parser: warn on `extract_table_references` total parse failure

`extract_table_references` tried three sqlparser strategies and used `unwrap_or_default()` on complete failure. After pgmold-261 the planner uses this to compute `hard_body_relation_deps` for `LANGUAGE sql` functions — a silent empty result there produces a wrong migration order that only surfaces later as `relation does not exist` at apply time.

Preserved the graceful-degradation contract (return empty for legitimately-unparseable bodies: empty, comments-only, pg-specific syntax) but added a stderr warning tagged `[pgmold:parser]` with the default schema, last parse error, and truncated body snippet. Used `eprintln!` rather than `tracing::warn!` (as the ticket originally suggested) because pgmold has no tracing dependency and `eprintln!` already surfaces in CI stderr. Format is extracted into a private helper so the message is unit-testable without capturing stderr.

## Test plan

- [x] `cargo test -p pgmold -- add_exclusion_constraint_with_setof_function_ordered_after_function` (new)
- [x] `cargo test -p pgmold -- alter_table_add_constraint_primary_key_using_index_errors_loudly` (new)
- [x] `cargo test -p pgmold -- format_parse_failure_` (new — four tests covering the helper)
- [x] `cargo test -p pgmold -- extract_table_references_returns_empty_on_unparseable_body` (new)
- [ ] Full test suite via CI