### PR TITLE
feat(parser): warn on unrecognized top-level statements (pgmold-271)

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -212,6 +212,13 @@ impl GrantArgs {
 #[command(version)]
 #[command(about = "PostgreSQL schema-as-code management", long_about = None)]
 struct Cli {
+    /// Promote parser warnings (unrecognized COMMENT ON / GRANT / REVOKE /
+    /// ALTER ... OWNER TO / ALTER DEFAULT PRIVILEGES) to errors. Intended
+    /// for CI pipelines that want to fail fast on silently-dropped
+    /// statements.
+    #[arg(long, global = true)]
+    strict: bool,
+
     #[command(subcommand)]
     command: Commands,
 }
@@ -473,6 +480,13 @@ async fn run_validation(
 
 pub async fn run() -> Result<()> {
     let cli = Cli::parse();
+
+    if cli.strict {
+        // Propagate to library-level parser via env var. This is a
+        // process-wide setting; safe because CLI invocations are
+        // single-shot.
+        std::env::set_var("PGMOLD_STRICT", "1");
+    }
 
     match cli.command {
         Commands::Diff {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -14,6 +14,7 @@ mod ownership;
 mod preprocess;
 mod sequences;
 mod tables;
+mod unrecognized;
 mod util;
 
 #[cfg(test)]
@@ -24,6 +25,7 @@ pub use dependencies::{
     topological_sort, ObjectRef,
 };
 pub use loader::load_schema_sources;
+pub use unrecognized::{find_unrecognized_statements, UnrecognizedStatement};
 
 use crate::model::*;
 use crate::pg::sqlgen::strip_ident_quotes;
@@ -61,7 +63,42 @@ pub fn parse_sql_file(path: &str) -> Result<Schema> {
     parse_sql_string(&content)
 }
 
+/// Returns `true` when the parser should treat unrecognized top-level
+/// statements as errors instead of warnings. Controlled via the
+/// `PGMOLD_STRICT` environment variable; set to `1` by the CLI's
+/// `--strict` flag.
+fn strict_mode_from_env() -> bool {
+    matches!(std::env::var("PGMOLD_STRICT").as_deref(), Ok("1"))
+}
+
 pub fn parse_sql_string(sql: &str) -> Result<Schema> {
+    parse_sql_string_with_strict(sql, strict_mode_from_env())
+}
+
+/// Parses SQL with an explicit strict flag. Callers that need deterministic
+/// strict behavior (tests, library consumers that do not want to mutate
+/// process-wide env vars) should prefer this over `parse_sql_string`.
+pub fn parse_sql_string_with_strict(sql: &str, strict: bool) -> Result<Schema> {
+    let schema = parse_sql_string_inner(sql)?;
+    let unrecognized = find_unrecognized_statements(sql);
+    for finding in &unrecognized {
+        eprintln!("{}", finding.warning_message());
+    }
+    if strict && !unrecognized.is_empty() {
+        let summary = unrecognized
+            .iter()
+            .map(|f| format!("  line {}: {}", f.line, f.snippet))
+            .collect::<Vec<_>>()
+            .join("\n");
+        return Err(SchemaError::ParseError(format!(
+            "{} unrecognized top-level statement(s) under --strict:\n{summary}",
+            unrecognized.len()
+        )));
+    }
+    Ok(schema)
+}
+
+fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
     let preprocessed_sql = preprocess_sql(sql);
     let dialect = PostgreSqlDialect {};
     let statements = Parser::parse_sql(&dialect, &preprocessed_sql)

--- a/src/parser/preprocess.rs
+++ b/src/parser/preprocess.rs
@@ -1,6 +1,6 @@
 use regex::Regex;
 
-fn strip_comments(sql: &str) -> String {
+pub(super) fn strip_comments(sql: &str) -> String {
     let bytes = sql.as_bytes();
     let length = bytes.len();
     let mut result = String::with_capacity(length);
@@ -194,7 +194,7 @@ fn reorder_sequence_options(sql: &str) -> String {
 /// Replaces quoted content (single-quoted strings, double-quoted identifiers,
 /// dollar-quoted blocks) with safe placeholders so that regex-based strip
 /// patterns cannot match keywords inside quoted text.
-fn protect_quoted_content(sql: &str) -> (String, Vec<(String, String)>) {
+pub(super) fn protect_quoted_content(sql: &str) -> (String, Vec<(String, String)>) {
     let bytes = sql.as_bytes();
     let length = bytes.len();
     let mut result = String::with_capacity(length);

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -4563,6 +4563,43 @@ CREATE AGGREGATE public.group_concat(text) (
 }
 
 #[test]
+fn parse_sql_string_with_strict_errors_on_unrecognized() {
+    let sql = "\
+CREATE TABLE public.users (id serial);
+CREATE POLICY p ON public.users USING (true);
+COMMENT ON POLICY p ON public.users IS 'policy comment';
+";
+    let result = parse_sql_string_with_strict(sql, true);
+    let err = result.expect_err("strict mode should reject unrecognized statements");
+    let message = err.to_string();
+    assert!(
+        message.contains("COMMENT ON POLICY"),
+        "error should mention the offending statement: {message}"
+    );
+    assert!(
+        message.contains("unrecognized"),
+        "error should say 'unrecognized': {message}"
+    );
+}
+
+#[test]
+fn parse_sql_string_with_strict_passes_when_clean() {
+    let sql = "CREATE TABLE public.users (id serial);";
+    parse_sql_string_with_strict(sql, true).expect("clean SQL should parse under strict");
+}
+
+#[test]
+fn parse_sql_string_does_not_error_on_unrecognized_without_strict() {
+    // Regression guard: non-strict parsing keeps warning-only semantics so
+    // existing callers are not broken.
+    let sql = "\
+CREATE TABLE public.users (id serial);
+COMMENT ON POLICY p ON public.users IS 'x';
+";
+    parse_sql_string_with_strict(sql, false).expect("non-strict mode should still parse");
+}
+
+#[test]
 fn alter_aggregate_owner_records_pending_owner() {
     let sql = r#"
 CREATE AGGREGATE public.group_concat(text) (

--- a/src/parser/unrecognized.rs
+++ b/src/parser/unrecognized.rs
@@ -1,0 +1,452 @@
+//! Detection of top-level SQL statements that pgmold's regex-based parse
+//! passes silently drop.
+//!
+//! When a `COMMENT ON`, `GRANT`, `REVOKE`, `ALTER ... OWNER TO`, or
+//! `ALTER DEFAULT PRIVILEGES` is syntactically valid but does not match one
+//! of the specific pgmold regex variants, `preprocess_sql` still strips it
+//! out before sqlparser runs — so sqlparser never sees it and pgmold never
+//! records it. Silent drop. This module surfaces those drops as warnings
+//! (and, under strict mode, as errors) so downstream users do not discover
+//! them months later as schema drift.
+//!
+//! See pgmold-271 (and gh#246, which was only diagnosable after quiet
+//! failure masked it for months).
+use regex::Regex;
+use std::sync::LazyLock;
+
+use super::preprocess::{protect_quoted_content, strip_comments};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnrecognizedStatement {
+    pub line: usize,
+    pub kind: &'static str,
+    pub snippet: String,
+}
+
+impl UnrecognizedStatement {
+    pub fn warning_message(&self) -> String {
+        format!(
+            "warning: pgmold did not recognize {} statement at line {}: {}",
+            self.kind, self.line, self.snippet
+        )
+    }
+}
+
+// Broad recognizers — one per statement class that pgmold's regex passes
+// are responsible for claiming. A match here means "this statement kind
+// exists at this location in the SQL"; whether it is actually claimed by
+// a specific pgmold parser is determined by matching against the claim
+// regexes below.
+
+static COMMENT_ON_BROAD: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"(?is)\bCOMMENT\s+ON\s+[^;]+?\s+IS\s+(?:(?:E|e)?'(?:[^'\\]|\\.|'')*'|\$\$[\s\S]*?\$\$|NULL)\s*;",
+    )
+    .unwrap()
+});
+
+static GRANT_BROAD: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?is)\bGRANT\s+[^;]+;").unwrap());
+
+static REVOKE_BROAD: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?is)\bREVOKE\s+[^;]+;").unwrap());
+
+// Restricted to the object kinds whose OWNER TO is routed through the
+// preprocess strip + ownership.rs regex pass. ALTER AGGREGATE ... OWNER
+// TO is parsed through the sqlparser AST path instead and must not appear
+// here. SCHEMA is included: preprocess leaves it alone and sqlparser's
+// AlterSchema is ignored in parser/mod.rs, so owner changes there are
+// silently dropped — exactly the shape this detector exists to surface.
+static ALTER_OWNER_BROAD: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"(?is)\bALTER\s+(?:TABLE|FUNCTION|TYPE|DOMAIN|MATERIALIZED\s+VIEW|VIEW|SEQUENCE|SCHEMA)\s+[^;]+?\s+OWNER\s+TO\s+[^;]+;",
+    )
+    .unwrap()
+});
+
+static ALTER_DEFAULT_PRIVILEGES_BROAD: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?is)\bALTER\s+DEFAULT\s+PRIVILEGES\s+[^;]+;").unwrap());
+
+// Specific claim patterns — one per existing pgmold regex parser. A broad
+// match that overlaps at least one of these is considered "claimed" and
+// will not produce a warning.
+
+static COMMENT_ON_TABLE_CLAIM: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?is)\bCOMMENT\s+ON\s+TABLE\s+").unwrap());
+static COMMENT_ON_COLUMN_CLAIM: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?is)\bCOMMENT\s+ON\s+COLUMN\s+").unwrap());
+static COMMENT_ON_FUNCTION_CLAIM: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?is)\bCOMMENT\s+ON\s+FUNCTION\s+").unwrap());
+static COMMENT_ON_AGGREGATE_CLAIM: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?is)\bCOMMENT\s+ON\s+AGGREGATE\s+").unwrap());
+static COMMENT_ON_VIEW_CLAIM: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?is)\bCOMMENT\s+ON\s+VIEW\s+").unwrap());
+static COMMENT_ON_MATERIALIZED_VIEW_CLAIM: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?is)\bCOMMENT\s+ON\s+MATERIALIZED\s+VIEW\s+").unwrap());
+static COMMENT_ON_TYPE_CLAIM: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?is)\bCOMMENT\s+ON\s+TYPE\s+").unwrap());
+static COMMENT_ON_DOMAIN_CLAIM: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?is)\bCOMMENT\s+ON\s+DOMAIN\s+").unwrap());
+static COMMENT_ON_SCHEMA_CLAIM: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?is)\bCOMMENT\s+ON\s+SCHEMA\s+").unwrap());
+static COMMENT_ON_SEQUENCE_CLAIM: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?is)\bCOMMENT\s+ON\s+SEQUENCE\s+").unwrap());
+static COMMENT_ON_TRIGGER_CLAIM: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?is)\bCOMMENT\s+ON\s+TRIGGER\s+").unwrap());
+
+// Mirrors grants.rs: GRANT privs ON [kind] target TO grantee. Object kind
+// keyword is optional so `GRANT SELECT ON public.users TO readonly;` is
+// not flagged.
+static GRANT_CLAIM: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"(?is)\bGRANT\s+.+?\s+ON\s+.+?\s+TO\s+(?:"[^"]+"|\w+|PUBLIC)"#).unwrap()
+});
+
+static REVOKE_CLAIM: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"(?is)\bREVOKE\s+.+?\s+ON\s+.+?\s+FROM\s+(?:"[^"]+"|\w+|PUBLIC)"#).unwrap()
+});
+
+static ALTER_TABLE_OWNER_CLAIM: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?is)\bALTER\s+TABLE\s+.+?\s+OWNER\s+TO\s+").unwrap());
+static ALTER_FUNCTION_OWNER_CLAIM: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?is)\bALTER\s+FUNCTION\s+.+?\s+OWNER\s+TO\s+").unwrap());
+static ALTER_TYPE_OWNER_CLAIM: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?is)\bALTER\s+TYPE\s+.+?\s+OWNER\s+TO\s+").unwrap());
+static ALTER_DOMAIN_OWNER_CLAIM: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?is)\bALTER\s+DOMAIN\s+.+?\s+OWNER\s+TO\s+").unwrap());
+static ALTER_MATERIALIZED_VIEW_OWNER_CLAIM: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?is)\bALTER\s+MATERIALIZED\s+VIEW\s+.+?\s+OWNER\s+TO\s+").unwrap()
+});
+static ALTER_VIEW_OWNER_CLAIM: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?is)\bALTER\s+VIEW\s+.+?\s+OWNER\s+TO\s+").unwrap());
+static ALTER_SEQUENCE_OWNER_CLAIM: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?is)\bALTER\s+SEQUENCE\s+.+?\s+OWNER\s+TO\s+").unwrap());
+
+static ALTER_DEFAULT_PRIVILEGES_GRANT_CLAIM: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"(?is)\bALTER\s+DEFAULT\s+PRIVILEGES\s+(?:FOR\s+ROLE\s+\w+\s+)?(?:IN\s+SCHEMA\s+\w+\s+)?GRANT\s+.+?\s+ON\s+(?:TABLES|SEQUENCES|FUNCTIONS|ROUTINES|TYPES|SCHEMAS)\s+TO\s+",
+    )
+    .unwrap()
+});
+
+static ALTER_DEFAULT_PRIVILEGES_REVOKE_CLAIM: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"(?is)\bALTER\s+DEFAULT\s+PRIVILEGES\s+(?:FOR\s+ROLE\s+\w+\s+)?(?:IN\s+SCHEMA\s+\w+\s+)?REVOKE\s+.+?\s+ON\s+(?:TABLES|SEQUENCES|FUNCTIONS|ROUTINES|TYPES|SCHEMAS)\s+FROM\s+",
+    )
+    .unwrap()
+});
+
+struct BroadRecognizer {
+    kind: &'static str,
+    broad: &'static LazyLock<Regex>,
+    claims: &'static [&'static LazyLock<Regex>],
+}
+
+static RECOGNIZERS: &[BroadRecognizer] = &[
+    BroadRecognizer {
+        kind: "COMMENT ON",
+        broad: &COMMENT_ON_BROAD,
+        claims: &[
+            &COMMENT_ON_TABLE_CLAIM,
+            &COMMENT_ON_COLUMN_CLAIM,
+            &COMMENT_ON_FUNCTION_CLAIM,
+            &COMMENT_ON_AGGREGATE_CLAIM,
+            &COMMENT_ON_VIEW_CLAIM,
+            &COMMENT_ON_MATERIALIZED_VIEW_CLAIM,
+            &COMMENT_ON_TYPE_CLAIM,
+            &COMMENT_ON_DOMAIN_CLAIM,
+            &COMMENT_ON_SCHEMA_CLAIM,
+            &COMMENT_ON_SEQUENCE_CLAIM,
+            &COMMENT_ON_TRIGGER_CLAIM,
+        ],
+    },
+    BroadRecognizer {
+        kind: "GRANT",
+        broad: &GRANT_BROAD,
+        claims: &[&GRANT_CLAIM],
+    },
+    BroadRecognizer {
+        kind: "REVOKE",
+        broad: &REVOKE_BROAD,
+        claims: &[&REVOKE_CLAIM],
+    },
+    BroadRecognizer {
+        kind: "ALTER ... OWNER TO",
+        broad: &ALTER_OWNER_BROAD,
+        claims: &[
+            &ALTER_TABLE_OWNER_CLAIM,
+            &ALTER_FUNCTION_OWNER_CLAIM,
+            &ALTER_TYPE_OWNER_CLAIM,
+            &ALTER_DOMAIN_OWNER_CLAIM,
+            &ALTER_MATERIALIZED_VIEW_OWNER_CLAIM,
+            &ALTER_VIEW_OWNER_CLAIM,
+            &ALTER_SEQUENCE_OWNER_CLAIM,
+        ],
+    },
+    BroadRecognizer {
+        kind: "ALTER DEFAULT PRIVILEGES",
+        broad: &ALTER_DEFAULT_PRIVILEGES_BROAD,
+        claims: &[
+            &ALTER_DEFAULT_PRIVILEGES_GRANT_CLAIM,
+            &ALTER_DEFAULT_PRIVILEGES_REVOKE_CLAIM,
+        ],
+    },
+];
+
+/// Returns unrecognized top-level SQL statements. Each entry carries a
+/// 1-based line number (referring to the original SQL) and a snippet of
+/// the offending statement, truncated to roughly 120 characters.
+pub fn find_unrecognized_statements(sql: &str) -> Vec<UnrecognizedStatement> {
+    // Sanitize comments and quoted content so that keywords inside string
+    // literals or `-- line comments` cannot trigger false positives. Both
+    // helpers preserve source offsets line-wise: strip_comments replaces
+    // removed content with whitespace, and protect_quoted_content replaces
+    // each literal with a placeholder. For multi-line literals the line
+    // number may drift downward, which is acceptable for a warning.
+    let stripped = strip_comments(sql);
+    let (sanitized, _replacements) = protect_quoted_content(&stripped);
+
+    let mut findings: Vec<UnrecognizedStatement> = Vec::new();
+
+    for recognizer in RECOGNIZERS {
+        for broad in recognizer.broad.find_iter(&sanitized) {
+            let body = broad.as_str();
+            let claimed = recognizer.claims.iter().any(|re| re.is_match(body));
+            if claimed {
+                continue;
+            }
+            let line = line_number(&sanitized, broad.start());
+            let snippet = truncate_snippet(body);
+            findings.push(UnrecognizedStatement {
+                line,
+                kind: recognizer.kind,
+                snippet,
+            });
+        }
+    }
+
+    findings.sort_by_key(|f| (f.line, f.snippet.clone()));
+    findings
+}
+
+fn line_number(sql: &str, offset: usize) -> usize {
+    let slice = &sql.as_bytes()[..offset.min(sql.len())];
+    1 + slice.iter().filter(|&&b| b == b'\n').count()
+}
+
+fn truncate_snippet(body: &str) -> String {
+    let normalized = body.split_whitespace().collect::<Vec<_>>().join(" ");
+    const LIMIT: usize = 120;
+    if normalized.chars().count() <= LIMIT {
+        return normalized;
+    }
+    let truncated: String = normalized.chars().take(LIMIT).collect();
+    format!("{truncated}…")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn comment_on_policy_flagged() {
+        let sql = "\
+CREATE TABLE public.users (id serial);
+CREATE POLICY p ON public.users USING (true);
+COMMENT ON POLICY p ON public.users IS 'policy comment';
+";
+        let findings = find_unrecognized_statements(sql);
+        assert_eq!(findings.len(), 1, "expected one finding: {findings:?}");
+        let finding = &findings[0];
+        assert_eq!(finding.kind, "COMMENT ON");
+        assert_eq!(finding.line, 3);
+        assert!(
+            finding.snippet.contains("COMMENT ON POLICY"),
+            "snippet missing COMMENT ON POLICY: {finding:?}"
+        );
+    }
+
+    #[test]
+    fn comment_on_table_not_flagged() {
+        let sql = "\
+CREATE TABLE public.users (id serial);
+COMMENT ON TABLE public.users IS 'a table';
+";
+        assert!(find_unrecognized_statements(sql).is_empty());
+    }
+
+    #[test]
+    fn comment_on_function_with_args_not_flagged() {
+        let sql = "COMMENT ON FUNCTION public.foo(integer, text) IS 'bar';";
+        assert!(find_unrecognized_statements(sql).is_empty());
+    }
+
+    #[test]
+    fn comment_on_aggregate_with_args_not_flagged() {
+        let sql = "COMMENT ON AGGREGATE public.group_concat(text) IS 'bar';";
+        assert!(find_unrecognized_statements(sql).is_empty());
+    }
+
+    #[test]
+    fn comment_on_materialized_view_not_flagged() {
+        let sql = "COMMENT ON MATERIALIZED VIEW public.mv IS 'bar';";
+        assert!(find_unrecognized_statements(sql).is_empty());
+    }
+
+    #[test]
+    fn comment_on_trigger_not_flagged() {
+        let sql = "COMMENT ON TRIGGER t ON public.users IS 'bar';";
+        assert!(find_unrecognized_statements(sql).is_empty());
+    }
+
+    #[test]
+    fn comment_on_index_flagged() {
+        let sql = "COMMENT ON INDEX public.idx_foo IS 'hello';";
+        let findings = find_unrecognized_statements(sql);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].kind, "COMMENT ON");
+    }
+
+    #[test]
+    fn comment_on_extension_flagged() {
+        let sql = "COMMENT ON EXTENSION hstore IS 'extra';";
+        let findings = find_unrecognized_statements(sql);
+        assert_eq!(findings.len(), 1);
+    }
+
+    #[test]
+    fn comment_on_constraint_flagged() {
+        let sql = "COMMENT ON CONSTRAINT foo ON public.users IS 'check it';";
+        let findings = find_unrecognized_statements(sql);
+        assert_eq!(findings.len(), 1);
+    }
+
+    #[test]
+    fn grant_on_table_not_flagged() {
+        let sql = "GRANT SELECT ON TABLE public.users TO readonly;";
+        assert!(find_unrecognized_statements(sql).is_empty());
+    }
+
+    #[test]
+    fn grant_implicit_table_not_flagged() {
+        let sql = "GRANT SELECT ON public.users TO readonly;";
+        assert!(find_unrecognized_statements(sql).is_empty());
+    }
+
+    #[test]
+    fn grant_all_tables_in_schema_not_flagged() {
+        let sql = "GRANT SELECT ON ALL TABLES IN SCHEMA public TO readonly;";
+        assert!(find_unrecognized_statements(sql).is_empty());
+    }
+
+    #[test]
+    fn grant_with_grant_option_not_flagged() {
+        let sql = "GRANT SELECT ON public.users TO app_user WITH GRANT OPTION;";
+        assert!(find_unrecognized_statements(sql).is_empty());
+    }
+
+    #[test]
+    fn grant_on_function_with_args_not_flagged() {
+        let sql = "GRANT EXECUTE ON FUNCTION add(integer, integer) TO app_user;";
+        assert!(find_unrecognized_statements(sql).is_empty());
+    }
+
+    #[test]
+    fn grant_role_membership_flagged() {
+        // Role membership grants (no ON clause) are cluster-level and not
+        // modelled by pgmold; today they are silently dropped by preprocess.
+        let sql = "GRANT admin_role TO alice;";
+        let findings = find_unrecognized_statements(sql);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].kind, "GRANT");
+    }
+
+    #[test]
+    fn revoke_role_membership_flagged() {
+        let sql = "REVOKE admin_role FROM alice;";
+        let findings = find_unrecognized_statements(sql);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].kind, "REVOKE");
+    }
+
+    #[test]
+    fn alter_schema_owner_flagged() {
+        let sql = "ALTER SCHEMA foo OWNER TO bar;";
+        let findings = find_unrecognized_statements(sql);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].kind, "ALTER ... OWNER TO");
+    }
+
+    #[test]
+    fn alter_table_owner_not_flagged() {
+        let sql = "ALTER TABLE public.users OWNER TO owner_role;";
+        assert!(find_unrecognized_statements(sql).is_empty());
+    }
+
+    #[test]
+    fn alter_function_owner_with_args_not_flagged() {
+        let sql = "ALTER FUNCTION public.foo(integer) OWNER TO owner_role;";
+        assert!(find_unrecognized_statements(sql).is_empty());
+    }
+
+    #[test]
+    fn alter_default_privileges_on_tables_not_flagged() {
+        let sql = "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO readonly;";
+        assert!(find_unrecognized_statements(sql).is_empty());
+    }
+
+    #[test]
+    fn alter_default_privileges_revoke_not_flagged() {
+        let sql = "ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE SELECT ON TABLES FROM public;";
+        assert!(find_unrecognized_statements(sql).is_empty());
+    }
+
+    #[test]
+    fn ignores_keywords_inside_string_literal() {
+        let sql = "CREATE TABLE t (label text DEFAULT 'GRANT SELECT ON TABLE x TO y;' NOT NULL);";
+        assert!(find_unrecognized_statements(sql).is_empty());
+    }
+
+    #[test]
+    fn ignores_comment_on_inside_line_comment() {
+        let sql = "-- COMMENT ON POLICY p ON public.x IS 'skipped';\nCREATE TABLE t (id int);";
+        assert!(find_unrecognized_statements(sql).is_empty());
+    }
+
+    #[test]
+    fn ignores_grant_inside_dollar_quoted_function_body() {
+        let sql = "\
+DO $$
+BEGIN
+    EXECUTE format('GRANT ALL ON SCHEMA public TO %I', current_user);
+END $$;
+";
+        assert!(find_unrecognized_statements(sql).is_empty());
+    }
+
+    #[test]
+    fn warning_message_includes_line_and_snippet() {
+        let sql = "\n\nCOMMENT ON POLICY p ON public.t IS 'x';";
+        let finding = find_unrecognized_statements(sql).remove(0);
+        let message = finding.warning_message();
+        assert!(message.contains("line 3"), "missing line number: {message}");
+        assert!(
+            message.contains("COMMENT ON POLICY"),
+            "missing snippet: {message}"
+        );
+    }
+
+    #[test]
+    fn multiple_unrecognized_statements_reported() {
+        let sql = "\
+COMMENT ON POLICY p ON public.t IS 'a';
+ALTER SCHEMA foo OWNER TO bar;
+GRANT role1 TO alice;
+";
+        let findings = find_unrecognized_statements(sql);
+        assert_eq!(findings.len(), 3);
+        let kinds: Vec<&str> = findings.iter().map(|f| f.kind).collect();
+        assert!(kinds.contains(&"COMMENT ON"));
+        assert!(kinds.contains(&"ALTER ... OWNER TO"));
+        assert!(kinds.contains(&"GRANT"));
+    }
+}


### PR DESCRIPTION
## Summary

- Adds parser::unrecognized module that scans SQL for COMMENT ON / GRANT / REVOKE / ALTER ... OWNER TO / ALTER DEFAULT PRIVILEGES statements not claimed by any specific pgmold regex parser.
- parse_sql_string prints warnings to stderr; new parse_sql_string_with_strict (and a --strict CLI flag via PGMOLD_STRICT env var) promotes them to errors for CI.
- Catches the silent-drop class that masked gh#246 for months: COMMENT ON POLICY / INDEX / EXTENSION / CONSTRAINT, ALTER SCHEMA OWNER TO, role-membership GRANTs, etc.

## Motivation

gh#246 (COMMENT ON with E-strings) shipped and sat unnoticed for months because the parser's regex pass silently dropped statements it could not match. Downstream phrase: "Quiet failure is the real bug." This closes that feedback gap.

## How it works

- `find_unrecognized_statements(sql)` returns `Vec<UnrecognizedStatement { line, kind, snippet }>`.
- Broad regexes mirror preprocess strip patterns. Claim regexes mirror the specific parsers (comments.rs, grants.rs, ownership.rs, parse_alter_default_privileges). A broad match with no overlapping claim is an unrecognized statement.
- SQL is pre-sanitized via `strip_comments` + `protect_quoted_content` so keywords inside string literals or dollar-quoted function bodies do not trigger false positives.

## Test plan

- [x] Unit tests in `src/parser/unrecognized.rs` cover:
  - COMMENT ON POLICY / INDEX / EXTENSION / CONSTRAINT flagged.
  - COMMENT ON TABLE / COLUMN / FUNCTION(args) / AGGREGATE(args) / MATERIALIZED VIEW / TRIGGER not flagged.
  - GRANT on TABLE / implicit TABLE / ALL IN SCHEMA / FUNCTION(args) / WITH GRANT OPTION not flagged.
  - GRANT / REVOKE role-membership (no ON clause) flagged.
  - ALTER SCHEMA OWNER flagged; ALTER TABLE / FUNCTION(args) OWNER not flagged.
  - ALTER DEFAULT PRIVILEGES GRANT / REVOKE not flagged.
  - Keywords inside string literals / line comments / dollar-quoted DO block ignored.
- [x] Integration tests in `src/parser/tests.rs` cover:
  - `parse_sql_string_with_strict(sql, true)` errors on COMMENT ON POLICY with line + snippet in message.
  - `parse_sql_string_with_strict(sql, true)` passes on clean SQL.
  - `parse_sql_string_with_strict(sql, false)` preserves warning-only semantics.
- [ ] CI green (cargo test --all-features).

## Follow-ups

- pgmold-272 (corpus convergence CI) will depend on this to assert "zero silently-dropped statements" against the vendored PostgreSQL regression suite.