### PR TITLE
fix(parser): strip ALTER TYPE RENAME ATTRIBUTE in preprocess (pgmold-281)

### DIFF
--- a/src/parser/preprocess.rs
+++ b/src/parser/preprocess.rs
@@ -305,7 +305,7 @@ pub(super) fn preprocess_sql(sql: &str) -> String {
         r"(?i)ALTER\s+SEQUENCE\s+[^;]+;",
         r"(?i)ALTER\s+TYPE\s+[^;]+\s+OWNER\s+TO\s+[^;]+;",
         r"(?i)ALTER\s+TYPE\s+[^;]+\s+SET\s+SCHEMA\s+[^;]+;",
-        r"(?i)ALTER\s+TYPE\s+[^;]+\s+(?:ADD|DROP|ALTER)\s+ATTRIBUTE\s+[^;]+;",
+        r"(?i)ALTER\s+TYPE\s+[^;]+\s+(?:ADD|DROP|ALTER|RENAME)\s+ATTRIBUTE\s+[^;]+;",
         r"(?i)ALTER\s+DOMAIN\s+[^;]+;",
         r"(?i)ALTER\s+DEFAULT\s+PRIVILEGES\s+[^;]+;",
         r"(?i)COMMENT\s+ON\s+\w+(?:\s+\w+)*\s+.+?\s+IS\s+(?:(?i:E)'(?:[^'\\]|\\.|'')*'|'(?:[^']|'')*'|\$\$[\s\S]*?\$\$|NULL)\s*;",
@@ -632,6 +632,20 @@ $$;"
     #[test]
     fn preprocess_keyword_in_dollar_quoted_body_preserved() {
         let sql = "CREATE FUNCTION f() RETURNS void AS $$\nGRANT SELECT ON t TO r;\n$$;";
+        let result = preprocess_sql(sql);
+        assert_eq!(result, sql);
+    }
+
+    #[test]
+    fn preprocess_strips_alter_type_rename_attribute() {
+        let sql = "ALTER TYPE composite_t RENAME ATTRIBUTE a TO aa;\nSELECT 1;";
+        let result = preprocess_sql(sql);
+        assert_eq!(result, "\nSELECT 1;");
+    }
+
+    #[test]
+    fn preprocess_preserves_alter_type_rename_to() {
+        let sql = "ALTER TYPE old_name RENAME TO new_name;";
         let result = preprocess_sql(sql);
         assert_eq!(result, sql);
     }


### PR DESCRIPTION
## Summary

`ALTER TYPE ... RENAME ATTRIBUTE a TO aa;` was slipping past the preprocess strip in `src/parser/preprocess.rs` and reaching sqlparser, which errored with `expected keyword, found ATTRIBUTE` and broke parsing of every subsequent statement in the file.

The fix adds `RENAME` to the verb alternation in the existing `ATTRIBUTE` strip pattern. Because the pattern still requires the `ATTRIBUTE` keyword after the verb, the whole-type rename form (`ALTER TYPE old_name RENAME TO new_name;` — supported directly by sqlparser's `AlterTypeOperation::Rename`) continues to pass through untouched.

Closes pgmold-281.

## Changes

- `src/parser/preprocess.rs:308` — extend ATTRIBUTE strip alternation from `(?:ADD|DROP|ALTER)` to `(?:ADD|DROP|ALTER|RENAME)`.
- Unit tests: positive strip case for `RENAME ATTRIBUTE`, negative preservation case for `RENAME TO`.

## Test plan

- [x] `preprocess_strips_alter_type_rename_attribute` — asserts `ALTER TYPE composite_t RENAME ATTRIBUTE a TO aa;\nSELECT 1;` reduces to `\nSELECT 1;`.
- [x] `preprocess_preserves_alter_type_rename_to` — asserts `ALTER TYPE old_name RENAME TO new_name;` is unchanged (sqlparser handles it).
- [x] `cargo fmt --all` clean.
- [ ] CI green.