### PR TITLE
fix(parser): accept E-string and dollar-quoted literals in COMMENT ON (gh#246)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2097,9 +2097,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2613,7 +2613,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.52.0",
  "windows-sys 0.59.0",
 ]
 

--- a/src/parser/comments.rs
+++ b/src/parser/comments.rs
@@ -1,3 +1,5 @@
+use std::sync::LazyLock;
+
 use crate::model::*;
 use regex::Regex;
 
@@ -16,25 +18,130 @@ pub(super) fn parse_comment_statements(sql: &str, schema: &mut Schema) {
     parse_trigger_comments(sql, schema);
 }
 
+/// Matches any string literal form PostgreSQL accepts in a COMMENT ON ... IS clause:
+/// standard `'…'` (with `''` escape), escape-syntax `E'…'` (with backslash escapes),
+/// untagged dollar-quoted `$$…$$`, or the bare keyword `NULL`.
+///
+/// Tagged dollar-quoting (`$tag$…$tag$`) is intentionally omitted: the `regex` crate
+/// does not support backreferences, and comment literals rarely use custom tags.
+const IS_LITERAL_PATTERN: &str =
+    r"(?:(?i:E)'(?:[^'\\]|\\.|'')*'|'(?:[^']|'')*'|\$\$[\s\S]*?\$\$|(?i:NULL))";
+
+fn compile(body: &str) -> Regex {
+    Regex::new(&format!(r"(?i){body}\s+IS\s+({IS_LITERAL_PATTERN})\s*;"))
+        .expect("COMMENT ON regex compiles")
+}
+
 fn extract_comment_text(raw: &str) -> Option<String> {
     let trimmed = raw.trim();
     if trimmed.eq_ignore_ascii_case("NULL") {
         return None;
     }
-    if trimmed.starts_with('\'') && trimmed.ends_with('\'') {
-        let inner = &trimmed[1..trimmed.len() - 1];
-        Some(inner.replace("''", "'"))
-    } else {
-        None
+    if let Some(rest) = trimmed.strip_prefix(['E', 'e']) {
+        if rest.starts_with('\'') && rest.ends_with('\'') && rest.len() >= 2 {
+            return Some(unescape_e_string(&rest[1..rest.len() - 1]));
+        }
     }
+    if trimmed.starts_with('\'') && trimmed.ends_with('\'') && trimmed.len() >= 2 {
+        return Some(trimmed[1..trimmed.len() - 1].replace("''", "'"));
+    }
+    if trimmed.starts_with("$$") && trimmed.ends_with("$$") && trimmed.len() >= 4 {
+        return Some(trimmed[2..trimmed.len() - 2].to_string());
+    }
+    // `IS_LITERAL_PATTERN` only matches the forms handled above, so reaching here
+    // means the upstream regex and this extractor have drifted apart.
+    unreachable!(
+        "extract_comment_text received literal not covered by IS_LITERAL_PATTERN: {raw:?}"
+    );
 }
 
-fn parse_table_comments(sql: &str, schema: &mut Schema) {
-    let regex = Regex::new(
-        r#"(?i)COMMENT\s+ON\s+TABLE\s+(?:["']?([^"'\s.]+)["']?\.)?["']?([^"'\s;]+)["']?\s+IS\s+((?:'(?:[^']|'')*')|NULL)\s*;"#
-    ).unwrap();
+/// Applies PostgreSQL's escape-string `E'…'` rules to the literal body.
+/// Handles the common C-style escapes; unknown escape sequences (including octal/hex
+/// byte forms such as `\0`, `\xHH`, `\uNNNN`) are kept verbatim, matching psql's
+/// permissive behaviour when `escape_string_warning` is off. Emitting a NUL byte
+/// would produce a string PostgreSQL itself rejects on write, so `\0` is preserved
+/// as `\0` rather than being substituted for `'\u{0}'`.
+fn unescape_e_string(body: &str) -> String {
+    let mut out = String::with_capacity(body.len());
+    let mut chars = body.chars().peekable();
+    while let Some(c) = chars.next() {
+        match c {
+            '\\' => match chars.next() {
+                Some('n') => out.push('\n'),
+                Some('t') => out.push('\t'),
+                Some('r') => out.push('\r'),
+                Some('b') => out.push('\u{08}'),
+                Some('f') => out.push('\u{0C}'),
+                Some('\\') => out.push('\\'),
+                Some('\'') => out.push('\''),
+                Some('"') => out.push('"'),
+                Some(other) => {
+                    out.push('\\');
+                    out.push(other);
+                }
+                None => out.push('\\'),
+            },
+            '\'' => {
+                if matches!(chars.peek(), Some('\'')) {
+                    chars.next();
+                }
+                out.push('\'');
+            }
+            c => out.push(c),
+        }
+    }
+    out
+}
 
-    for capture in regex.captures_iter(sql) {
+static TABLE_RE: LazyLock<Regex> = LazyLock::new(|| {
+    compile(r#"COMMENT\s+ON\s+TABLE\s+(?:["']?([^"'\s.]+)["']?\.)?["']?([^"'\s;]+)["']?"#)
+});
+
+static COLUMN_RE: LazyLock<Regex> = LazyLock::new(|| {
+    compile(
+        r#"COMMENT\s+ON\s+COLUMN\s+(?:["']?([^"'\s.]+)["']?\.)?["']?([^"'\s.]+)["']?\.["']?([^"'\s;]+)["']?"#,
+    )
+});
+
+static FUNCTION_RE: LazyLock<Regex> = LazyLock::new(|| {
+    compile(
+        r#"COMMENT\s+ON\s+FUNCTION\s+(?:["']?([^"'\s(]+)["']?\.)?["']?([^"'\s(]+)["']?\s*\(([^)]*)\)"#,
+    )
+});
+
+static VIEW_RE: LazyLock<Regex> = LazyLock::new(|| {
+    compile(r#"COMMENT\s+ON\s+VIEW\s+(?:["']?([^"'\s.]+)["']?\.)?["']?([^"'\s;]+)["']?"#)
+});
+
+static MATERIALIZED_VIEW_RE: LazyLock<Regex> = LazyLock::new(|| {
+    compile(
+        r#"COMMENT\s+ON\s+MATERIALIZED\s+VIEW\s+(?:["']?([^"'\s.]+)["']?\.)?["']?([^"'\s;]+)["']?"#,
+    )
+});
+
+static TYPE_RE: LazyLock<Regex> = LazyLock::new(|| {
+    compile(r#"COMMENT\s+ON\s+TYPE\s+(?:["']?([^"'\s.]+)["']?\.)?["']?([^"'\s;]+)["']?"#)
+});
+
+static DOMAIN_RE: LazyLock<Regex> = LazyLock::new(|| {
+    compile(r#"COMMENT\s+ON\s+DOMAIN\s+(?:["']?([^"'\s.]+)["']?\.)?["']?([^"'\s;]+)["']?"#)
+});
+
+static SCHEMA_RE: LazyLock<Regex> =
+    LazyLock::new(|| compile(r#"COMMENT\s+ON\s+SCHEMA\s+["']?([^"'\s;]+)["']?"#));
+
+static SEQUENCE_RE: LazyLock<Regex> = LazyLock::new(|| {
+    compile(r#"COMMENT\s+ON\s+SEQUENCE\s+(?:["']?([^"'\s.]+)["']?\.)?["']?([^"'\s;]+)["']?"#)
+});
+
+static TRIGGER_RE: LazyLock<Regex> = LazyLock::new(|| {
+    compile(
+        r#"COMMENT\s+ON\s+TRIGGER\s+["']?([^"'\s]+)["']?\s+ON\s+(?:["']?([^"'\s.]+)["']?\.)?["']?([^"'\s;]+)["']?"#,
+    )
+});
+
+fn parse_table_comments(sql: &str, schema: &mut Schema) {
+    for capture in TABLE_RE.captures_iter(sql) {
         let schema_part = capture.get(1).map(|m| unquote_ident(m.as_str()));
         let table_name = unquote_ident(capture.get(2).unwrap().as_str());
         let comment = extract_comment_text(capture.get(3).unwrap().as_str());
@@ -50,11 +157,7 @@ fn parse_table_comments(sql: &str, schema: &mut Schema) {
 }
 
 fn parse_column_comments(sql: &str, schema: &mut Schema) {
-    let regex = Regex::new(
-        r#"(?i)COMMENT\s+ON\s+COLUMN\s+(?:["']?([^"'\s.]+)["']?\.)?["']?([^"'\s.]+)["']?\.["']?([^"'\s;]+)["']?\s+IS\s+((?:'(?:[^']|'')*')|NULL)\s*;"#
-    ).unwrap();
-
-    for capture in regex.captures_iter(sql) {
+    for capture in COLUMN_RE.captures_iter(sql) {
         let schema_part = capture.get(1).map(|m| unquote_ident(m.as_str()));
         let table_name = unquote_ident(capture.get(2).unwrap().as_str());
         let column_name = unquote_ident(capture.get(3).unwrap().as_str());
@@ -71,11 +174,7 @@ fn parse_column_comments(sql: &str, schema: &mut Schema) {
 }
 
 fn parse_function_comments(sql: &str, schema: &mut Schema) {
-    let regex = Regex::new(
-        r#"(?i)COMMENT\s+ON\s+FUNCTION\s+(?:["']?([^"'\s(]+)["']?\.)?["']?([^"'\s(]+)["']?\s*\(([^)]*)\)\s+IS\s+((?:'(?:[^']|'')*')|NULL)\s*;"#
-    ).unwrap();
-
-    for capture in regex.captures_iter(sql) {
+    for capture in FUNCTION_RE.captures_iter(sql) {
         let schema_part = capture.get(1).map(|m| unquote_ident(m.as_str()));
         let function_name = unquote_ident(capture.get(2).unwrap().as_str());
         let arguments = capture.get(3).unwrap().as_str();
@@ -92,11 +191,7 @@ fn parse_function_comments(sql: &str, schema: &mut Schema) {
 }
 
 fn parse_view_comments(sql: &str, schema: &mut Schema) {
-    let regex = Regex::new(
-        r#"(?i)COMMENT\s+ON\s+VIEW\s+(?:["']?([^"'\s.]+)["']?\.)?["']?([^"'\s;]+)["']?\s+IS\s+((?:'(?:[^']|'')*')|NULL)\s*;"#
-    ).unwrap();
-
-    for capture in regex.captures_iter(sql) {
+    for capture in VIEW_RE.captures_iter(sql) {
         let schema_part = capture.get(1).map(|m| unquote_ident(m.as_str()));
         let view_name = unquote_ident(capture.get(2).unwrap().as_str());
         let comment = extract_comment_text(capture.get(3).unwrap().as_str());
@@ -112,11 +207,7 @@ fn parse_view_comments(sql: &str, schema: &mut Schema) {
 }
 
 fn parse_materialized_view_comments(sql: &str, schema: &mut Schema) {
-    let regex = Regex::new(
-        r#"(?i)COMMENT\s+ON\s+MATERIALIZED\s+VIEW\s+(?:["']?([^"'\s.]+)["']?\.)?["']?([^"'\s;]+)["']?\s+IS\s+((?:'(?:[^']|'')*')|NULL)\s*;"#
-    ).unwrap();
-
-    for capture in regex.captures_iter(sql) {
+    for capture in MATERIALIZED_VIEW_RE.captures_iter(sql) {
         let schema_part = capture.get(1).map(|m| unquote_ident(m.as_str()));
         let view_name = unquote_ident(capture.get(2).unwrap().as_str());
         let comment = extract_comment_text(capture.get(3).unwrap().as_str());
@@ -132,11 +223,7 @@ fn parse_materialized_view_comments(sql: &str, schema: &mut Schema) {
 }
 
 fn parse_type_comments(sql: &str, schema: &mut Schema) {
-    let regex = Regex::new(
-        r#"(?i)COMMENT\s+ON\s+TYPE\s+(?:["']?([^"'\s.]+)["']?\.)?["']?([^"'\s;]+)["']?\s+IS\s+((?:'(?:[^']|'')*')|NULL)\s*;"#
-    ).unwrap();
-
-    for capture in regex.captures_iter(sql) {
+    for capture in TYPE_RE.captures_iter(sql) {
         let schema_part = capture.get(1).map(|m| unquote_ident(m.as_str()));
         let type_name = unquote_ident(capture.get(2).unwrap().as_str());
         let comment = extract_comment_text(capture.get(3).unwrap().as_str());
@@ -152,11 +239,7 @@ fn parse_type_comments(sql: &str, schema: &mut Schema) {
 }
 
 fn parse_domain_comments(sql: &str, schema: &mut Schema) {
-    let regex = Regex::new(
-        r#"(?i)COMMENT\s+ON\s+DOMAIN\s+(?:["']?([^"'\s.]+)["']?\.)?["']?([^"'\s;]+)["']?\s+IS\s+((?:'(?:[^']|'')*')|NULL)\s*;"#
-    ).unwrap();
-
-    for capture in regex.captures_iter(sql) {
+    for capture in DOMAIN_RE.captures_iter(sql) {
         let schema_part = capture.get(1).map(|m| unquote_ident(m.as_str()));
         let domain_name = unquote_ident(capture.get(2).unwrap().as_str());
         let comment = extract_comment_text(capture.get(3).unwrap().as_str());
@@ -172,12 +255,7 @@ fn parse_domain_comments(sql: &str, schema: &mut Schema) {
 }
 
 fn parse_schema_comments(sql: &str, schema: &mut Schema) {
-    let regex = Regex::new(
-        r#"(?i)COMMENT\s+ON\s+SCHEMA\s+["']?([^"'\s;]+)["']?\s+IS\s+((?:'(?:[^']|'')*')|NULL)\s*;"#,
-    )
-    .unwrap();
-
-    for capture in regex.captures_iter(sql) {
+    for capture in SCHEMA_RE.captures_iter(sql) {
         let schema_name = unquote_ident(capture.get(1).unwrap().as_str());
         let comment = extract_comment_text(capture.get(2).unwrap().as_str());
 
@@ -190,11 +268,7 @@ fn parse_schema_comments(sql: &str, schema: &mut Schema) {
 }
 
 fn parse_sequence_comments(sql: &str, schema: &mut Schema) {
-    let regex = Regex::new(
-        r#"(?i)COMMENT\s+ON\s+SEQUENCE\s+(?:["']?([^"'\s.]+)["']?\.)?["']?([^"'\s;]+)["']?\s+IS\s+((?:'(?:[^']|'')*')|NULL)\s*;"#
-    ).unwrap();
-
-    for capture in regex.captures_iter(sql) {
+    for capture in SEQUENCE_RE.captures_iter(sql) {
         let schema_part = capture.get(1).map(|m| unquote_ident(m.as_str()));
         let sequence_name = unquote_ident(capture.get(2).unwrap().as_str());
         let comment = extract_comment_text(capture.get(3).unwrap().as_str());
@@ -210,11 +284,7 @@ fn parse_sequence_comments(sql: &str, schema: &mut Schema) {
 }
 
 fn parse_trigger_comments(sql: &str, schema: &mut Schema) {
-    let regex = Regex::new(
-        r#"(?i)COMMENT\s+ON\s+TRIGGER\s+["']?([^"'\s]+)["']?\s+ON\s+(?:["']?([^"'\s.]+)["']?\.)?["']?([^"'\s;]+)["']?\s+IS\s+((?:'(?:[^']|'')*')|NULL)\s*;"#
-    ).unwrap();
-
-    for capture in regex.captures_iter(sql) {
+    for capture in TRIGGER_RE.captures_iter(sql) {
         let trigger_name = unquote_ident(capture.get(1).unwrap().as_str());
         let schema_part = capture.get(2).map(|m| unquote_ident(m.as_str()));
         let table_name = unquote_ident(capture.get(3).unwrap().as_str());
@@ -227,5 +297,71 @@ fn parse_trigger_comments(sql: &str, schema: &mut Schema) {
             object_key,
             comment,
         });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_standard_string() {
+        assert_eq!(extract_comment_text("'hello'"), Some("hello".into()));
+    }
+
+    #[test]
+    fn extract_doubled_quote_escape() {
+        assert_eq!(
+            extract_comment_text("'it''s fine'"),
+            Some("it's fine".into())
+        );
+    }
+
+    #[test]
+    fn extract_e_string_with_backslash_escapes() {
+        assert_eq!(
+            extract_comment_text(r"E'@name foo\n@omit create'"),
+            Some("@name foo\n@omit create".into())
+        );
+    }
+
+    #[test]
+    fn extract_e_string_lowercase_prefix() {
+        assert_eq!(
+            extract_comment_text(r"e'tab\there'"),
+            Some("tab\there".into())
+        );
+    }
+
+    #[test]
+    fn extract_e_string_unknown_escape_preserved() {
+        assert_eq!(
+            extract_comment_text(r"E'keep \z literally'"),
+            Some(r"keep \z literally".into())
+        );
+    }
+
+    #[test]
+    fn extract_e_string_null_byte_not_substituted() {
+        let result = extract_comment_text(r"E'null \0 escape'").unwrap();
+        assert!(
+            !result.contains('\0'),
+            "NUL byte must not be emitted (PostgreSQL rejects it): {result:?}",
+        );
+        assert_eq!(result, r"null \0 escape");
+    }
+
+    #[test]
+    fn extract_dollar_quoted_literal() {
+        assert_eq!(
+            extract_comment_text(r#"$$contains 'quotes' and \backslashes$$"#),
+            Some(r#"contains 'quotes' and \backslashes"#.into())
+        );
+    }
+
+    #[test]
+    fn extract_null_maps_to_none() {
+        assert_eq!(extract_comment_text("NULL"), None);
+        assert_eq!(extract_comment_text("null"), None);
     }
 }

--- a/src/parser/loader.rs
+++ b/src/parser/loader.rs
@@ -133,6 +133,7 @@ pub fn load_schema_sources(sources: &[String]) -> Result<Schema> {
         merged.pending_owners.extend(schema.pending_owners);
         merged.pending_grants.extend(schema.pending_grants);
         merged.pending_revokes.extend(schema.pending_revokes);
+        merged.pending_comments.extend(schema.pending_comments);
     }
 
     merged.pending_policies = merged.finalize_partial();
@@ -284,6 +285,28 @@ mod tests {
         let pattern = format!("{}/*.sql", dir.path().display());
         let result = resolve_source(&pattern).unwrap();
         assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn comment_on_in_separate_file_applies_to_function() {
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join("0_func.sql"),
+            "CREATE FUNCTION foo() RETURNS void LANGUAGE sql AS $$ SELECT 1 $$;",
+        )
+        .unwrap();
+        fs::write(
+            dir.path().join("1_tags.sql"),
+            "COMMENT ON FUNCTION foo() IS E'@name fooTag';",
+        )
+        .unwrap();
+
+        let result = load_schema_sources(&[dir.path().to_string_lossy().into_owned()]).unwrap();
+        let func = result
+            .functions
+            .get("public.foo()")
+            .expect("function should merge");
+        assert_eq!(func.comment.as_deref(), Some("@name fooTag"));
     }
 
     #[test]

--- a/src/parser/preprocess.rs
+++ b/src/parser/preprocess.rs
@@ -308,7 +308,7 @@ pub(super) fn preprocess_sql(sql: &str) -> String {
         r"(?i)ALTER\s+TYPE\s+[^;]+\s+(?:ADD|DROP|ALTER)\s+ATTRIBUTE\s+[^;]+;",
         r"(?i)ALTER\s+DOMAIN\s+[^;]+;",
         r"(?i)ALTER\s+DEFAULT\s+PRIVILEGES\s+[^;]+;",
-        r"(?i)COMMENT\s+ON\s+\w+(?:\s+\w+)*\s+.+?\s+IS\s+(?:'(?:[^']|'')*'|NULL)\s*;",
+        r"(?i)COMMENT\s+ON\s+\w+(?:\s+\w+)*\s+.+?\s+IS\s+(?:(?i:E)'(?:[^'\\]|\\.|'')*'|'(?:[^']|'')*'|\$\$[\s\S]*?\$\$|NULL)\s*;",
         r"(?i)REVOKE\s+[^;]+;",
         r"(?i)GRANT\s+[^;]+;",
     ];

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -2344,6 +2344,88 @@ fn comment_on_schema_stripped_during_parse() {
 }
 
 #[test]
+fn comment_on_function_captures_text() {
+    let sql = r#"
+        CREATE FUNCTION add(a integer, b integer) RETURNS integer LANGUAGE sql AS $$ SELECT a + b $$;
+        COMMENT ON FUNCTION add(integer, integer) IS 'Adds two numbers';
+    "#;
+    let schema = parse_sql_string(sql).unwrap();
+    let func = schema
+        .functions
+        .get("public.add(integer, integer)")
+        .expect("function should be parsed");
+    assert_eq!(func.comment.as_deref(), Some("Adds two numbers"));
+}
+
+#[test]
+fn comment_on_function_accepts_e_string_literal() {
+    let sql = r#"
+        CREATE FUNCTION mrv.submit_plan(a integer) RETURNS void LANGUAGE sql AS $$ SELECT 1 $$;
+        COMMENT ON FUNCTION mrv.submit_plan(integer) IS E'@name submitPlan\n@omit create,update';
+    "#;
+    let schema = parse_sql_string(sql).unwrap();
+    let func = schema
+        .functions
+        .get("mrv.submit_plan(integer)")
+        .expect("function should be parsed");
+    assert_eq!(
+        func.comment.as_deref(),
+        Some("@name submitPlan\n@omit create,update")
+    );
+}
+
+#[test]
+fn comment_on_column_accepts_e_string_literal() {
+    let sql = r#"
+        CREATE TABLE mrv.orders (id integer PRIMARY KEY, total numeric);
+        COMMENT ON COLUMN mrv.orders.total IS E'@deprecated use\ttotals.amount';
+    "#;
+    let schema = parse_sql_string(sql).unwrap();
+    let table = schema.tables.get("mrv.orders").expect("table should parse");
+    let column = table.columns.get("total").expect("column should exist");
+    assert_eq!(
+        column.comment.as_deref(),
+        Some("@deprecated use\ttotals.amount")
+    );
+}
+
+#[test]
+fn comment_on_table_accepts_dollar_quoted_literal() {
+    let sql = r#"
+        CREATE TABLE t (id integer PRIMARY KEY);
+        COMMENT ON TABLE t IS $$holds ' and " chars literally$$;
+    "#;
+    let schema = parse_sql_string(sql).unwrap();
+    let table = schema.tables.get("public.t").unwrap();
+    assert_eq!(
+        table.comment.as_deref(),
+        Some(r#"holds ' and " chars literally"#)
+    );
+}
+
+#[test]
+fn comment_on_function_null_clears_comment() {
+    let sql = r#"
+        CREATE FUNCTION foo() RETURNS void LANGUAGE sql AS $$ SELECT 1 $$;
+        COMMENT ON FUNCTION foo() IS NULL;
+    "#;
+    let schema = parse_sql_string(sql).unwrap();
+    let func = schema.functions.get("public.foo()").unwrap();
+    assert!(func.comment.is_none());
+}
+
+#[test]
+fn comment_on_table_doubled_quote_unescaped() {
+    let sql = r#"
+        CREATE TABLE t (id integer PRIMARY KEY);
+        COMMENT ON TABLE t IS 'it''s a table';
+    "#;
+    let schema = parse_sql_string(sql).unwrap();
+    let table = schema.tables.get("public.t").unwrap();
+    assert_eq!(table.comment.as_deref(), Some("it's a table"));
+}
+
+#[test]
 fn parses_grant_on_enum_type() {
     let sql = r#"
         CREATE TYPE user_role AS ENUM ('admin', 'user');

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -93,6 +93,7 @@ fn merge_schemas(schemas: Vec<Schema>) -> Result<Schema> {
         merged.pending_owners.extend(schema.pending_owners);
         merged.pending_grants.extend(schema.pending_grants);
         merged.pending_revokes.extend(schema.pending_revokes);
+        merged.pending_comments.extend(schema.pending_comments);
     }
 
     merged.finalize().map_err(SchemaError::ParseError)?;


### PR DESCRIPTION
Closes #246.

## Summary

`COMMENT ON` statements with non-standard string literals were silently dropped at parse time. Root cause was the IS-clause regex in `src/parser/comments.rs` only matching `'…'` or `NULL` — PostgreSQL's `E'…'` (escape strings, heavily used by PostGraphile smart tags like `E'@name foo\n@omit create'`) and `\$\$…\$\$` (dollar-quoted) forms were rejected and the comments vanished with no error, warning, or exit code.

While investigating, also noticed that `pending_comments` were never merged across files in `parser/loader.rs` or across providers in `provider/mod.rs`, so a `COMMENT ON` in a different file from its target was silently dropped during the merge step.

## Changes

- **`src/parser/comments.rs`** — shared `IS_LITERAL_PATTERN` matching standard / E-string / untagged dollar-quoted / NULL; new `extract_comment_text` routes to the right unescape per form. `unescape_e_string` handles `\n \t \r \b \f \\ \' \"` plus doubled single quotes. `\0` is intentionally preserved verbatim (PostgreSQL itself rejects NUL bytes, so substituting would produce strings the database cannot store). Regex patterns moved into `LazyLock<Regex>` statics so they compile once per process instead of once per parse.
- **`src/parser/preprocess.rs`** — strip regex broadened to the same literal forms so E-string / dollar-quoted comments do not leak to sqlparser.
- **`src/parser/loader.rs`**, **`src/provider/mod.rs`** — one-line additions extending `pending_comments` during schema merging.
- **Tests** — 8 integration tests in `src/parser/tests.rs` covering E-strings, dollar-quoted, NULL, doubled-quote escape, and cross-file merging. 8 unit tests on `extract_comment_text` inside `comments.rs`. 1 cross-file loader test.

## Out of scope

Tagged dollar-quoting (`\$tag\$…\$tag\$`) is not supported — the `regex` crate has no backreferences and tagged comment literals are rare.

`COMMENT ON` for `POLICY` / `CONSTRAINT` / `OPERATOR` / `EXTENSION` / `RULE` still isn't parsed. Tracked as follow-up in pgmold-270.

## Test plan

- [ ] CI green on Linux + macOS matrix
- [ ] Integration tests (`tests/integration.rs`) continue to pass
- [ ] Spot-check against the downstream sagri-tokyo/mrv schema: run `pgmold plan` on the schema directory and confirm PostGraphile smart-tag `COMMENT ON FUNCTION … IS E'@name …'` statements now appear in the plan rather than being silently absent.