### PR TITLE
chore: bump version to 0.34.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1587,7 +1587,7 @@ dependencies = [
 
 [[package]]
 name = "pgmold"
-version = "0.34.5"
+version = "0.34.6"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "pgmold"
-version = "0.34.5"
+version = "0.34.6"
 edition = "2021"
 exclude = [".auto-claude/", ".auto-claude-security.json", ".claude_settings.json"]
 description = "PostgreSQL schema-as-code management tool"


### PR DESCRIPTION
Release 0.34.6.

## Fixes

- fix(parser): skip plpgsql bodies in extract_*_references (gh#259, #260)
- fix(parser): strip ALTER TYPE RENAME ATTRIBUTE in preprocess (pgmold-281, #258)
- fix(parser): strip argmodes and argnames in COMMENT ON FUNCTION/AGGREGATE args (pgmold-285, #257)
- fix(parser): normalize COMMENT ON FUNCTION/AGGREGATE arg types (pgmold-284, #256)

## Non-user-facing

- test(corpus): vendor PG regression fixtures, ratchet silent drops (pgmold-272, #255)
- feat(parser): warn on unrecognized top-level statements (pgmold-271, #254)