### PR TITLE
fix(pgmold-269): unnamed multi-word function arg types + SETOF normalization

### DIFF
--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1442,6 +1442,14 @@ pub fn normalize_pg_type(type_name: &str) -> Cow<'_, str> {
         return Cow::Owned(format!("table({})", normalized_cols.join(", ")));
     }
 
+    // Recurse into SETOF <type> so inner type normalization (public. stripping,
+    // alias canonicalization) applies uniformly between parsed and introspected
+    // return types (e.g. `SETOF public.customer` vs `SETOF customer`).
+    if trimmed.len() >= 6 && trimmed[..6].eq_ignore_ascii_case("setof ") {
+        let inner = normalize_pg_type(trimmed[6..].trim());
+        return Cow::Owned(format!("setof {inner}"));
+    }
+
     // Strip public. schema prefix — PostgreSQL qualifies user-defined types
     // in function signatures but SQL declarations typically omit it
     let trimmed = trimmed.strip_prefix("public.").unwrap_or(trimmed);
@@ -3341,6 +3349,26 @@ fn normalize_pg_type_strips_public_schema_prefix() {
     assert_eq!(normalize_pg_type("public.my_enum"), "my_enum");
     // Non-public schemas should be preserved
     assert_eq!(normalize_pg_type("auth.role_type"), "auth.role_type");
+}
+
+#[test]
+fn normalize_pg_type_setof_strips_public_prefix_and_aliases() {
+    assert_eq!(
+        normalize_pg_type("SETOF public.customer"),
+        "setof customer"
+    );
+    assert_eq!(normalize_pg_type("setof customer"), "setof customer");
+    assert_eq!(
+        normalize_pg_type("SETOF public.CUSTOMER"),
+        "setof customer"
+    );
+    // Cross-schema SETOF preserves qualification
+    assert_eq!(
+        normalize_pg_type("SETOF auth.session"),
+        "setof auth.session"
+    );
+    // Inner alias is canonicalized
+    assert_eq!(normalize_pg_type("SETOF int4"), "setof integer");
 }
 
 #[test]

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -3353,15 +3353,9 @@ fn normalize_pg_type_strips_public_schema_prefix() {
 
 #[test]
 fn normalize_pg_type_setof_strips_public_prefix_and_aliases() {
-    assert_eq!(
-        normalize_pg_type("SETOF public.customer"),
-        "setof customer"
-    );
+    assert_eq!(normalize_pg_type("SETOF public.customer"), "setof customer");
     assert_eq!(normalize_pg_type("setof customer"), "setof customer");
-    assert_eq!(
-        normalize_pg_type("SETOF public.CUSTOMER"),
-        "setof customer"
-    );
+    assert_eq!(normalize_pg_type("SETOF public.CUSTOMER"), "setof customer");
     // Cross-schema SETOF preserves qualification
     assert_eq!(
         normalize_pg_type("SETOF auth.session"),

--- a/src/pg/introspect.rs
+++ b/src/pg/introspect.rs
@@ -1809,6 +1809,20 @@ fn find_default_keyword(arg: &str) -> Option<usize> {
     None
 }
 
+/// Returns true when the first token of an argument string is a PostgreSQL
+/// type keyword that starts a multi-word type name (e.g. `timestamp with time zone`).
+/// `pg_get_function_arguments` emits unnamed args as just the type, so without this
+/// check the splitter would wrongly treat `timestamp` as an argument name.
+fn is_unnamed_multiword_type(first_token: &str) -> bool {
+    if first_token.starts_with('"') {
+        return false;
+    }
+    matches!(
+        first_token.to_ascii_lowercase().as_str(),
+        "timestamp" | "time" | "double" | "character" | "bit" | "interval"
+    )
+}
+
 fn parse_function_arguments(args_str: &str) -> Vec<FunctionArg> {
     if args_str.is_empty() {
         return Vec::new();
@@ -1838,8 +1852,10 @@ fn parse_function_arguments(args_str: &str) -> Vec<FunctionArg> {
                 (ArgMode::In, arg_without_default)
             };
 
-            let parts: Vec<&str> = arg_rest.trim().splitn(2, ' ').collect();
-            if parts.len() == 2 {
+            let arg_rest = arg_rest.trim();
+            let parts: Vec<&str> = arg_rest.splitn(2, ' ').collect();
+            let has_name = parts.len() == 2 && !is_unnamed_multiword_type(parts[0]);
+            if has_name {
                 FunctionArg {
                     name: Some(strip_ident_quotes(parts[0])),
                     data_type: crate::model::normalize_pg_type(parts[1]).into_owned(),
@@ -1849,7 +1865,7 @@ fn parse_function_arguments(args_str: &str) -> Vec<FunctionArg> {
             } else {
                 FunctionArg {
                     name: None,
-                    data_type: crate::model::normalize_pg_type(arg_rest.trim()).into_owned(),
+                    data_type: crate::model::normalize_pg_type(arg_rest).into_owned(),
                     mode,
                     default,
                 }
@@ -2678,6 +2694,48 @@ mod tests {
         let args = parse_function_arguments("p_role text DEFAULT 'ADMIN'::text");
         assert_eq!(args.len(), 1);
         assert_eq!(args[0].default.as_deref(), Some("'ADMIN'::text"));
+    }
+
+    #[test]
+    fn parse_function_arguments_unnamed_timestamp_with_time_zone() {
+        let args = parse_function_arguments("timestamp with time zone");
+        assert_eq!(args.len(), 1);
+        assert_eq!(args[0].name, None);
+        assert_eq!(args[0].data_type, "timestamp with time zone");
+    }
+
+    #[test]
+    fn parse_function_arguments_unnamed_double_precision() {
+        let args = parse_function_arguments("double precision, integer");
+        assert_eq!(args.len(), 2);
+        assert_eq!(args[0].name, None);
+        assert_eq!(args[0].data_type, "double precision");
+        assert_eq!(args[1].name, None);
+        assert_eq!(args[1].data_type, "integer");
+    }
+
+    #[test]
+    fn parse_function_arguments_unnamed_character_varying() {
+        let args = parse_function_arguments("character varying");
+        assert_eq!(args.len(), 1);
+        assert_eq!(args[0].name, None);
+        assert_eq!(args[0].data_type, "character varying");
+    }
+
+    #[test]
+    fn parse_function_arguments_named_with_timestamp_type() {
+        let args = parse_function_arguments("p_effective_date timestamp with time zone");
+        assert_eq!(args.len(), 1);
+        assert_eq!(args[0].name, Some("p_effective_date".to_string()));
+        assert_eq!(args[0].data_type, "timestamp with time zone");
+    }
+
+    #[test]
+    fn parse_function_arguments_quoted_timestamp_name_still_named() {
+        let args = parse_function_arguments("\"timestamp\" timestamp with time zone");
+        assert_eq!(args.len(), 1);
+        assert_eq!(args[0].name, Some("timestamp".to_string()));
+        assert_eq!(args[0].data_type, "timestamp with time zone");
     }
 
     #[test]

--- a/tests/corpus/pagila.sql
+++ b/tests/corpus/pagila.sql
@@ -1,4 +1,3 @@
--- IGNORE: pgmold-268 planner emits partition table 'payment_p2022_01' twice; pgmold-267 (trigger args) confirmed fixed — only the partition dup remains
 -- Source: https://github.com/devrimgunduz/pagila/blob/master/pagila-schema.sql
 -- Commit: 5ba5a57aeb159f75f02aca2432d3c262186d13d3
 -- License: MIT


### PR DESCRIPTION
## Summary

Pagila corpus convergence surfaced two function introspection gaps after pgmold-268 (duplicate partition) and tsvector support landed:

1. `parse_function_arguments` split the first space in arg strings like `timestamp with time zone` and treated `timestamp` as the argument name, producing a bogus `public.last_day(with time zone)` signature that differed from the parsed `public.last_day(timestamp with time zone)`. Now, an unquoted first-token matching a multi-word PG type keyword (`timestamp`, `time`, `double`, `character`, `bit`, `interval`) is treated as type, not name.
2. `normalize_pg_type` only stripped the `public.` prefix at the start of the string, so the parsed return type `SETOF public.customer` did not converge with the introspected `SETOF customer` (unqualified because `public` is in search_path). Added recursion into `SETOF <type>` so alias canonicalization and `public.` stripping apply uniformly.

Un-ignored `tests/corpus/pagila.sql` — both the convergence blockers listed in pgmold-269 are addressed.

## Test plan

- [x] `parse_function_arguments_unnamed_timestamp_with_time_zone` — direct repro of the args bug
- [x] `parse_function_arguments_unnamed_double_precision` / `character_varying`
- [x] `parse_function_arguments_named_with_timestamp_type` — guards against over-triggering
- [x] `parse_function_arguments_quoted_timestamp_name_still_named` — quoted names still parse as names
- [x] `normalize_pg_type_setof_strips_public_prefix_and_aliases` — SETOF + public., cross-schema, and alias recursion
- [x] Corpus convergence test unblocked on `pagila.sql`