### PR TITLE
fix(pgmold-238): preserve CONSTRAINT keyword and DEFERRABLE clause on triggers

### DIFF
--- a/src/diff/dependencies.rs
+++ b/src/diff/dependencies.rs
@@ -765,6 +765,9 @@ mod tests {
                 enabled: TriggerEnabled::Origin,
                 old_table_name: None,
                 new_table_name: None,
+                is_constraint: false,
+                deferrable: false,
+                initially_deferred: false,
                 comment: None,
             },
         );
@@ -801,6 +804,9 @@ mod tests {
                 enabled: TriggerEnabled::Origin,
                 old_table_name: None,
                 new_table_name: None,
+                is_constraint: false,
+                deferrable: false,
+                initially_deferred: false,
                 comment: None,
             },
         );
@@ -1195,6 +1201,9 @@ mod tests {
                 update_columns: vec![],
                 old_table_name: None,
                 new_table_name: None,
+                is_constraint: false,
+                deferrable: false,
+                initially_deferred: false,
                 comment: None,
             },
         );
@@ -1230,6 +1239,9 @@ mod tests {
                 update_columns: vec![],
                 old_table_name: None,
                 new_table_name: None,
+                is_constraint: false,
+                deferrable: false,
+                initially_deferred: false,
                 comment: None,
             },
         );

--- a/src/diff/mod.rs
+++ b/src/diff/mod.rs
@@ -1607,6 +1607,9 @@ mod tests {
             enabled: crate::model::TriggerEnabled::Origin,
             old_table_name: None,
             new_table_name: None,
+            is_constraint: false,
+            deferrable: false,
+            initially_deferred: false,
             comment: None,
         }
     }
@@ -1702,6 +1705,9 @@ mod tests {
             enabled: crate::model::TriggerEnabled::Origin,
             old_table_name: None,
             new_table_name: None,
+            is_constraint: false,
+            deferrable: false,
+            initially_deferred: false,
             comment: None,
         };
         to.triggers.insert(
@@ -2397,6 +2403,9 @@ mod tests {
                 enabled: crate::model::TriggerEnabled::Origin,
                 old_table_name: None,
                 new_table_name: None,
+                is_constraint: false,
+                deferrable: false,
+                initially_deferred: false,
                 comment: None,
             },
         );
@@ -2419,6 +2428,9 @@ mod tests {
                 enabled: crate::model::TriggerEnabled::Origin,
                 old_table_name: None,
                 new_table_name: None,
+                is_constraint: false,
+                deferrable: false,
+                initially_deferred: false,
                 comment: None,
             },
         );
@@ -2469,6 +2481,9 @@ CREATE TRIGGER "on_auth_user_created" AFTER INSERT ON "auth"."users" FOR EACH RO
             enabled: crate::model::TriggerEnabled::Origin,
             old_table_name: None,
             new_table_name: None,
+            is_constraint: false,
+            deferrable: false,
+            initially_deferred: false,
             comment: None,
         };
 
@@ -2571,6 +2586,9 @@ CREATE TRIGGER "on_user_role_change" AFTER INSERT OR UPDATE OR DELETE ON "public
                 enabled: crate::model::TriggerEnabled::Origin,
                 old_table_name: None,
                 new_table_name: None,
+                is_constraint: false,
+                deferrable: false,
+                initially_deferred: false,
                 comment: None,
             },
         );
@@ -2592,6 +2610,9 @@ CREATE TRIGGER "on_user_role_change" AFTER INSERT OR UPDATE OR DELETE ON "public
                 enabled: crate::model::TriggerEnabled::Origin,
                 old_table_name: None,
                 new_table_name: None,
+                is_constraint: false,
+                deferrable: false,
+                initially_deferred: false,
                 comment: None,
             },
         );
@@ -2621,6 +2642,9 @@ CREATE TRIGGER "on_user_role_change" AFTER INSERT OR UPDATE OR DELETE ON "public
                 enabled: crate::model::TriggerEnabled::Origin,
                 old_table_name: None,
                 new_table_name: None,
+                is_constraint: false,
+                deferrable: false,
+                initially_deferred: false,
                 comment: None,
             },
         );

--- a/src/diff/objects.rs
+++ b/src/diff/objects.rs
@@ -553,6 +553,9 @@ fn triggers_equal_except_enabled(from: &Trigger, to: &Trigger) -> bool {
         && from.function_args == to.function_args
         && from.old_table_name == to.old_table_name
         && from.new_table_name == to.new_table_name
+        && from.is_constraint == to.is_constraint
+        && from.deferrable == to.deferrable
+        && from.initially_deferred == to.initially_deferred
 }
 
 pub(super) fn triggers_semantically_equal(from: &Trigger, to: &Trigger) -> bool {

--- a/src/diff/planner.rs
+++ b/src/diff/planner.rs
@@ -1926,6 +1926,9 @@ mod tests {
             enabled: TriggerEnabled::Origin,
             old_table_name: None,
             new_table_name: None,
+            is_constraint: false,
+            deferrable: false,
+            initially_deferred: false,
             comment: None,
         };
 
@@ -2095,6 +2098,9 @@ mod tests {
             enabled: TriggerEnabled::Origin,
             old_table_name: None,
             new_table_name: None,
+            is_constraint: false,
+            deferrable: false,
+            initially_deferred: false,
             comment: None,
         };
 
@@ -3416,6 +3422,9 @@ mod tests {
             enabled: TriggerEnabled::Origin,
             old_table_name: None,
             new_table_name: None,
+            is_constraint: false,
+            deferrable: false,
+            initially_deferred: false,
             comment: None,
         }
     }

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -760,6 +760,9 @@ mod tests {
                 enabled: TriggerEnabled::Origin,
                 old_table_name: None,
                 new_table_name: None,
+                is_constraint: false,
+                deferrable: false,
+                initially_deferred: false,
                 comment: None,
             },
         );
@@ -780,6 +783,9 @@ mod tests {
                 enabled: TriggerEnabled::Origin,
                 old_table_name: None,
                 new_table_name: None,
+                is_constraint: false,
+                deferrable: false,
+                initially_deferred: false,
                 comment: None,
             },
         );
@@ -2040,6 +2046,9 @@ mod tests {
             enabled: TriggerEnabled::Origin,
             old_table_name: None,
             new_table_name: None,
+            is_constraint: false,
+            deferrable: false,
+            initially_deferred: false,
             comment: None,
         }
     }

--- a/src/lint/locks.rs
+++ b/src/lint/locks.rs
@@ -684,6 +684,9 @@ mod tests {
             enabled: TriggerEnabled::Origin,
             old_table_name: None,
             new_table_name: None,
+            is_constraint: false,
+            deferrable: false,
+            initially_deferred: false,
             comment: None,
         })];
         let warnings = detect_lock_hazards(&ops);

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -874,6 +874,12 @@ pub struct Trigger {
     pub enabled: TriggerEnabled,
     pub old_table_name: Option<String>,
     pub new_table_name: Option<String>,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub is_constraint: bool,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub deferrable: bool,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub initially_deferred: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub comment: Option<String>,
 }
@@ -1838,6 +1844,9 @@ mod tests {
             enabled: TriggerEnabled::Origin,
             old_table_name: None,
             new_table_name: None,
+            is_constraint: false,
+            deferrable: false,
+            initially_deferred: false,
             comment: None,
         };
 
@@ -1867,6 +1876,9 @@ mod tests {
             enabled: TriggerEnabled::Origin,
             old_table_name: None,
             new_table_name: None,
+            is_constraint: false,
+            deferrable: false,
+            initially_deferred: false,
             comment: None,
         };
         schema

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -32,10 +32,10 @@ use sqlparser::ast::{
     AlterFunction, AlterFunctionKind, AlterFunctionOperation, AlterIndexOperation, AlterTable,
     AlterTableOperation, AlterType, AlterTypeAddValue, AlterTypeAddValuePosition,
     AlterTypeOperation, CreateAggregate, CreateAggregateOption, CreateDomain, CreateExtension,
-    CreateFunction, CreateServerStatement, CreateTrigger, CreateView, DropDomain, DropExtension,
-    DropFunction, DropTrigger, FunctionParallel, ObjectType, Owner, RenameTableNameKind,
-    SchemaName, Statement, TableConstraint, TriggerEvent as SqlTriggerEvent, TriggerPeriod,
-    TriggerReferencingType, UserDefinedTypeRepresentation,
+    CreateFunction, CreateServerStatement, CreateTrigger, CreateView, DeferrableInitial,
+    DropDomain, DropExtension, DropFunction, DropTrigger, FunctionParallel, ObjectType, Owner,
+    RenameTableNameKind, SchemaName, Statement, TableConstraint, TriggerEvent as SqlTriggerEvent,
+    TriggerPeriod, TriggerReferencingType, UserDefinedTypeRepresentation,
 };
 use sqlparser::dialect::PostgreSqlDialect;
 use sqlparser::parser::Parser;
@@ -733,6 +733,8 @@ pub fn parse_sql_string(sql: &str) -> Result<Schema> {
                 referencing,
                 condition,
                 exec_body,
+                is_constraint,
+                characteristics,
                 ..
             }) => {
                 let (tbl_schema, tbl_name) = extract_qualified_name(&table_name);
@@ -846,6 +848,38 @@ pub fn parse_sql_string(sql: &str) -> Result<Schema> {
                     .map(|args| args.iter().map(|a| a.to_string()).collect())
                     .unwrap_or_default();
 
+                let (deferrable, initially_deferred) = match characteristics {
+                    Some(c) => {
+                        let deferrable = c.deferrable.unwrap_or(false);
+                        let initially_deferred = matches!(c.initially, Some(DeferrableInitial::Deferred));
+                        if !is_constraint && (c.deferrable.is_some() || c.initially.is_some()) {
+                            return Err(SchemaError::ParseError(format!(
+                                "Trigger '{trigger_name}' has DEFERRABLE/INITIALLY clause but is not a CONSTRAINT trigger"
+                            )));
+                        }
+                        if initially_deferred && !deferrable {
+                            return Err(SchemaError::ParseError(format!(
+                                "Trigger '{trigger_name}' has INITIALLY DEFERRED but is NOT DEFERRABLE"
+                            )));
+                        }
+                        (deferrable, initially_deferred)
+                    }
+                    None => (false, false),
+                };
+
+                if is_constraint {
+                    if timing != TriggerTiming::After {
+                        return Err(SchemaError::ParseError(format!(
+                            "CONSTRAINT trigger '{trigger_name}' must be AFTER"
+                        )));
+                    }
+                    if !for_each_row {
+                        return Err(SchemaError::ParseError(format!(
+                            "CONSTRAINT trigger '{trigger_name}' must be FOR EACH ROW"
+                        )));
+                    }
+                }
+
                 let trigger = Trigger {
                     name: trigger_name.clone(),
                     target_schema: tbl_schema.clone(),
@@ -865,6 +899,9 @@ pub fn parse_sql_string(sql: &str) -> Result<Schema> {
                     enabled: TriggerEnabled::Origin,
                     old_table_name,
                     new_table_name,
+                    is_constraint,
+                    deferrable,
+                    initially_deferred,
                     comment: None,
                 };
 

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -1155,6 +1155,87 @@ EXECUTE FUNCTION audit_fn();
 }
 
 #[test]
+fn parses_constraint_trigger_deferrable_initially_deferred() {
+    let sql = r#"
+CREATE FUNCTION check_junction() RETURNS TRIGGER LANGUAGE plpgsql AS $$ BEGIN RETURN NULL; END; $$;
+CREATE CONSTRAINT TRIGGER "on_farmer_insert_require_junction"
+AFTER INSERT ON "public"."farmers"
+DEFERRABLE INITIALLY DEFERRED
+FOR EACH ROW
+EXECUTE FUNCTION "public"."check_junction"();
+"#;
+    let schema = parse_sql_string(sql).unwrap();
+    let trigger = schema
+        .triggers
+        .get("public.farmers.on_farmer_insert_require_junction")
+        .unwrap();
+    assert!(trigger.is_constraint);
+    assert!(trigger.deferrable);
+    assert!(trigger.initially_deferred);
+    assert_eq!(trigger.timing, TriggerTiming::After);
+    assert!(trigger.for_each_row);
+}
+
+#[test]
+fn parses_constraint_trigger_initially_immediate() {
+    let sql = r#"
+CREATE FUNCTION check_junction() RETURNS TRIGGER LANGUAGE plpgsql AS $$ BEGIN RETURN NULL; END; $$;
+CREATE CONSTRAINT TRIGGER my_trig
+AFTER INSERT ON users
+DEFERRABLE INITIALLY IMMEDIATE
+FOR EACH ROW
+EXECUTE FUNCTION check_junction();
+"#;
+    let schema = parse_sql_string(sql).unwrap();
+    let trigger = schema.triggers.get("public.users.my_trig").unwrap();
+    assert!(trigger.is_constraint);
+    assert!(trigger.deferrable);
+    assert!(!trigger.initially_deferred);
+}
+
+#[test]
+fn parses_non_constraint_trigger_defaults() {
+    let sql = r#"
+CREATE FUNCTION audit_fn() RETURNS TRIGGER LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END; $$;
+CREATE TRIGGER audit_trigger
+AFTER INSERT ON users
+FOR EACH ROW
+EXECUTE FUNCTION audit_fn();
+"#;
+    let schema = parse_sql_string(sql).unwrap();
+    let trigger = schema.triggers.get("public.users.audit_trigger").unwrap();
+    assert!(!trigger.is_constraint);
+    assert!(!trigger.deferrable);
+    assert!(!trigger.initially_deferred);
+}
+
+#[test]
+fn rejects_constraint_trigger_before() {
+    let sql = r#"
+CREATE FUNCTION f() RETURNS TRIGGER LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END; $$;
+CREATE CONSTRAINT TRIGGER bad
+BEFORE INSERT ON users
+FOR EACH ROW
+EXECUTE FUNCTION f();
+"#;
+    let err = parse_sql_string(sql).unwrap_err().to_string();
+    assert!(err.contains("CONSTRAINT trigger") && err.contains("AFTER"));
+}
+
+#[test]
+fn rejects_constraint_trigger_for_each_statement() {
+    let sql = r#"
+CREATE FUNCTION f() RETURNS TRIGGER LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END; $$;
+CREATE CONSTRAINT TRIGGER bad
+AFTER INSERT ON users
+FOR EACH STATEMENT
+EXECUTE FUNCTION f();
+"#;
+    let err = parse_sql_string(sql).unwrap_err().to_string();
+    assert!(err.contains("CONSTRAINT trigger") && err.contains("FOR EACH ROW"));
+}
+
+#[test]
 fn rejects_new_table_on_delete_only_trigger() {
     let sql = r#"
 CREATE FUNCTION audit_fn() RETURNS TRIGGER LANGUAGE plpgsql AS $$ BEGIN RETURN OLD; END; $$;

--- a/src/pg/introspect.rs
+++ b/src/pg/introspect.rs
@@ -2008,7 +2008,10 @@ async fn introspect_triggers(
                 JOIN pg_attribute a ON a.attrelid = t.tgrelid AND a.attnum = attr_num
             ) AS update_columns,
             t.tgoldtable AS old_table_name,
-            t.tgnewtable AS new_table_name
+            t.tgnewtable AS new_table_name,
+            t.tgconstraint <> 0 AS is_constraint,
+            t.tgdeferrable AS is_deferrable,
+            t.tginitdeferred AS is_initially_deferred
         FROM pg_trigger t
         JOIN pg_class c ON t.tgrelid = c.oid
         JOIN pg_namespace ns ON c.relnamespace = ns.oid
@@ -2045,6 +2048,9 @@ async fn introspect_triggers(
         let update_columns: Option<Vec<String>> = row.get("update_columns");
         let old_table_name: Option<String> = row.get("old_table_name");
         let new_table_name: Option<String> = row.get("new_table_name");
+        let is_constraint: bool = row.get("is_constraint");
+        let deferrable: bool = row.get("is_deferrable");
+        let initially_deferred: bool = row.get("is_initially_deferred");
 
         let function_args = decode_trigger_args(&function_args_raw, function_nargs)?;
 
@@ -2101,6 +2107,9 @@ async fn introspect_triggers(
             enabled,
             old_table_name,
             new_table_name,
+            is_constraint,
+            deferrable,
+            initially_deferred,
             // TODO: read trigger comment from pg_description
             comment: None,
         };

--- a/src/pg/sqlgen.rs
+++ b/src/pg/sqlgen.rs
@@ -1634,13 +1634,27 @@ fn trigger_execute_clause(trigger: &Trigger) -> String {
 }
 
 fn generate_create_trigger(trigger: &Trigger) -> String {
-    let mut sql = format!("CREATE TRIGGER {}", quote_ident(&trigger.name));
+    let mut sql = if trigger.is_constraint {
+        format!("CREATE CONSTRAINT TRIGGER {}", quote_ident(&trigger.name))
+    } else {
+        format!("CREATE TRIGGER {}", quote_ident(&trigger.name))
+    };
 
     sql.push_str(&format!(
         " {} ON {}",
         trigger_timing_and_events(trigger),
         quote_qualified(&trigger.target_schema, &trigger.target_name)
     ));
+
+    if trigger.deferrable {
+        if trigger.initially_deferred {
+            sql.push_str(" DEFERRABLE INITIALLY DEFERRED");
+        } else {
+            sql.push_str(" DEFERRABLE INITIALLY IMMEDIATE");
+        }
+    } else if trigger.is_constraint {
+        sql.push_str(" NOT DEFERRABLE");
+    }
 
     if trigger.for_each_row {
         sql.push_str(" FOR EACH ROW");
@@ -2273,6 +2287,9 @@ mod tests {
             enabled: TriggerEnabled::Origin,
             old_table_name: None,
             new_table_name: None,
+            is_constraint: false,
+            deferrable: false,
+            initially_deferred: false,
             comment: None,
         };
 
@@ -2312,6 +2329,9 @@ mod tests {
             enabled: TriggerEnabled::Origin,
             old_table_name: None,
             new_table_name: None,
+            is_constraint: false,
+            deferrable: false,
+            initially_deferred: false,
             comment: None,
         };
 
@@ -2341,6 +2361,9 @@ mod tests {
             enabled: TriggerEnabled::Origin,
             old_table_name: None,
             new_table_name: None,
+            is_constraint: false,
+            deferrable: false,
+            initially_deferred: false,
             comment: None,
         };
 
@@ -2375,6 +2398,9 @@ mod tests {
             enabled: TriggerEnabled::Origin,
             old_table_name: None,
             new_table_name: None,
+            is_constraint: false,
+            deferrable: false,
+            initially_deferred: false,
             comment: None,
         };
 
@@ -2403,6 +2429,9 @@ mod tests {
             enabled: TriggerEnabled::Origin,
             old_table_name: None,
             new_table_name: None,
+            is_constraint: false,
+            deferrable: false,
+            initially_deferred: false,
             comment: None,
         };
 
@@ -2426,6 +2455,104 @@ mod tests {
             sql[0],
             r#"DROP TRIGGER "audit_trigger" ON "public"."users";"#
         );
+    }
+
+    #[test]
+    fn create_constraint_trigger_deferrable_initially_deferred() {
+        use crate::model::{Trigger, TriggerEnabled, TriggerEvent, TriggerTiming};
+
+        let trigger = Trigger {
+            name: "on_farmer_insert_require_junction".to_string(),
+            target_schema: "public".to_string(),
+            target_name: "farmers".to_string(),
+            timing: TriggerTiming::After,
+            events: vec![TriggerEvent::Insert],
+            update_columns: vec![],
+            for_each_row: true,
+            when_clause: None,
+            function_schema: "public".to_string(),
+            function_name: "check_farmer_junction_link".to_string(),
+            function_args: vec![],
+            enabled: TriggerEnabled::Origin,
+            old_table_name: None,
+            new_table_name: None,
+            is_constraint: true,
+            deferrable: true,
+            initially_deferred: true,
+            comment: None,
+        };
+
+        let ops = vec![MigrationOp::CreateTrigger(trigger)];
+        let sql = generate_sql(&ops);
+        assert_eq!(sql.len(), 1);
+        assert_eq!(
+            sql[0],
+            r#"CREATE CONSTRAINT TRIGGER "on_farmer_insert_require_junction" AFTER INSERT ON "public"."farmers" DEFERRABLE INITIALLY DEFERRED FOR EACH ROW EXECUTE FUNCTION "public"."check_farmer_junction_link"();"#
+        );
+    }
+
+    #[test]
+    fn create_constraint_trigger_initially_immediate() {
+        use crate::model::{Trigger, TriggerEnabled, TriggerEvent, TriggerTiming};
+
+        let trigger = Trigger {
+            name: "c".to_string(),
+            target_schema: "public".to_string(),
+            target_name: "t".to_string(),
+            timing: TriggerTiming::After,
+            events: vec![TriggerEvent::Insert],
+            update_columns: vec![],
+            for_each_row: true,
+            when_clause: None,
+            function_schema: "public".to_string(),
+            function_name: "f".to_string(),
+            function_args: vec![],
+            enabled: TriggerEnabled::Origin,
+            old_table_name: None,
+            new_table_name: None,
+            is_constraint: true,
+            deferrable: true,
+            initially_deferred: false,
+            comment: None,
+        };
+
+        let ops = vec![MigrationOp::CreateTrigger(trigger)];
+        let sql = generate_sql(&ops);
+        assert_eq!(sql.len(), 1);
+        assert!(sql[0].contains("CREATE CONSTRAINT TRIGGER"));
+        assert!(sql[0].contains("DEFERRABLE INITIALLY IMMEDIATE"));
+    }
+
+    #[test]
+    fn create_constraint_trigger_not_deferrable() {
+        use crate::model::{Trigger, TriggerEnabled, TriggerEvent, TriggerTiming};
+
+        let trigger = Trigger {
+            name: "c".to_string(),
+            target_schema: "public".to_string(),
+            target_name: "t".to_string(),
+            timing: TriggerTiming::After,
+            events: vec![TriggerEvent::Insert],
+            update_columns: vec![],
+            for_each_row: true,
+            when_clause: None,
+            function_schema: "public".to_string(),
+            function_name: "f".to_string(),
+            function_args: vec![],
+            enabled: TriggerEnabled::Origin,
+            old_table_name: None,
+            new_table_name: None,
+            is_constraint: true,
+            deferrable: false,
+            initially_deferred: false,
+            comment: None,
+        };
+
+        let ops = vec![MigrationOp::CreateTrigger(trigger)];
+        let sql = generate_sql(&ops);
+        assert_eq!(sql.len(), 1);
+        assert!(sql[0].contains("CREATE CONSTRAINT TRIGGER"));
+        assert!(sql[0].contains("NOT DEFERRABLE"));
     }
 
     #[test]
@@ -2523,6 +2650,9 @@ mod tests {
             enabled: TriggerEnabled::Disabled,
             old_table_name: None,
             new_table_name: None,
+            is_constraint: false,
+            deferrable: false,
+            initially_deferred: false,
             comment: None,
         };
 
@@ -2713,6 +2843,9 @@ mod tests {
             enabled: TriggerEnabled::Origin,
             old_table_name: Some("deleted_rows".to_string()),
             new_table_name: None,
+            is_constraint: false,
+            deferrable: false,
+            initially_deferred: false,
             comment: None,
         };
 
@@ -2742,6 +2875,9 @@ mod tests {
             enabled: TriggerEnabled::Origin,
             old_table_name: None,
             new_table_name: Some("inserted_rows".to_string()),
+            is_constraint: false,
+            deferrable: false,
+            initially_deferred: false,
             comment: None,
         };
 
@@ -2771,6 +2907,9 @@ mod tests {
             enabled: TriggerEnabled::Origin,
             old_table_name: Some("old_rows".to_string()),
             new_table_name: Some("new_rows".to_string()),
+            is_constraint: false,
+            deferrable: false,
+            initially_deferred: false,
             comment: None,
         };
 

--- a/tests/convergence.rs
+++ b/tests/convergence.rs
@@ -310,6 +310,33 @@ async fn trigger() {
 }
 
 #[tokio::test]
+async fn constraint_trigger_deferrable_initially_deferred() {
+    assert_convergence_public(
+        r#"
+        CREATE TABLE public.farmers (
+            id BIGSERIAL PRIMARY KEY
+        );
+
+        CREATE FUNCTION public.check_farmer_junction_link()
+        RETURNS TRIGGER
+        LANGUAGE plpgsql
+        AS $$
+        BEGIN
+            RETURN NULL;
+        END;
+        $$;
+
+        CREATE CONSTRAINT TRIGGER on_farmer_insert_require_junction
+        AFTER INSERT ON public.farmers
+        DEFERRABLE INITIALLY DEFERRED
+        FOR EACH ROW
+        EXECUTE FUNCTION public.check_farmer_junction_link();
+        "#,
+    )
+    .await;
+}
+
+#[tokio::test]
 async fn sequence() {
     assert_convergence_public(
         r#"


### PR DESCRIPTION
## Summary

Fixes #238. `CREATE CONSTRAINT TRIGGER ... DEFERRABLE INITIALLY DEFERRED` now round-trips through plan/apply — previously the generated migration stripped both the `CONSTRAINT` keyword and the `DEFERRABLE` clause, silently converting deferred-integrity checks into regular statement-end triggers.

- `Trigger` model grows three fields: `is_constraint`, `deferrable`, `initially_deferred`.
- Parser reads `CreateTrigger.is_constraint` and `characteristics`, rejecting DEFERRABLE on non-constraint triggers and enforcing AFTER + FOR EACH ROW on constraint triggers.
- Introspection reads `tgconstraint`, `tgdeferrable`, and `tginitdeferred` from `pg_trigger` (aliased to dodge the `DEFERRABLE` reserved word).
- SQL generation emits `CREATE CONSTRAINT TRIGGER` and the `DEFERRABLE INITIALLY {DEFERRED|IMMEDIATE}` / `NOT DEFERRABLE` clause in the correct position.
- Trigger equality includes the new fields so changes cause drop+recreate.

## Test plan

- [x] Unit tests: parser accepts `CREATE CONSTRAINT TRIGGER ... DEFERRABLE INITIALLY DEFERRED`, rejects `DEFERRABLE` on regular triggers, rejects BEFORE / FOR EACH STATEMENT on constraint triggers.
- [x] Unit tests: sqlgen emits the exact expected SQL from the issue reproducer, plus `INITIALLY IMMEDIATE` and `NOT DEFERRABLE` variants.
- [x] Integration (convergence): apply a constraint trigger and verify `plan` is empty on the second run.
- [ ] CI green.