### PR TITLE
fix(parser): resolve unqualified pg_catalog trigger helpers

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -739,7 +739,14 @@ pub fn parse_sql_string(sql: &str) -> Result<Schema> {
                         "Trigger '{trigger_name}' missing EXECUTE clause"
                     ))
                 })?;
+                let func_unqualified = exec.func_name.0.len() == 1;
                 let (func_schema, func_name) = extract_qualified_name(&exec.func_name);
+                let func_schema = if func_unqualified && is_pg_catalog_trigger_function(&func_name)
+                {
+                    "pg_catalog".to_string()
+                } else {
+                    func_schema
+                };
 
                 let timing = match period {
                     Some(TriggerPeriod::Before) => TriggerTiming::Before,
@@ -1218,6 +1225,20 @@ pub fn parse_sql_string(sql: &str) -> Result<Schema> {
     schema.pending_policies = schema.finalize_partial();
 
     Ok(schema)
+}
+
+/// Returns `true` when `name` refers to a built-in `pg_catalog` trigger
+/// helper. PostgreSQL resolves unqualified trigger function names via
+/// `search_path`, which always includes `pg_catalog`; emitting these under
+/// `public` produces invalid DDL (the function does not live there), so the
+/// parser records them under their actual schema.
+fn is_pg_catalog_trigger_function(name: &str) -> bool {
+    matches!(
+        name,
+        "tsvector_update_trigger"
+            | "tsvector_update_trigger_column"
+            | "suppress_redundant_updates_trigger"
+    )
 }
 
 fn parse_create_aggregate(stmt: CreateAggregate, schema: &mut Schema) -> Result<()> {

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -606,6 +606,7 @@ EXECUTE FUNCTION tsvector_update_trigger('fulltext', 'pg_catalog.english', 'titl
         .unwrap();
 
     assert_eq!(trigger.name, "film_fulltext_trigger");
+    assert_eq!(trigger.function_schema, "pg_catalog");
     assert_eq!(trigger.function_name, "tsvector_update_trigger");
     assert_eq!(
         trigger.function_args,
@@ -616,6 +617,61 @@ EXECUTE FUNCTION tsvector_update_trigger('fulltext', 'pg_catalog.english', 'titl
             "'description'"
         ]
     );
+}
+
+#[test]
+fn unqualified_builtin_trigger_function_resolves_to_pg_catalog() {
+    let sql = r#"
+CREATE TABLE public.docs (id serial PRIMARY KEY, body text);
+
+CREATE TRIGGER redundant_guard
+BEFORE UPDATE ON public.docs
+FOR EACH ROW
+EXECUTE FUNCTION suppress_redundant_updates_trigger();
+"#;
+    let schema = parse_sql_string(sql).unwrap();
+    let trigger = schema
+        .triggers
+        .get("public.docs.redundant_guard")
+        .unwrap();
+    assert_eq!(trigger.function_schema, "pg_catalog");
+    assert_eq!(trigger.function_name, "suppress_redundant_updates_trigger");
+}
+
+#[test]
+fn qualified_trigger_function_schema_is_preserved() {
+    let sql = r#"
+CREATE TABLE public.t (id int);
+
+CREATE FUNCTION public.last_updated() RETURNS TRIGGER LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END; $$;
+
+CREATE TRIGGER last_updated
+BEFORE UPDATE ON public.t
+FOR EACH ROW
+EXECUTE FUNCTION public.last_updated();
+"#;
+    let schema = parse_sql_string(sql).unwrap();
+    let trigger = schema.triggers.get("public.t.last_updated").unwrap();
+    assert_eq!(trigger.function_schema, "public");
+    assert_eq!(trigger.function_name, "last_updated");
+}
+
+#[test]
+fn unqualified_non_builtin_trigger_function_defaults_to_public() {
+    let sql = r#"
+CREATE TABLE public.t (id int);
+
+CREATE FUNCTION public.my_fn() RETURNS TRIGGER LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END; $$;
+
+CREATE TRIGGER my_trigger
+BEFORE UPDATE ON public.t
+FOR EACH ROW
+EXECUTE FUNCTION my_fn();
+"#;
+    let schema = parse_sql_string(sql).unwrap();
+    let trigger = schema.triggers.get("public.t.my_trigger").unwrap();
+    assert_eq!(trigger.function_schema, "public");
+    assert_eq!(trigger.function_name, "my_fn");
 }
 
 #[test]

--- a/src/pg/sqlgen.rs
+++ b/src/pg/sqlgen.rs
@@ -2289,6 +2289,40 @@ mod tests {
     }
 
     #[test]
+    fn create_trigger_qualifies_pg_catalog_function() {
+        use crate::model::{Trigger, TriggerEnabled, TriggerEvent, TriggerTiming};
+
+        let trigger = Trigger {
+            name: "film_fulltext_trigger".to_string(),
+            target_schema: "public".to_string(),
+            target_name: "film".to_string(),
+            timing: TriggerTiming::Before,
+            events: vec![TriggerEvent::Insert, TriggerEvent::Update],
+            update_columns: vec![],
+            for_each_row: true,
+            when_clause: None,
+            function_schema: "pg_catalog".to_string(),
+            function_name: "tsvector_update_trigger".to_string(),
+            function_args: vec![
+                "'fulltext'".to_string(),
+                "'pg_catalog.english'".to_string(),
+                "'title'".to_string(),
+                "'description'".to_string(),
+            ],
+            enabled: TriggerEnabled::Origin,
+            old_table_name: None,
+            new_table_name: None,
+            comment: None,
+        };
+
+        let sql = generate_sql(&[MigrationOp::CreateTrigger(trigger)]);
+        assert_eq!(sql.len(), 1);
+        assert!(sql[0].contains(
+            "EXECUTE FUNCTION \"pg_catalog\".\"tsvector_update_trigger\"('fulltext', 'pg_catalog.english', 'title', 'description');"
+        ));
+    }
+
+    #[test]
     fn create_trigger_with_update_of_columns() {
         use crate::model::{Trigger, TriggerEnabled, TriggerEvent, TriggerTiming};
 

--- a/tests/corpus/pagila.sql
+++ b/tests/corpus/pagila.sql
@@ -1,4 +1,4 @@
--- IGNORE: pgmold-266 trigger sqlgen qualifies built-in tsvector_update_trigger with "public", PG resolves it via pg_catalog
+-- IGNORE: pgmold-267 introspection drops trigger function args (tgargs) so film_fulltext_trigger fails to converge after apply
 -- Source: https://github.com/devrimgunduz/pagila/blob/master/pagila-schema.sql
 -- Commit: 5ba5a57aeb159f75f02aca2432d3c262186d13d3
 -- License: MIT


### PR DESCRIPTION
## Summary

- `CREATE TRIGGER ... EXECUTE FUNCTION` with an unqualified built-in (`tsvector_update_trigger`, `tsvector_update_trigger_column`, `suppress_redundant_updates_trigger`) now parses with `function_schema = "pg_catalog"` instead of the `public` default, so sqlgen emits a valid `EXECUTE FUNCTION "pg_catalog"."tsvector_update_trigger"(...)` and apply no longer fails with `function public.tsvector_update_trigger() does not exist`.
- Introspection already returns `pg_catalog` via `pg_proc.pronamespace`, so round-trip diffs converge on the schema side.
- Explicit qualifiers and user-defined `public` functions are untouched.

Refs pgmold-266. The remaining pagila-corpus blocker (introspection drops `pg_trigger.tgargs`) is filed as pgmold-267; `tests/corpus/pagila.sql` stays `-- IGNORE`'d pointing at that ticket.

## Test plan

- [x] `cargo test --test parser_coverage_triage` — new tests:
  - `unqualified_builtin_trigger_function_resolves_to_pg_catalog`
  - `qualified_trigger_function_schema_is_preserved`
  - `unqualified_non_builtin_trigger_function_defaults_to_public`
  - existing `parses_trigger_with_string_literal_args` now also asserts `function_schema == "pg_catalog"`
- [x] `cargo test` (sqlgen): new `create_trigger_qualifies_pg_catalog_function` asserts the emitted DDL
- [ ] Corpus convergence for pagila is still gated on pgmold-267 (args introspection); IGNORE marker updated accordingly