### PR TITLE
fix(drift-check): don't fold stderr into the JSON report capture

### DIFF
--- a/.github/actions/drift-check/action.yml
+++ b/.github/actions/drift-check/action.yml
@@ -323,16 +323,22 @@ runs:
         set +f
 
         echo "Running drift detection..."
-        set +e
+        # Keep stderr on the runner console for debugging (parser warnings, etc.)
+        # but keep stdout clean so jq can parse the JSON report unambiguously.
+        STDERR_LOG="$RUNNER_TEMP/pgmold-drift-stderr.log"
+        DRIFT_EXIT=0
         OUTPUT=$(pgmold drift "${SCHEMA_ARGS[@]}" \
           --database "$INPUT_DATABASE" \
           --target-schemas "$INPUT_TARGET_SCHEMAS" \
-          --json 2>&1)
-        DRIFT_EXIT=$?
-        set -e
+          --json 2>"$STDERR_LOG") || DRIFT_EXIT=$?
+        if [[ -s "$STDERR_LOG" ]]; then
+          echo "::group::pgmold drift stderr"
+          cat "$STDERR_LOG"
+          echo "::endgroup::"
+        fi
 
         if ! echo "$OUTPUT" | jq empty 2>/dev/null; then
-          echo "::error::pgmold drift produced non-JSON output (exit $DRIFT_EXIT):"
+          echo "::error::pgmold drift produced non-JSON output (exit $DRIFT_EXIT); see 'pgmold drift stderr' group above"
           echo "$OUTPUT"
           exit 1
         fi


### PR DESCRIPTION
## Problem

`pgmold drift --json` emits PLpgSQL parser warnings to stderr (e.g., `[pgmold:parser] extract_table_references: all parse strategies failed ...`) while emitting the JSON report on stdout. The drift-check action captured them together via `2>&1`, so any stderr output prepended non-JSON noise to `$OUTPUT` and `jq empty` rejected the whole capture as non-JSON.

In 0.34.1 and earlier this was masked: the `permission denied for pg_authid` error failed the binary before JSON was produced, so the same `jq empty` rejection hid behind a different cause. After the pg_roles fix shipped in 0.34.2, the JSON path succeeds and stderr leaks into `$OUTPUT` on every run that has parser warnings (which is effectively every real-world schema).

Observed downstream on `sagri-tokyo/mrv`:

```
##[error]pgmold drift produced non-JSON output (exit 0):
[pgmold:parser] extract_table_references: all parse strategies failed ...
[pgmold:parser] extract_table_references: all parse strategies failed ...
...
{
  "has_drift": true,
  "expected_fingerprint": "...",
  ...
}
```

## Fix

Redirect stderr to a temp log file (`$RUNNER_TEMP/pgmold-drift-stderr.log`), surface its contents in a collapsible `::group::` block so parser warnings stay debuggable, and keep stdout alone for jq. `DRIFT_EXIT` is captured via `|| DRIFT_EXIT=$?` so `set -e` stays active across the block.

## Test plan

- [ ] `sagri-tokyo/mrv#3824`'s `pgmold-validation` goes green once this lands in a tagged release and the downloaded `latest` binary reflects it.