### PR TITLE
fix(action): don't merge pgmold stderr into JSON stdout in drift step

### DIFF
--- a/.github/actions/drift-check/action.yml
+++ b/.github/actions/drift-check/action.yml
@@ -323,17 +323,21 @@ runs:
         set +f
 
         echo "Running drift detection..."
+        DRIFT_STDERR="$RUNNER_TEMP/pgmold-drift-stderr.log"
         set +e
         OUTPUT=$(pgmold drift "${SCHEMA_ARGS[@]}" \
           --database "$INPUT_DATABASE" \
           --target-schemas "$INPUT_TARGET_SCHEMAS" \
-          --json 2>&1)
+          --json 2>"$DRIFT_STDERR")
         DRIFT_EXIT=$?
         set -e
 
         if ! echo "$OUTPUT" | jq empty 2>/dev/null; then
           echo "::error::pgmold drift produced non-JSON output (exit $DRIFT_EXIT):"
+          echo "--- stdout ---"
           echo "$OUTPUT"
+          echo "--- stderr ---"
+          cat "$DRIFT_STDERR"
           exit 1
         fi
 


### PR DESCRIPTION
## Summary

The `drift-check` action captured both stdout and stderr into `OUTPUT`
via `2>&1`, then tried to parse `OUTPUT` as JSON:

```bash
OUTPUT=$(pgmold drift ... --json 2>&1)
if ! echo "$OUTPUT" | jq empty 2>/dev/null; then
  echo "::error::pgmold drift produced non-JSON output..."
  exit 1
fi
```

This was harmless until v0.34.0 (#230), which added
`eprintln!("[pgmold:parser] extract_table_references: all parse
strategies failed ...")` in `src/parser/dependencies.rs`. The warnings
now pollute stdout and every drift check fails with
`pgmold drift produced non-JSON output (exit 0)`.

## Reproducer

`sagri-tokyo/mrv` CI (issue sagri-tokyo/mrv#3831): the `pg_authid`
error is gone after v0.34.2, but the next drift run surfaced this
latent bug. Run: https://github.com/sagri-tokyo/mrv/actions/runs/24709708156

```
##[error]pgmold drift produced non-JSON output (exit 0):
[pgmold:parser] extract_table_references: all parse strategies failed (schema=ai, ...)
[pgmold:parser] extract_table_references: all parse strategies failed (schema=ai, ...)
...
```

## Fix

Capture stderr to a separate file so stdout stays pure JSON, and print
both on parse failure. Matches the existing `plan`/`diff` steps which
already let stderr flow naturally.

## Test plan

- [x] Shell diff is minimal (5 lines)
- [ ] Action CI green
- [ ] Downstream re-verify on `sagri-tokyo/mrv` schema PR