### PR TITLE
style: fix rustfmt in pg_catalog trigger test

### DIFF
--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -630,10 +630,7 @@ FOR EACH ROW
 EXECUTE FUNCTION suppress_redundant_updates_trigger();
 "#;
     let schema = parse_sql_string(sql).unwrap();
-    let trigger = schema
-        .triggers
-        .get("public.docs.redundant_guard")
-        .unwrap();
+    let trigger = schema.triggers.get("public.docs.redundant_guard").unwrap();
     assert_eq!(trigger.function_schema, "pg_catalog");
     assert_eq!(trigger.function_name, "suppress_redundant_updates_trigger");
 }


### PR DESCRIPTION
## Summary

- Collapse a four-line method chain into one line in `unqualified_builtin_trigger_function_resolves_to_pg_catalog` — rustfmt required, CI `Format` job on main was red after 2bef1be.
- No logic change; all other CI jobs on main (Clippy/Test/Integration/Corpus/PG 13–17/Parser Coverage) passed.

## Test plan

- [x] `cargo fmt --all --check` locally via CI