### PR TITLE
feat(aggregates): model CREATE AGGREGATE end-to-end (pgmold-262)

### DIFF
--- a/src/baseline/report.rs
+++ b/src/baseline/report.rs
@@ -9,6 +9,8 @@ pub struct ObjectCounts {
     pub enums: usize,
     pub tables: usize,
     pub functions: usize,
+    #[serde(default)]
+    pub aggregates: usize,
     pub views: usize,
     pub triggers: usize,
     pub sequences: usize,
@@ -21,6 +23,7 @@ impl ObjectCounts {
             enums: schema.enums.len(),
             tables: schema.tables.len(),
             functions: schema.functions.len(),
+            aggregates: schema.aggregates.len(),
             views: schema.views.len(),
             triggers: schema.triggers.len(),
             sequences: schema.sequences.len(),
@@ -32,6 +35,7 @@ impl ObjectCounts {
             + self.enums
             + self.tables
             + self.functions
+            + self.aggregates
             + self.views
             + self.triggers
             + self.sequences
@@ -78,6 +82,7 @@ pub fn generate_text_report(report: &BaselineReport) -> String {
         ("Enums:", report.object_counts.enums),
         ("Tables:", report.object_counts.tables),
         ("Functions:", report.object_counts.functions),
+        ("Aggregates:", report.object_counts.aggregates),
         ("Views:", report.object_counts.views),
         ("Triggers:", report.object_counts.triggers),
         ("Sequences:", report.object_counts.sequences),
@@ -160,6 +165,7 @@ mod tests {
                 enums: 1,
                 tables: 5,
                 functions: 3,
+                aggregates: 0,
                 views: 1,
                 triggers: 2,
                 sequences: 4,
@@ -186,6 +192,7 @@ mod tests {
             enums: 2,
             tables: 3,
             functions: 4,
+            aggregates: 0,
             views: 5,
             triggers: 6,
             sequences: 7,

--- a/src/baseline/unsupported.rs
+++ b/src/baseline/unsupported.rs
@@ -61,7 +61,6 @@ pub async fn detect_unsupported_objects(
     let mut unsupported = Vec::new();
 
     unsupported.extend(detect_composite_types(connection, target_schemas).await?);
-    unsupported.extend(detect_aggregates(connection, target_schemas).await?);
     unsupported.extend(detect_rules(connection, target_schemas).await?);
     unsupported.extend(detect_inherited_tables(connection, target_schemas).await?);
     unsupported.extend(detect_foreign_tables(connection, target_schemas).await?);
@@ -96,32 +95,6 @@ async fn detect_composite_types(
         .map(|row| UnsupportedObject::CompositeType {
             schema: row.get("nspname"),
             name: row.get("typname"),
-        })
-        .collect())
-}
-
-async fn detect_aggregates(
-    connection: &PgConnection,
-    target_schemas: &[String],
-) -> Result<Vec<UnsupportedObject>> {
-    let rows = sqlx::query(
-        r#"
-        SELECT n.nspname, p.proname
-        FROM pg_proc p
-        JOIN pg_namespace n ON p.pronamespace = n.oid
-        WHERE p.prokind = 'a' AND n.nspname = ANY($1)
-        "#,
-    )
-    .bind(target_schemas)
-    .fetch_all(connection.pool())
-    .await
-    .map_err(|e| SchemaError::DatabaseError(format!("Failed to detect aggregates: {e}")))?;
-
-    Ok(rows
-        .into_iter()
-        .map(|row| UnsupportedObject::Aggregate {
-            schema: row.get("nspname"),
-            name: row.get("proname"),
         })
         .collect())
 }

--- a/src/diff/dump_planner.rs
+++ b/src/diff/dump_planner.rs
@@ -14,6 +14,7 @@ pub(crate) fn plan_dump(ops: Vec<MigrationOp>) -> Vec<MigrationOp> {
     let mut create_sequences = Vec::new();
     let mut create_partitions = Vec::new();
     let mut create_functions = Vec::new();
+    let mut create_aggregates = Vec::new();
     let mut create_views = Vec::new();
     let mut create_triggers = Vec::new();
     let mut enable_rls = Vec::new();
@@ -35,6 +36,7 @@ pub(crate) fn plan_dump(ops: Vec<MigrationOp>) -> Vec<MigrationOp> {
             MigrationOp::CreateSequence(_) => create_sequences.push(op),
             MigrationOp::CreatePartition(_) => create_partitions.push(op),
             MigrationOp::CreateFunction(_) => create_functions.push(op),
+            MigrationOp::CreateAggregate(_) => create_aggregates.push(op),
             MigrationOp::CreateView(_) => create_views.push(op),
             MigrationOp::CreateTrigger(_) => create_triggers.push(op),
             MigrationOp::EnableRls { .. } => enable_rls.push(op),
@@ -74,6 +76,7 @@ pub(crate) fn plan_dump(ops: Vec<MigrationOp>) -> Vec<MigrationOp> {
             | MigrationOp::AlterPolicy { .. }
             | MigrationOp::DropFunction { .. }
             | MigrationOp::AlterFunction { .. }
+            | MigrationOp::DropAggregate { .. }
             | MigrationOp::DropView { .. }
             | MigrationOp::AlterView { .. }
             | MigrationOp::DropTrigger { .. }
@@ -100,6 +103,7 @@ pub(crate) fn plan_dump(ops: Vec<MigrationOp>) -> Vec<MigrationOp> {
     result.extend(create_enums);
     result.extend(create_domains);
     result.extend(create_functions);
+    result.extend(create_aggregates);
     result.extend(create_tables);
     result.extend(create_partitions);
     result.extend(create_sequences);

--- a/src/diff/mod.rs
+++ b/src/diff/mod.rs
@@ -22,8 +22,8 @@ use dependencies::{
 };
 use grants::diff_default_privileges;
 use objects::{
-    diff_domains, diff_enums, diff_extensions, diff_functions, diff_partitions, diff_schemas,
-    diff_sequences, diff_servers, diff_tables, diff_triggers, diff_views,
+    diff_aggregates, diff_domains, diff_enums, diff_extensions, diff_functions, diff_partitions,
+    diff_schemas, diff_sequences, diff_servers, diff_tables, diff_triggers, diff_views,
 };
 use table_elements::{
     diff_check_constraints, diff_columns, diff_exclusion_constraints, diff_force_rls,
@@ -56,6 +56,7 @@ pub fn compute_diff_with_flags(
     ops.extend(diff_tables(from, to, &options));
     ops.extend(diff_partitions(from, to, &options));
     ops.extend(diff_functions(from, to, &options));
+    ops.extend(diff_aggregates(from, to, &options));
     ops.extend(diff_views(from, to, &options));
     ops.extend(diff_triggers(from, to));
     ops.extend(diff_sequences(from, to, &options));

--- a/src/diff/objects.rs
+++ b/src/diff/objects.rs
@@ -430,6 +430,44 @@ fn view_owner_kind(materialized: bool) -> OwnerObjectKind {
     }
 }
 
+pub(super) fn diff_aggregates(
+    from: &Schema,
+    to: &Schema,
+    options: &DiffOptions,
+) -> Vec<MigrationOp> {
+    let mut ops = Vec::new();
+    diff_objects(
+        &mut ops,
+        options,
+        &from.aggregates,
+        &to.aggregates,
+        |_key, agg| MigrationOp::CreateAggregate(agg.clone()),
+        |ops, _key, from_agg, to_agg| {
+            if !from_agg.semantically_equals(to_agg) {
+                ops.push(MigrationOp::DropAggregate {
+                    name: qualified_name(&from_agg.schema, &from_agg.name),
+                    args: from_agg.args_string(),
+                });
+                ops.push(MigrationOp::CreateAggregate(to_agg.clone()));
+            }
+        },
+        |_key, agg| MigrationOp::DropAggregate {
+            name: qualified_name(&agg.schema, &agg.name),
+            args: agg.args_string(),
+        },
+        |_key, agg| ObjectCoords {
+            schema: agg.schema.clone(),
+            name: agg.name.clone(),
+            args: Some(agg.args_string()),
+        },
+        Some(GrantObjectKind::Aggregate),
+        |_val| Some(OwnerObjectKind::Aggregate),
+        |val| &val.owner,
+        |val| &val.grants,
+    );
+    ops
+}
+
 pub(super) fn diff_views(from: &Schema, to: &Schema, options: &DiffOptions) -> Vec<MigrationOp> {
     let mut ops = Vec::new();
     diff_objects(

--- a/src/diff/op_key.rs
+++ b/src/diff/op_key.rs
@@ -137,6 +137,14 @@ pub(crate) enum OpKey {
         name: String,
         args: String,
     },
+    CreateAggregate {
+        name: String,
+        args: String,
+    },
+    DropAggregate {
+        name: String,
+        args: String,
+    },
     CreateView(String),
     DropView(String),
     AlterView(String),
@@ -346,6 +354,14 @@ impl OpKey {
                 name: name.clone(),
                 args: args.clone(),
             },
+            MigrationOp::CreateAggregate(a) => OpKey::CreateAggregate {
+                name: qualified_name(&a.schema, &a.name),
+                args: a.args_string(),
+            },
+            MigrationOp::DropAggregate { name, args } => OpKey::DropAggregate {
+                name: name.clone(),
+                args: args.clone(),
+            },
             MigrationOp::CreateView(v) => OpKey::CreateView(qualified_name(&v.schema, &v.name)),
             MigrationOp::DropView { name, .. } => OpKey::DropView(name.clone()),
             MigrationOp::AlterView { name, .. } => OpKey::AlterView(name.clone()),
@@ -483,6 +499,17 @@ pub(crate) fn add_privilege_dependency_edge(
             if let Some(args) = args {
                 edges.push((
                     OpKey::CreateFunction {
+                        name: qualified,
+                        args: args.clone(),
+                    },
+                    key.clone(),
+                ));
+            }
+        }
+        GrantObjectKind::Aggregate => {
+            if let Some(args) = args {
+                edges.push((
+                    OpKey::CreateAggregate {
                         name: qualified,
                         args: args.clone(),
                     },

--- a/src/diff/planner.rs
+++ b/src/diff/planner.rs
@@ -663,9 +663,7 @@ impl MigrationGraph {
                                 }
                             }
                         }
-                        if let (Some(sch), Some(n)) =
-                            (&agg.finalfunc_schema, &agg.finalfunc_name)
-                        {
+                        if let (Some(sch), Some(n)) = (&agg.finalfunc_schema, &agg.finalfunc_name) {
                             let finalfunc = qualified_name(sch, n);
                             for other_key in &keys {
                                 if let OpKey::CreateFunction {

--- a/src/diff/planner.rs
+++ b/src/diff/planner.rs
@@ -34,6 +34,8 @@ struct NodeSets {
     sequences: Vec<NodeIndex>,
     functions: Vec<NodeIndex>,
     alter_functions: Vec<NodeIndex>,
+    aggregates: Vec<NodeIndex>,
+    drop_aggregates: Vec<NodeIndex>,
     tables: Vec<NodeIndex>,
     partitions: Vec<NodeIndex>,
     add_columns: Vec<NodeIndex>,
@@ -87,6 +89,8 @@ impl NodeSets {
             sequences: graph.nodes_matching(|k| matches!(k, OpKey::CreateSequence(_))),
             functions: graph.nodes_matching(|k| matches!(k, OpKey::CreateFunction { .. })),
             alter_functions: graph.nodes_matching(|k| matches!(k, OpKey::AlterFunction { .. })),
+            aggregates: graph.nodes_matching(|k| matches!(k, OpKey::CreateAggregate { .. })),
+            drop_aggregates: graph.nodes_matching(|k| matches!(k, OpKey::DropAggregate { .. })),
             tables: graph.nodes_matching(|k| matches!(k, OpKey::CreateTable(_))),
             partitions: graph.nodes_matching(|k| matches!(k, OpKey::CreatePartition(_))),
             add_columns: graph.nodes_matching(|k| matches!(k, OpKey::AddColumn { .. })),
@@ -208,6 +212,7 @@ impl MigrationGraph {
         self.edges_all_to_all(&ns.schemas, &ns.domains);
         self.edges_all_to_all(&ns.schemas, &ns.sequences);
         self.edges_all_to_all(&ns.schemas, &ns.functions);
+        self.edges_all_to_all(&ns.schemas, &ns.aggregates);
         self.edges_all_to_all(&ns.schemas, &ns.views);
         self.edges_all_to_all(&ns.version_schemas, &ns.version_views);
 
@@ -233,6 +238,9 @@ impl MigrationGraph {
         self.edges_all_to_all(&ns.enums, &ns.alter_functions);
         self.edges_all_to_all(&ns.domains, &ns.alter_functions);
         self.edges_all_to_all(&ns.add_enum_values, &ns.alter_functions);
+        self.edges_all_to_all(&ns.enums, &ns.aggregates);
+        self.edges_all_to_all(&ns.domains, &ns.aggregates);
+        self.edges_all_to_all(&ns.add_enum_values, &ns.aggregates);
     }
 
     /// Tier 3: Sequences and functions before tables.
@@ -317,6 +325,14 @@ impl MigrationGraph {
         self.edges_all_to_all(&ns.functions, &ns.add_columns);
         self.edges_all_to_all(&ns.functions, &ns.triggers);
         self.edges_all_to_all(&ns.functions, &ns.policies);
+
+        // Aggregate ordering is handled entirely by content-aware edges:
+        //   - aggregate → view / policy / trigger when those bodies call the aggregate
+        //     (via `push_function_edges`, which now matches `CreateAggregate` too)
+        //   - SFUNC/FINALFUNC function → aggregate in the `CreateAggregate` arm of
+        //     `add_content_aware_edges`
+        // Blanket tier edges would create spurious cycles when an aggregate's SFUNC
+        // body indirectly references a view / policy / trigger that uses the aggregate.
     }
 
     /// Tier 4: Tables before partitions, and tables before all table-level objects.
@@ -371,6 +387,11 @@ impl MigrationGraph {
         self.edges_all_to_all(&ns.drop_partitions, &ns.drop_tables);
 
         self.edges_all_to_all(&ns.drop_views, &ns.drop_tables);
+
+        // Aggregates depend on their SFUNC function, so drop aggregates before dropping functions.
+        self.edges_all_to_all(&ns.drop_aggregates, &ns.drop_functions);
+        // Views can reference aggregates; drop views before aggregates they consumed.
+        self.edges_all_to_all(&ns.drop_views, &ns.drop_aggregates);
 
         self.edges_all_to_all(&ns.drop_version_views, &ns.drop_version_schemas);
 
@@ -621,6 +642,41 @@ impl MigrationGraph {
                             edges_to_add
                                 .push((OpKey::CreateTable(ref_qualified.clone()), key.clone()));
                             edges_to_add.push((OpKey::CreateView(ref_qualified), key.clone()));
+                        }
+                    }
+                }
+
+                // CreateAggregate depends on its SFUNC and FINALFUNC functions.
+                // The aggregate's own OpKey::CreateAggregate is the consumer; the
+                // referenced function's CreateFunction op (if any matches by qualified name)
+                // is the producer.
+                OpKey::CreateAggregate { .. } => {
+                    if let Some(MigrationOp::CreateAggregate(agg)) = self.get_op(key) {
+                        let sfunc = qualified_name(&agg.sfunc_schema, &agg.sfunc_name);
+                        for other_key in &keys {
+                            if let OpKey::CreateFunction {
+                                name: other_name, ..
+                            } = other_key
+                            {
+                                if *other_name == sfunc {
+                                    edges_to_add.push((other_key.clone(), key.clone()));
+                                }
+                            }
+                        }
+                        if let (Some(sch), Some(n)) =
+                            (&agg.finalfunc_schema, &agg.finalfunc_name)
+                        {
+                            let finalfunc = qualified_name(sch, n);
+                            for other_key in &keys {
+                                if let OpKey::CreateFunction {
+                                    name: other_name, ..
+                                } = other_key
+                                {
+                                    if *other_name == finalfunc {
+                                        edges_to_add.push((other_key.clone(), key.clone()));
+                                    }
+                                }
+                            }
                         }
                     }
                 }
@@ -888,6 +944,20 @@ impl MigrationGraph {
                                 ));
                             }
                         }
+                        OwnerObjectKind::Aggregate => {
+                            if let Some(MigrationOp::AlterOwner {
+                                args: Some(args), ..
+                            }) = self.get_op(key)
+                            {
+                                edges_to_add.push((
+                                    OpKey::CreateAggregate {
+                                        name: qualified,
+                                        args: args.clone(),
+                                    },
+                                    key.clone(),
+                                ));
+                            }
+                        }
                     }
                 }
 
@@ -958,13 +1028,16 @@ fn push_function_edges(
     consumer_key: &OpKey,
 ) {
     for other_key in keys {
-        if let OpKey::CreateFunction {
-            name: other_name, ..
-        } = other_key
-        {
-            if *other_name == ref_qualified {
+        match other_key {
+            OpKey::CreateFunction {
+                name: other_name, ..
+            }
+            | OpKey::CreateAggregate {
+                name: other_name, ..
+            } if *other_name == ref_qualified => {
                 edges.push((other_key.clone(), consumer_key.clone()));
             }
+            _ => {}
         }
     }
 }

--- a/src/diff/types.rs
+++ b/src/diff/types.rs
@@ -1,10 +1,10 @@
 use std::collections::HashSet;
 
 use crate::model::{
-    CheckConstraint, Column, Domain, EnumType, ExclusionConstraint, Extension, ForeignKey,
-    Function, Index, Partition, PgSchema, PgType, Policy, PrimaryKey, Privilege, QualifiedName,
-    Sequence, SequenceDataType, SequenceOwner, Server, Table, Trigger, TriggerEnabled, VersionView,
-    View,
+    Aggregate, CheckConstraint, Column, Domain, EnumType, ExclusionConstraint, Extension,
+    ForeignKey, Function, Index, Partition, PgSchema, PgType, Policy, PrimaryKey, Privilege,
+    QualifiedName, Sequence, SequenceDataType, SequenceOwner, Server, Table, Trigger,
+    TriggerEnabled, VersionView, View,
 };
 
 pub struct DiffOptions<'a> {
@@ -20,6 +20,7 @@ pub enum CommentObjectType {
     View,
     MaterializedView,
     Function,
+    Aggregate,
     Type,
     Domain,
     Schema,
@@ -35,6 +36,7 @@ pub enum OwnerObjectKind {
     MaterializedView,
     Sequence,
     Function,
+    Aggregate,
     Type,
     Domain,
 }
@@ -45,6 +47,7 @@ pub enum GrantObjectKind {
     View,
     Sequence,
     Function,
+    Aggregate,
     Schema,
     Type,
     Domain,
@@ -166,6 +169,11 @@ pub enum MigrationOp {
         name: String,
         args: String,
         new_function: Function,
+    },
+    CreateAggregate(Aggregate),
+    DropAggregate {
+        name: String,
+        args: String,
     },
     CreateView(View),
     DropView {

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -331,6 +331,34 @@ pub fn schema_to_create_ops(schema: &Schema) -> Vec<MigrationOp> {
         );
     }
 
+    for aggregate in schema.aggregates.values() {
+        ops.push(MigrationOp::CreateAggregate(aggregate.clone()));
+        let agg_args = aggregate.args_string();
+        push_owner_and_grant_ops(
+            &mut ops,
+            DumpObjectInfo {
+                owner: &aggregate.owner,
+                owner_kind: OwnerObjectKind::Aggregate,
+                grants: &aggregate.grants,
+                grant_kind: GrantObjectKind::Aggregate,
+                schema: &aggregate.schema,
+                name: &aggregate.name,
+                args: Some(agg_args.clone()),
+            },
+        );
+        if let Some(text) = &aggregate.comment {
+            ops.push(MigrationOp::SetComment {
+                object_type: CommentObjectType::Aggregate,
+                schema: aggregate.schema.clone(),
+                name: aggregate.name.clone(),
+                arguments: Some(agg_args.clone()),
+                column: None,
+                target: None,
+                comment: Some(text.clone()),
+            });
+        }
+    }
+
     for view in schema.views.values() {
         ops.push(MigrationOp::CreateView(view.clone()));
         push_owner_and_grant_ops(

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -236,6 +236,7 @@ pub fn filter_schema(schema: &Schema, filter: &Filter) -> Schema {
     let strip_grants = !filter.should_include_type(ObjectType::Grants);
 
     let mut functions = filter_field(&schema.functions, filter, ObjectType::Functions);
+    let mut aggregates = filter_field(&schema.aggregates, filter, ObjectType::Functions);
     let mut views = filter_field(&schema.views, filter, ObjectType::Views);
     let mut sequences = filter_field(&schema.sequences, filter, ObjectType::Sequences);
     let mut enums = filter_field(&schema.enums, filter, ObjectType::Enums);
@@ -244,6 +245,7 @@ pub fn filter_schema(schema: &Schema, filter: &Filter) -> Schema {
 
     if strip_grants {
         strip_grants_from_values(&mut functions);
+        strip_grants_from_values(&mut aggregates);
         strip_grants_from_values(&mut views);
         strip_grants_from_values(&mut sequences);
         strip_grants_from_values(&mut enums);
@@ -268,6 +270,7 @@ pub fn filter_schema(schema: &Schema, filter: &Filter) -> Schema {
         enums,
         domains,
         functions,
+        aggregates,
         views,
         triggers: filter_field(&schema.triggers, filter, ObjectType::Triggers),
         sequences,
@@ -341,6 +344,7 @@ pub fn filter_by_target_schemas(schema: &Schema, target_schemas: &[String]) -> S
         enums: retain_by_schema(&schema.enums, &allowed, |e| &e.schema),
         domains: retain_by_schema(&schema.domains, &allowed, |d| &d.schema),
         functions: retain_by_schema(&schema.functions, &allowed, |f| &f.schema),
+        aggregates: retain_by_schema(&schema.aggregates, &allowed, |a| &a.schema),
         views: retain_by_schema(&schema.views, &allowed, |v| &v.schema),
         triggers: retain_by_schema(&schema.triggers, &allowed, |t| &t.target_schema),
         sequences: retain_by_schema(&schema.sequences, &allowed, |s| &s.schema),
@@ -383,6 +387,12 @@ impl HasName for crate::model::Table {
 }
 
 impl HasName for crate::model::Function {
+    fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+impl HasName for crate::model::Aggregate {
     fn name(&self) -> &str {
         &self.name
     }
@@ -452,6 +462,7 @@ macro_rules! impl_has_grants {
 
 impl_has_grants!(
     crate::model::Function,
+    crate::model::Aggregate,
     crate::model::View,
     crate::model::Sequence,
     crate::model::EnumType,

--- a/src/lint/mod.rs
+++ b/src/lint/mod.rs
@@ -256,6 +256,8 @@ fn lint_op(op: &MigrationOp, options: &LintOptions) -> Vec<LintResult> {
         | MigrationOp::CreateFunction(_)
         | MigrationOp::DropFunction { .. }
         | MigrationOp::AlterFunction { .. }
+        | MigrationOp::CreateAggregate(_)
+        | MigrationOp::DropAggregate { .. }
         | MigrationOp::CreateView(_)
         | MigrationOp::AlterView { .. }
         | MigrationOp::CreateTrigger(_)

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -72,6 +72,7 @@ pub enum PendingOwnerObjectType {
     View,
     Sequence,
     Function,
+    Aggregate,
     Enum,
     Domain,
 }
@@ -81,6 +82,7 @@ pub enum PendingCommentObjectType {
     Table,
     Column,
     Function,
+    Aggregate,
     View,
     MaterializedView,
     Type,
@@ -114,6 +116,7 @@ pub enum PendingGrantObjectType {
     View,
     Sequence,
     Function,
+    Aggregate,
     Schema,
     Enum,
     Domain,
@@ -139,6 +142,8 @@ pub struct Schema {
     pub enums: BTreeMap<String, EnumType>,
     pub domains: BTreeMap<String, Domain>,
     pub functions: BTreeMap<String, Function>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub aggregates: BTreeMap<String, Aggregate>,
     pub views: BTreeMap<String, View>,
     pub triggers: BTreeMap<String, Trigger>,
     pub sequences: BTreeMap<String, Sequence>,
@@ -645,6 +650,72 @@ pub enum SecurityType {
     Definer,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+pub enum AggregateParallel {
+    Safe,
+    Restricted,
+    Unsafe,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Aggregate {
+    pub schema: String,
+    pub name: String,
+    pub args: Vec<String>,
+    pub sfunc_schema: String,
+    pub sfunc_name: String,
+    pub stype: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub finalfunc_schema: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub finalfunc_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub initcond: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parallel: Option<AggregateParallel>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub grants: Vec<Grant>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
+}
+
+impl Aggregate {
+    /// Returns the comma-separated list of argument types, normalized for PG canonical forms.
+    pub fn args_string(&self) -> String {
+        self.args
+            .iter()
+            .map(|a| normalize_pg_type(a).into_owned())
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
+
+    /// Returns "name(args)" used as the BTreeMap key suffix, matching Function::signature.
+    pub fn signature(&self) -> String {
+        format!("{}({})", self.name, self.args_string())
+    }
+
+    /// Compares two aggregates semantically, ignoring ownership.
+    pub fn semantically_equals(&self, other: &Aggregate) -> bool {
+        self.schema == other.schema
+            && self.name == other.name
+            && self.args.len() == other.args.len()
+            && self
+                .args
+                .iter()
+                .zip(other.args.iter())
+                .all(|(a, b)| normalize_pg_type(a) == normalize_pg_type(b))
+            && self.sfunc_schema == other.sfunc_schema
+            && self.sfunc_name == other.sfunc_name
+            && normalize_pg_type(&self.stype) == normalize_pg_type(&other.stype)
+            && self.finalfunc_schema == other.finalfunc_schema
+            && self.finalfunc_name == other.finalfunc_name
+            && self.initcond == other.initcond
+            && self.parallel == other.parallel
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct View {
     pub name: String,
@@ -884,6 +955,7 @@ impl Schema {
             enums: BTreeMap::new(),
             domains: BTreeMap::new(),
             functions: BTreeMap::new(),
+            aggregates: BTreeMap::new(),
             views: BTreeMap::new(),
             triggers: BTreeMap::new(),
             sequences: BTreeMap::new(),
@@ -1012,6 +1084,14 @@ impl Schema {
                     false
                 }
             }
+            PendingOwnerObjectType::Aggregate => {
+                if let Some(agg) = self.aggregates.get_mut(&po.object_key) {
+                    agg.owner = Some(po.owner.clone());
+                    true
+                } else {
+                    false
+                }
+            }
             PendingOwnerObjectType::Enum => {
                 if let Some(enum_type) = self.enums.get_mut(&po.object_key) {
                     enum_type.owner = Some(po.owner.clone());
@@ -1069,7 +1149,12 @@ impl Schema {
                 .map(|v| &mut v.grants)
                 .or_else(|| self.tables.get_mut(key).map(|t| &mut t.grants)),
             PendingGrantObjectType::Sequence => self.sequences.get_mut(key).map(|s| &mut s.grants),
-            PendingGrantObjectType::Function => self.functions.get_mut(key).map(|f| &mut f.grants),
+            PendingGrantObjectType::Function => self
+                .functions
+                .get_mut(key)
+                .map(|f| &mut f.grants)
+                .or_else(|| self.aggregates.get_mut(key).map(|a| &mut a.grants)),
+            PendingGrantObjectType::Aggregate => self.aggregates.get_mut(key).map(|a| &mut a.grants),
             PendingGrantObjectType::Schema => self.schemas.get_mut(key).map(|s| &mut s.grants),
             PendingGrantObjectType::Enum => self
                 .enums
@@ -1169,6 +1254,14 @@ impl Schema {
                     false
                 }
             }
+            PendingCommentObjectType::Aggregate => {
+                if let Some(agg) = self.aggregates.get_mut(&pc.object_key) {
+                    agg.comment = pc.comment.clone();
+                    true
+                } else {
+                    false
+                }
+            }
             PendingCommentObjectType::View | PendingCommentObjectType::MaterializedView => {
                 if let Some(view) = self.views.get_mut(&pc.object_key) {
                     view.comment = pc.comment.clone();
@@ -1232,6 +1325,9 @@ impl Schema {
         }
         for function in self.functions.values_mut() {
             merge_grants_by_grantee(&mut function.grants);
+        }
+        for aggregate in self.aggregates.values_mut() {
+            merge_grants_by_grantee(&mut aggregate.grants);
         }
         for schema in self.schemas.values_mut() {
             merge_grants_by_grantee(&mut schema.grants);

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1154,7 +1154,9 @@ impl Schema {
                 .get_mut(key)
                 .map(|f| &mut f.grants)
                 .or_else(|| self.aggregates.get_mut(key).map(|a| &mut a.grants)),
-            PendingGrantObjectType::Aggregate => self.aggregates.get_mut(key).map(|a| &mut a.grants),
+            PendingGrantObjectType::Aggregate => {
+                self.aggregates.get_mut(key).map(|a| &mut a.grants)
+            }
             PendingGrantObjectType::Schema => self.schemas.get_mut(key).map(|s| &mut s.grants),
             PendingGrantObjectType::Enum => self
                 .enums

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -29,12 +29,13 @@ use crate::model::*;
 use crate::pg::sqlgen::strip_ident_quotes;
 use crate::util::{normalize_sql_whitespace, Result, SchemaError};
 use sqlparser::ast::{
-    AlterIndexOperation, AlterTable, AlterTableOperation, AlterType, AlterTypeAddValue,
-    AlterTypeAddValuePosition, AlterTypeOperation, CreateDomain, CreateExtension, CreateFunction,
-    CreateServerStatement, CreateTrigger, CreateView, DropDomain, DropExtension, DropFunction,
-    DropTrigger, ObjectType, RenameTableNameKind, SchemaName, Statement, TableConstraint,
-    TriggerEvent as SqlTriggerEvent, TriggerPeriod, TriggerReferencingType,
-    UserDefinedTypeRepresentation,
+    AlterFunction, AlterFunctionKind, AlterFunctionOperation, AlterIndexOperation, AlterTable,
+    AlterTableOperation, AlterType, AlterTypeAddValue, AlterTypeAddValuePosition,
+    AlterTypeOperation, CreateAggregate, CreateAggregateOption, CreateDomain, CreateExtension,
+    CreateFunction, CreateServerStatement, CreateTrigger, CreateView, DropDomain, DropExtension,
+    DropFunction, DropTrigger, FunctionParallel, ObjectType, Owner, RenameTableNameKind,
+    SchemaName, Statement, TableConstraint, TriggerEvent as SqlTriggerEvent, TriggerPeriod,
+    TriggerReferencingType, UserDefinedTypeRepresentation,
 };
 use sqlparser::dialect::PostgreSqlDialect;
 use sqlparser::parser::Parser;
@@ -1033,7 +1034,6 @@ pub fn parse_sql_string(sql: &str) -> Result<Schema> {
             | Statement::DropOperator(_)
             | Statement::DropOperatorClass(_)
             | Statement::DropOperatorFamily(_)
-            | Statement::CreateAggregate(_)
             | Statement::CreateTextSearchConfiguration(_)
             | Statement::CreateTextSearchDictionary(_)
             | Statement::CreateTextSearchParser(_)
@@ -1143,7 +1143,6 @@ pub fn parse_sql_string(sql: &str) -> Result<Schema> {
             // separately; the previously wildcarded behaviour is preserved
             // here.
             | Statement::CreateType { .. }
-            | Statement::AlterFunction(_)
             | Statement::AlterCollation(_)
             | Statement::AlterOperatorFamily(_)
             | Statement::AlterOperatorClass(_)
@@ -1155,6 +1154,12 @@ pub fn parse_sql_string(sql: &str) -> Result<Schema> {
             | Statement::WaitFor(_) => {}
             Statement::CreateServer(stmt) => {
                 parse_create_server(stmt, &mut schema);
+            }
+            Statement::CreateAggregate(stmt) => {
+                parse_create_aggregate(stmt, &mut schema)?;
+            }
+            Statement::AlterFunction(alter) => {
+                parse_alter_aggregate_owner(alter, &mut schema);
             }
         }
     }
@@ -1168,6 +1173,135 @@ pub fn parse_sql_string(sql: &str) -> Result<Schema> {
     schema.pending_policies = schema.finalize_partial();
 
     Ok(schema)
+}
+
+fn parse_create_aggregate(stmt: CreateAggregate, schema: &mut Schema) -> Result<()> {
+    let (agg_schema, agg_name) = extract_qualified_name(&stmt.name);
+    let args: Vec<String> = stmt
+        .args
+        .iter()
+        .map(|dt| crate::model::normalize_pg_type(&dt.to_string()).into_owned())
+        .collect();
+
+    let mut sfunc_schema: Option<String> = None;
+    let mut sfunc_name: Option<String> = None;
+    let mut stype: Option<String> = None;
+    let mut finalfunc_schema: Option<String> = None;
+    let mut finalfunc_name: Option<String> = None;
+    let mut initcond: Option<String> = None;
+    let mut parallel: Option<AggregateParallel> = None;
+
+    for option in stmt.options {
+        match option {
+            CreateAggregateOption::Sfunc(name) => {
+                let (s, n) = extract_qualified_name(&name);
+                sfunc_schema = Some(s);
+                sfunc_name = Some(n);
+            }
+            CreateAggregateOption::Stype(data_type) => {
+                stype = Some(crate::model::normalize_pg_type(&data_type.to_string()).into_owned());
+            }
+            CreateAggregateOption::Finalfunc(name) => {
+                let (s, n) = extract_qualified_name(&name);
+                finalfunc_schema = Some(s);
+                finalfunc_name = Some(n);
+            }
+            CreateAggregateOption::Initcond(value) => {
+                initcond = Some(value.to_string().trim_matches('\'').to_string());
+            }
+            CreateAggregateOption::Parallel(p) => {
+                parallel = match p {
+                    FunctionParallel::Safe => Some(AggregateParallel::Safe),
+                    FunctionParallel::Restricted => Some(AggregateParallel::Restricted),
+                    // PARALLEL = UNSAFE is the PostgreSQL default; drop to keep parse and introspect aligned.
+                    FunctionParallel::Unsafe => None,
+                };
+            }
+            CreateAggregateOption::Sspace(_)
+            | CreateAggregateOption::FinalfuncExtra
+            | CreateAggregateOption::FinalfuncModify(_)
+            | CreateAggregateOption::Combinefunc(_)
+            | CreateAggregateOption::Serialfunc(_)
+            | CreateAggregateOption::Deserialfunc(_)
+            | CreateAggregateOption::Msfunc(_)
+            | CreateAggregateOption::Minvfunc(_)
+            | CreateAggregateOption::Mstype(_)
+            | CreateAggregateOption::Msspace(_)
+            | CreateAggregateOption::Mfinalfunc(_)
+            | CreateAggregateOption::MfinalfuncExtra
+            | CreateAggregateOption::MfinalfuncModify(_)
+            | CreateAggregateOption::Minitcond(_)
+            | CreateAggregateOption::Sortop(_)
+            | CreateAggregateOption::Hypothetical => {}
+        }
+    }
+
+    let sfunc_schema = sfunc_schema.ok_or_else(|| {
+        SchemaError::ParseError(format!(
+            "CREATE AGGREGATE {agg_schema}.{agg_name} missing required SFUNC"
+        ))
+    })?;
+    let sfunc_name = sfunc_name.unwrap();
+    let stype = stype.ok_or_else(|| {
+        SchemaError::ParseError(format!(
+            "CREATE AGGREGATE {agg_schema}.{agg_name} missing required STYPE"
+        ))
+    })?;
+
+    let aggregate = Aggregate {
+        schema: agg_schema.clone(),
+        name: agg_name.clone(),
+        args,
+        sfunc_schema,
+        sfunc_name,
+        stype,
+        finalfunc_schema,
+        finalfunc_name,
+        initcond,
+        parallel,
+        owner: None,
+        grants: Vec::new(),
+        comment: None,
+    };
+
+    let key = qualified_name(&agg_schema, &aggregate.signature());
+    schema.aggregates.insert(key, aggregate);
+    Ok(())
+}
+
+fn parse_alter_aggregate_owner(alter: AlterFunction, schema: &mut Schema) {
+    if !matches!(alter.kind, AlterFunctionKind::Aggregate) {
+        return;
+    }
+    let AlterFunctionOperation::OwnerTo(owner) = alter.operation else {
+        return;
+    };
+    let owner_name = match owner {
+        Owner::Ident(ident) => ident.value,
+        Owner::CurrentRole | Owner::CurrentUser | Owner::SessionUser => return,
+    };
+
+    let (agg_schema, agg_name) = extract_qualified_name(&alter.function.name);
+    let args_sig = if alter.aggregate_star {
+        String::new()
+    } else {
+        alter
+            .function
+            .args
+            .unwrap_or_default()
+            .iter()
+            .map(|a| crate::model::normalize_pg_type(&a.data_type.to_string()).into_owned())
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
+    let signature = format!("{agg_name}({args_sig})");
+    let object_key = qualified_name(&agg_schema, &signature);
+
+    schema.pending_owners.push(PendingOwner {
+        object_type: PendingOwnerObjectType::Aggregate,
+        object_key,
+        owner: owner_name,
+    });
 }
 
 fn parse_create_server(stmt: CreateServerStatement, schema: &mut Schema) {

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -4202,3 +4202,47 @@ ALTER TABLE public.measurement DETACH PARTITION public.measurement_y2021m01 CONC
         "Concurrently detached partition should not appear in schema"
     );
 }
+
+#[test]
+fn create_aggregate_minimal_sfunc_stype() {
+    let sql = r#"
+CREATE AGGREGATE public.group_concat(text) (
+    SFUNC = public._group_concat,
+    STYPE = text
+);
+"#;
+    let schema = parse_sql_string(sql).expect("Should parse CREATE AGGREGATE");
+    let agg = schema
+        .aggregates
+        .get("public.group_concat(text)")
+        .expect("Aggregate should be stored under signature key");
+
+    assert_eq!(agg.schema, "public");
+    assert_eq!(agg.name, "group_concat");
+    assert_eq!(agg.args, vec!["text".to_string()]);
+    assert_eq!(agg.sfunc_schema, "public");
+    assert_eq!(agg.sfunc_name, "_group_concat");
+    assert_eq!(agg.stype, "text");
+    assert!(agg.finalfunc_name.is_none());
+    assert!(agg.initcond.is_none());
+    assert!(agg.parallel.is_none());
+}
+
+#[test]
+fn alter_aggregate_owner_records_pending_owner() {
+    let sql = r#"
+CREATE AGGREGATE public.group_concat(text) (
+    SFUNC = public._group_concat,
+    STYPE = text
+);
+
+ALTER AGGREGATE public.group_concat(text) OWNER TO postgres;
+"#;
+    let schema = parse_sql_string(sql).expect("Should parse");
+    let agg = schema
+        .aggregates
+        .get("public.group_concat(text)")
+        .expect("Aggregate should exist");
+
+    assert_eq!(agg.owner.as_deref(), Some("postgres"));
+}

--- a/src/pg/introspect.rs
+++ b/src/pg/introspect.rs
@@ -21,6 +21,7 @@ pub async fn introspect_schema(
         domains,
         tables,
         functions,
+        aggregates,
         views,
         triggers,
         sequences,
@@ -49,6 +50,7 @@ pub async fn introspect_schema(
         introspect_domains(connection, target_schemas, include_extension_objects),
         introspect_tables(connection, target_schemas, include_extension_objects),
         introspect_functions(connection, target_schemas, include_extension_objects),
+        introspect_aggregates(connection, target_schemas, include_extension_objects),
         introspect_views(connection, target_schemas, include_extension_objects),
         introspect_triggers(connection, target_schemas, include_extension_objects),
         introspect_sequences(connection, target_schemas, include_extension_objects),
@@ -79,6 +81,7 @@ pub async fn introspect_schema(
     schema.domains = domains;
     schema.tables = tables;
     schema.functions = functions;
+    schema.aggregates = aggregates;
     schema.views = views;
     schema.triggers = triggers;
     schema.sequences = sequences;
@@ -102,6 +105,8 @@ pub async fn introspect_schema(
     for (qualified_name, grants) in function_grants {
         if let Some(function) = schema.functions.get_mut(&qualified_name) {
             function.grants = grants;
+        } else if let Some(aggregate) = schema.aggregates.get_mut(&qualified_name) {
+            aggregate.grants = grants;
         }
     }
 
@@ -1650,6 +1655,110 @@ async fn introspect_functions(
     }
 
     Ok(functions)
+}
+
+async fn introspect_aggregates(
+    connection: &PgConnection,
+    target_schemas: &[String],
+    include_extension_objects: bool,
+) -> Result<BTreeMap<String, Aggregate>> {
+    let rows = sqlx::query(
+        r#"
+        SELECT
+            p.proname AS name,
+            n.nspname AS schema,
+            pg_get_function_identity_arguments(p.oid) AS arguments,
+            r.rolname AS owner,
+            sfunc_n.nspname AS sfunc_schema,
+            sfunc.proname AS sfunc_name,
+            pg_catalog.format_type(a.aggtranstype, NULL) AS stype,
+            finalfunc_n.nspname AS finalfunc_schema,
+            finalfunc.proname AS finalfunc_name,
+            a.agginitval AS initcond,
+            p.proparallel AS parallel,
+            a.aggkind AS aggkind
+        FROM pg_proc p
+        JOIN pg_namespace n ON p.pronamespace = n.oid
+        JOIN pg_aggregate a ON a.aggfnoid = p.oid
+        JOIN pg_roles r ON p.proowner = r.oid
+        LEFT JOIN pg_proc sfunc ON a.aggtransfn = sfunc.oid
+        LEFT JOIN pg_namespace sfunc_n ON sfunc.pronamespace = sfunc_n.oid
+        LEFT JOIN pg_proc finalfunc ON a.aggfinalfn = finalfunc.oid AND a.aggfinalfn <> 0
+        LEFT JOIN pg_namespace finalfunc_n ON finalfunc.pronamespace = finalfunc_n.oid
+        WHERE n.nspname = ANY($1::text[])
+          AND p.prokind = 'a'
+          AND ($2::boolean OR NOT EXISTS (
+              SELECT 1 FROM pg_depend d
+              WHERE d.objid = p.oid
+              AND d.deptype = 'e'
+          ))
+        "#,
+    )
+    .bind(target_schemas)
+    .bind(include_extension_objects)
+    .fetch_all(connection.pool())
+    .await
+    .map_err(|e| SchemaError::DatabaseError(format!("Failed to fetch aggregates: {e}")))?;
+
+    let mut aggregates = BTreeMap::new();
+    for row in rows {
+        let name: String = row.get("name");
+        let schema: String = row.get("schema");
+        let aggkind: i8 = row.get("aggkind");
+        // Only materialize normal aggregates for now — ordered-set ('o') and
+        // hypothetical ('h') aggregates have different signatures and are out
+        // of scope for pgmold-262.
+        if pg_char(aggkind) != 'n' {
+            continue;
+        }
+
+        let arguments_str: String = row.get("arguments");
+        let args: Vec<String> = if arguments_str.trim().is_empty() {
+            Vec::new()
+        } else {
+            parse_function_arguments(&arguments_str)
+                .into_iter()
+                .map(|arg| crate::model::normalize_pg_type(&arg.data_type).into_owned())
+                .collect()
+        };
+
+        let owner: String = row.get("owner");
+        let sfunc_schema: String = row.get("sfunc_schema");
+        let sfunc_name: String = row.get("sfunc_name");
+        let stype_raw: String = row.get("stype");
+        let stype = crate::model::normalize_pg_type(&stype_raw).into_owned();
+        let finalfunc_schema: Option<String> = row.get("finalfunc_schema");
+        let finalfunc_name: Option<String> = row.get("finalfunc_name");
+        let initcond: Option<String> = row.get("initcond");
+        let parallel_char: i8 = row.get("parallel");
+        let parallel = match pg_char(parallel_char) {
+            's' => Some(AggregateParallel::Safe),
+            'r' => Some(AggregateParallel::Restricted),
+            // 'u' (unsafe) is the PostgreSQL default; do not store it so parse and introspect converge
+            _ => None,
+        };
+
+        let aggregate = Aggregate {
+            schema: schema.clone(),
+            name: name.clone(),
+            args,
+            sfunc_schema,
+            sfunc_name,
+            stype,
+            finalfunc_schema,
+            finalfunc_name,
+            initcond,
+            parallel,
+            owner: Some(owner),
+            grants: Vec::new(),
+            comment: None,
+        };
+
+        let key = qualified_name(&schema, &aggregate.signature());
+        aggregates.insert(key, aggregate);
+    }
+
+    Ok(aggregates)
 }
 
 /// Splits a function argument list on commas, skipping commas inside

--- a/src/pg/sqlgen.rs
+++ b/src/pg/sqlgen.rs
@@ -3,11 +3,11 @@ use crate::diff::{
     MigrationOp, OwnerObjectKind, PolicyChanges, SequenceChanges,
 };
 use crate::model::{
-    parse_qualified_name, versioned_schema_name, ArgMode, CheckConstraint, Column, Domain,
-    ExclusionConstraint, ForeignKey, Function, Index, IndexType, Partition, PartitionBound,
-    PartitionStrategy, PgType, Policy, PolicyCommand, Privilege, QualifiedName, ReferentialAction,
-    SecurityType, Sequence, SequenceDataType, Table, Trigger, TriggerEnabled, TriggerEvent,
-    TriggerTiming, VersionView, View, Volatility,
+    parse_qualified_name, versioned_schema_name, Aggregate, AggregateParallel, ArgMode,
+    CheckConstraint, Column, Domain, ExclusionConstraint, ForeignKey, Function, Index, IndexType,
+    Partition, PartitionBound, PartitionStrategy, PgType, Policy, PolicyCommand, Privilege,
+    QualifiedName, ReferentialAction, SecurityType, Sequence, SequenceDataType, Table, Trigger,
+    TriggerEnabled, TriggerEvent, TriggerTiming, VersionView, View, Volatility,
 };
 
 pub fn generate_sql(ops: &[MigrationOp]) -> Vec<String> {
@@ -318,6 +318,17 @@ fn generate_op_sql(op: &MigrationOp) -> Vec<String> {
             vec![generate_function_ddl(new_function, true)]
         }
 
+        MigrationOp::CreateAggregate(agg) => vec![generate_aggregate_ddl(agg)],
+
+        MigrationOp::DropAggregate { name, args } => {
+            let (schema, agg_name) = parse_qualified_name(name);
+            vec![format!(
+                "DROP AGGREGATE {}({});",
+                quote_qualified(&schema, &agg_name),
+                args
+            )]
+        }
+
         MigrationOp::CreateView(view) => generate_view_ddl(view, false),
 
         MigrationOp::DropView { name, materialized } => {
@@ -560,6 +571,10 @@ fn generate_op_sql(op: &MigrationOp) -> Vec<String> {
                 CommentObjectType::Function => {
                     let args = arguments.as_deref().unwrap_or("");
                     format!("FUNCTION {}({})", quote_qualified(schema, name), args)
+                }
+                CommentObjectType::Aggregate => {
+                    let args = arguments.as_deref().unwrap_or("");
+                    format!("AGGREGATE {}({})", quote_qualified(schema, name), args)
                 }
                 CommentObjectType::View => {
                     format!("VIEW {}", quote_qualified(schema, name))
@@ -1233,6 +1248,48 @@ fn generate_function_ddl(func: &Function, replace: bool) -> String {
     parts.join(" ")
 }
 
+fn generate_aggregate_ddl(agg: &Aggregate) -> String {
+    let args = if agg.args.is_empty() {
+        "*".to_string()
+    } else {
+        agg.args
+            .iter()
+            .map(|a| a.as_str())
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
+
+    let mut options = vec![format!(
+        "SFUNC = {}",
+        quote_qualified(&agg.sfunc_schema, &agg.sfunc_name)
+    )];
+    options.push(format!("STYPE = {}", agg.stype));
+
+    if let (Some(sch), Some(n)) = (&agg.finalfunc_schema, &agg.finalfunc_name) {
+        options.push(format!("FINALFUNC = {}", quote_qualified(sch, n)));
+    }
+
+    if let Some(cond) = &agg.initcond {
+        options.push(format!("INITCOND = '{}'", escape_string(cond)));
+    }
+
+    if let Some(parallel) = &agg.parallel {
+        let label = match parallel {
+            AggregateParallel::Safe => "SAFE",
+            AggregateParallel::Restricted => "RESTRICTED",
+            AggregateParallel::Unsafe => "UNSAFE",
+        };
+        options.push(format!("PARALLEL = {label}"));
+    }
+
+    format!(
+        "CREATE AGGREGATE {}({}) ({});",
+        quote_qualified(&agg.schema, &agg.name),
+        args,
+        options.join(", ")
+    )
+}
+
 fn generate_view_ddl(view: &View, replace: bool) -> Vec<String> {
     let qualified_name = quote_qualified(&view.schema, &view.name);
     if view.materialized {
@@ -1425,6 +1482,7 @@ fn generate_alter_owner(
         OwnerObjectKind::MaterializedView => "MATERIALIZED VIEW",
         OwnerObjectKind::Sequence => "SEQUENCE",
         OwnerObjectKind::Function => "FUNCTION",
+        OwnerObjectKind::Aggregate => "AGGREGATE",
         OwnerObjectKind::Type => "TYPE",
         OwnerObjectKind::Domain => "DOMAIN",
     };
@@ -1641,6 +1699,8 @@ fn grant_object_kind_to_sql(kind: &GrantObjectKind) -> &'static str {
         GrantObjectKind::View => "TABLE",
         GrantObjectKind::Sequence => "SEQUENCE",
         GrantObjectKind::Function => "FUNCTION",
+        // Aggregates share GRANT namespace with functions in PostgreSQL
+        GrantObjectKind::Aggregate => "FUNCTION",
         GrantObjectKind::Schema => "SCHEMA",
         GrantObjectKind::Type => "TYPE",
         GrantObjectKind::Domain => "DOMAIN",

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -80,6 +80,7 @@ fn merge_schemas(schemas: Vec<Schema>) -> Result<Schema> {
         merge_collection(&mut merged.tables, schema.tables, "table")?;
         merge_collection(&mut merged.enums, schema.enums, "enum")?;
         merge_collection(&mut merged.functions, schema.functions, "function")?;
+        merge_collection(&mut merged.aggregates, schema.aggregates, "aggregate")?;
         merge_collection(&mut merged.views, schema.views, "view")?;
         merge_collection(&mut merged.triggers, schema.triggers, "trigger")?;
         merge_collection(&mut merged.sequences, schema.sequences, "sequence")?;

--- a/tests/convergence.rs
+++ b/tests/convergence.rs
@@ -1256,3 +1256,47 @@ async fn inline_check_constraint_converges() {
     )
     .await;
 }
+
+#[tokio::test]
+async fn aggregate_with_sfunc_and_stype_converges() {
+    assert_convergence_public(
+        r#"
+        CREATE FUNCTION public._group_concat(text, text) RETURNS text
+            LANGUAGE sql IMMUTABLE AS $_$
+        SELECT CASE WHEN $2 IS NULL THEN $1 WHEN $1 IS NULL THEN $2 ELSE $1 || ', ' || $2 END
+        $_$;
+
+        CREATE AGGREGATE public.group_concat(text) (
+            SFUNC = public._group_concat,
+            STYPE = text
+        );
+        "#,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn aggregate_referenced_by_view_converges() {
+    assert_convergence_public(
+        r#"
+        CREATE FUNCTION public._group_concat(text, text) RETURNS text
+            LANGUAGE sql IMMUTABLE AS $_$
+        SELECT CASE WHEN $2 IS NULL THEN $1 WHEN $1 IS NULL THEN $2 ELSE $1 || ', ' || $2 END
+        $_$;
+
+        CREATE AGGREGATE public.group_concat(text) (
+            SFUNC = public._group_concat,
+            STYPE = text
+        );
+
+        CREATE TABLE public.actors (
+            id INTEGER PRIMARY KEY,
+            name TEXT NOT NULL
+        );
+
+        CREATE VIEW public.all_actors AS
+            SELECT public.group_concat(name) AS names FROM public.actors;
+        "#,
+    )
+    .await;
+}

--- a/tests/corpus/pagila.sql
+++ b/tests/corpus/pagila.sql
@@ -1,3 +1,4 @@
+-- IGNORE: pgmold-266 trigger sqlgen qualifies built-in tsvector_update_trigger with "public", PG resolves it via pg_catalog
 -- Source: https://github.com/devrimgunduz/pagila/blob/master/pagila-schema.sql
 -- Commit: 5ba5a57aeb159f75f02aca2432d3c262186d13d3
 -- License: MIT

--- a/tests/corpus/pagila.sql
+++ b/tests/corpus/pagila.sql
@@ -1,4 +1,3 @@
--- IGNORE: pgmold-262 CREATE AGGREGATE is parse-through only; nicer_but_slower_film_list view references public.group_concat and fails at apply
 -- Source: https://github.com/devrimgunduz/pagila/blob/master/pagila-schema.sql
 -- Commit: 5ba5a57aeb159f75f02aca2432d3c262186d13d3
 -- License: MIT


### PR DESCRIPTION
## Summary

Materializes `CREATE AGGREGATE` into the Schema model so pagila's `group_concat` aggregate (and the `nicer_but_slower_film_list` view that calls it) round-trip through parse → plan → apply → introspect without `function "public.group_concat(text)" does not exist` errors at apply time.

Surfaced by pgmold-262 after pgmold-261 fixed the planner-cycle panic on pagila.

## What changed

- **`model::Aggregate`** (new): schema/name/args, SFUNC, STYPE, optional FINALFUNC / INITCOND / PARALLEL, plus owner/grants/comment. `Schema::aggregates` added as a `BTreeMap` with `skip_serializing_if = "is_empty"` so existing fingerprints are stable.
- **Parser**: `Statement::CreateAggregate` routed into `schema.aggregates`; the Aggregate arm of `Statement::AlterFunction` (`OWNER TO`) pushes a `PendingOwner`. `ALTER AGGREGATE … OWNER TO` is no longer silently dropped.
- **Diff**: `diff_aggregates` (DROP + CREATE on semantic change) with new `CreateAggregate` / `DropAggregate` `MigrationOp` variants.
- **Planner**: content-aware edge `SFUNC/FINALFUNC function → aggregate`; `push_function_edges` now matches `CreateAggregate` so views / policies / triggers that call the aggregate are ordered after it. Blanket tier edges deliberately avoided to prevent cycles when an aggregate's SFUNC transitively references a view that uses the aggregate.
- **SQL gen**: emits `CREATE AGGREGATE … (SFUNC = …, STYPE = …, [FINALFUNC], [INITCOND], [PARALLEL])`, `DROP AGGREGATE`, `ALTER AGGREGATE … OWNER TO`, `COMMENT ON AGGREGATE`, and reuses `GRANT … ON FUNCTION …` for the aggregate ACL namespace.
- **Introspect**: queries `pg_aggregate JOIN pg_proc` filtered to `prokind='a'` and `aggkind='n'`; ordered-set / hypothetical aggregates are intentionally skipped. `function_grants` routing falls through to aggregates when the function lookup misses. `proparallel='u'` normalizes to `None` so parse and introspect converge on the PG default.
- **Baseline**: `UnsupportedObject::Aggregate` is no longer surfaced by `detect_unsupported_objects`; `ObjectCounts.aggregates` added with `#[serde(default)]` for back-compat.
- **Pagila corpus**: `-- IGNORE: pgmold-262 …` marker removed.

## Test plan

- [ ] `cargo test --test corpus -- --ignored pagila` converges (the reason this ticket exists)
- [ ] `cargo test aggregate_with_sfunc_and_stype_converges` — minimal SFUNC+STYPE round-trip
- [ ] `cargo test aggregate_referenced_by_view_converges` — view that calls the aggregate plans in the right order
- [ ] `cargo test create_aggregate_minimal_sfunc_stype` — parser unit
- [ ] `cargo test alter_aggregate_owner_records_pending_owner` — parser unit for the AlterFunction→Aggregate routing
- [ ] Full `cargo test` green (the aggregate map is opt-in so pre-existing fingerprints should be unchanged)