### PR TITLE
chore: bump version to 0.34.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1587,7 +1587,7 @@ dependencies = [
 
 [[package]]
 name = "pgmold"
-version = "0.34.2"
+version = "0.34.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "pgmold"
-version = "0.34.2"
+version = "0.34.3"
 edition = "2021"
 exclude = [".auto-claude/", ".auto-claude-security.json", ".claude_settings.json"]
 description = "PostgreSQL schema-as-code management tool"


### PR DESCRIPTION
Releases the drift-check stderr fix from #244. Consumers using the drift-check action resolve `latest` at runtime, so without a new release the fix never reaches CI pipelines — currently manifests as every caller's drift step failing with `pgmold drift produced non-JSON output` on v0.34.2 because PLpgSQL parser warnings on stderr are folded into the JSON capture.