### PR TITLE
chore: bump version to 0.34.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1587,7 +1587,7 @@ dependencies = [
 
 [[package]]
 name = "pgmold"
-version = "0.33.7"
+version = "0.34.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "pgmold"
-version = "0.33.7"
+version = "0.34.0"
 edition = "2021"
 exclude = [".auto-claude/", ".auto-claude-security.json", ".claude_settings.json"]
 description = "PostgreSQL schema-as-code management tool"


### PR DESCRIPTION
## Summary

Release v0.34.0. Highlights since v0.33.7:

### Features
- `feat(aggregates)`: model CREATE AGGREGATE end-to-end (pgmold-262)
- `feat(diff/sqlgen)`: handle CREATE/ALTER/DROP SERVER (pgmold-99)
- `feat`: ALTER INDEX (pgmold-110)
- `feat`: ALTER TYPE ADD VALUE (pgmold-112)
- `feat(parser)`: bump sqlparser through 0.60.7 → 0.60.14, passing through ~25 more DDL variants

### Fixes
- `fix(pgmold-269)`: unnamed multi-word function arg types + SETOF normalization
- `fix(parser)`: drop standalone table entry when ATTACH PARTITION converts it (pgmold-268)
- `fix(introspect)`: decode trigger function args from `pg_trigger.tgargs` (pgmold-260/267)
- `fix(parser)`: resolve unqualified pg_catalog trigger helpers
- `fix(planner)`: break FK cycles and expand SETOF skip set (pgmold-261)
- `fix(parser)`: accept ALTER TABLE ATTACH/DETACH PARTITION (pgmold-258)
- `fix(parser)`: accept WITH [NO] DATA on CREATE MATERIALIZED VIEW (pgmold-256)
- `fix(parser)`: accept 'fulltext' as identifier (pgmold-259)
- `fix(parser)`: CREATE TRIGGER EXECUTE FUNCTION call-site args
- `fix(pgmold-252)`: domain-sequence handling
- `fix`: array literal defaults, policy expression normalization, GIST index method, grant type normalization, inline column constraints

### Milestones
- Pagila corpus now fully converges (was IGNORE-gated since pgmold-260)

### Infra
- `perf(model)`: return `Cow` from `normalize_pg_type`
- `chore(deps)`: cutover pgmold-sqlparser from git dep to published 0.60.6

## Test plan
- [x] All CI jobs passed on main at 1ded0f4 (PG 13/14/15/16/17, integration, corpus convergence, clippy, fmt, parser triage)