### PR TITLE
fix: use pg_roles instead of pg_authid for foreign-server owner lookup

### DIFF
--- a/src/pg/introspect.rs
+++ b/src/pg/introspect.rs
@@ -254,7 +254,7 @@ async fn introspect_servers(connection: &PgConnection) -> Result<BTreeMap<String
             s.srvoptions AS options
         FROM pg_foreign_server s
         JOIN pg_foreign_data_wrapper fdw ON fdw.oid = s.srvfdw
-        LEFT JOIN pg_authid u ON u.oid = s.srvowner
+        LEFT JOIN pg_roles u ON u.oid = s.srvowner
         "#,
     )
     .fetch_all(connection.pool())


### PR DESCRIPTION
## Problem

`introspect_servers()` queries `pg_authid` to resolve the `rolname` of each
foreign server's owner. `pg_authid` is a superuser-only catalog
(it stores password hashes), so any non-superuser introspection run
fails with:

```
Error: Database error: Failed to fetch foreign servers:
error returned from database: permission denied for table pg_authid
```

This surfaces in the Sagri staging drift-check, where pgmold connects
via an SSM tunnel as the application's database role (not a superuser).

## Fix

Swap `pg_authid` for `pg_roles` in the `LEFT JOIN`. `pg_roles` is a
catalog view over `pg_authid` that exposes `oid` and `rolname` to any
authenticated role, while redacting the password / auth-token fields.
The join is purely for the owner name, so the view is a drop-in
replacement and removes the superuser requirement.

## Verification

- `cargo check --lib` clean
- Change is one line in `src/pg/introspect.rs`
- No existing test covers `introspect_servers` directly (no mockable
  fixture), but the query is exercised by the integration drift-check
  that currently fails against Sagri staging; rerunning that path after
  this lands is the natural integration test.

## Compat note

Postgres has had `pg_roles` since 8.1, which is well before the minimum
version pgmold supports, so this is a safe change on every target DB.