### PR TITLE
chore: bump version to 0.34.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1587,7 +1587,7 @@ dependencies = [
 
 [[package]]
 name = "pgmold"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "pgmold"
-version = "0.34.0"
+version = "0.34.1"
 edition = "2021"
 exclude = [".auto-claude/", ".auto-claude-security.json", ".claude_settings.json"]
 description = "PostgreSQL schema-as-code management tool"


### PR DESCRIPTION
## Summary
Release 0.34.1.

- #239 — preserve CONSTRAINT keyword and DEFERRABLE clause on triggers (fixes pgmold-238).