### PR TITLE
chore: bump version to 0.34.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1587,7 +1587,7 @@ dependencies = [
 
 [[package]]
 name = "pgmold"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "pgmold"
-version = "0.34.1"
+version = "0.34.2"
 edition = "2021"
 exclude = [".auto-claude/", ".auto-claude-security.json", ".claude_settings.json"]
 description = "PostgreSQL schema-as-code management tool"


### PR DESCRIPTION
## Summary

Bumps Cargo version `0.34.1` → `0.34.2` to release PR #241 (`pg_roles`
replacement for `pg_authid` in foreign-server owner lookup).

## Why

v0.34.1 was tagged on commit `8d95209` (the version bump itself). The
`pg_authid` fix in #241 landed immediately after on `098e924` and was
never released. Downstream consumers using `actions/drift-check` resolve
`latest` at runtime, so they keep pulling the 0.34.1 binary — meaning
the fix has been dormant for every CI run since the merge.

Concrete consequence: `sagri-tokyo/mrv` CI has been failing on every
schema PR with `permission denied for table pg_authid` ([issue #3831](https://github.com/sagri-tokyo/mrv/issues/3831)),
even after pinning the action SHA to `098e924f`. Verified against staging
that the new `pg_roles`-based query runs fine as a non-superuser RDS
role.

## Change

- `Cargo.toml`: `0.34.1` → `0.34.2`
- `Cargo.lock`: mirrored

Once merged, tag `v0.34.2` to trigger the release pipeline; CI using
`version: latest` will pick it up automatically.

## Test plan

- [x] `cargo check` passes locally
- [ ] Release CI green on the new tag
- [ ] Downstream re-verify on a `sagri-tokyo/mrv` schema PR