### PR TITLE
chore: bump version to 0.34.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1587,7 +1587,7 @@ dependencies = [
 
 [[package]]
 name = "pgmold"
-version = "0.34.4"
+version = "0.34.5"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "pgmold"
-version = "0.34.4"
+version = "0.34.5"
 edition = "2021"
 exclude = [".auto-claude/", ".auto-claude-security.json", ".claude_settings.json"]
 description = "PostgreSQL schema-as-code management tool"


### PR DESCRIPTION
## Summary

Release 0.34.5 covering all unreleased fixes since v0.34.2. Note: 0.34.3 and 0.34.4 bump commits landed on main but were never tagged or published to crates.io, so their changes are folded into this release.

## Fixes since v0.34.2
- fix(drift-check): don't fold stderr into the JSON report capture (#244)
- fix(parser): accept E-string and dollar-quoted literals in COMMENT ON / gh#246 (#247)
- fix(planner): don't collide SetComment OpKeys on per-column/overload comments / gh#249 (#250)
- fix(parser): add COMMENT ON AGGREGATE regex arm / pgmold-278 (#252)

## Test plan
- [x] cargo build --release succeeds
- [x] cargo fmt clean
- [ ] CI green (tag + crates.io publish + GitHub release after merge)