### PR TITLE
fix(planner): order SetComment after its target; args in Grant OpKey

### DIFF
--- a/src/diff/op_key.rs
+++ b/src/diff/op_key.rs
@@ -180,12 +180,17 @@ pub(crate) enum OpKey {
         object_kind: GrantObjectKind,
         schema: String,
         name: String,
+        // For Function and Aggregate, `args` carries the normalized signature so
+        // overloads do not collide on (kind, schema, name, grantee). None for
+        // non-overloadable kinds (Table, View, Sequence, Schema, Type, Domain).
+        args: Option<String>,
         grantee: String,
     },
     RevokePrivileges {
         object_kind: GrantObjectKind,
         schema: String,
         name: String,
+        args: Option<String>,
         grantee: String,
     },
     AlterDefaultPrivileges {
@@ -417,24 +422,28 @@ impl OpKey {
                 object_kind,
                 schema,
                 name,
+                args,
                 grantee,
                 ..
             } => OpKey::GrantPrivileges {
                 object_kind: *object_kind,
                 schema: schema.clone(),
                 name: name.clone(),
+                args: args.clone(),
                 grantee: grantee.clone(),
             },
             MigrationOp::RevokePrivileges {
                 object_kind,
                 schema,
                 name,
+                args,
                 grantee,
                 ..
             } => OpKey::RevokePrivileges {
                 object_kind: *object_kind,
                 schema: schema.clone(),
                 name: name.clone(),
+                args: args.clone(),
                 grantee: grantee.clone(),
             },
             MigrationOp::AlterDefaultPrivileges {

--- a/src/diff/planner.rs
+++ b/src/diff/planner.rs
@@ -6522,7 +6522,7 @@ mod tests {
                 target: Some("users".to_string()),
                 comment: Some("audit trigger".to_string()),
             },
-            MigrationOp::CreateTable(simple_table_with_fks("users", &[])),
+            MigrationOp::CreateTable(simple_table_with_fks("users", vec![])),
             MigrationOp::CreateFunction(make_simple_function("audit_fn", "public")),
             MigrationOp::CreateTrigger(make_trigger("audit_trg", "public", "users", "audit_fn")),
         ];
@@ -6562,6 +6562,7 @@ mod tests {
 
     #[test]
     fn overloaded_function_grants_do_not_collide_on_opkey() {
+        use crate::diff::GrantObjectKind;
         use crate::model::Privilege;
         // Latent companion of gh#249/#250: OpKey::GrantPrivileges was keyed by
         // (kind, schema, name, grantee) without args, so a grant on two overloads

--- a/src/diff/planner.rs
+++ b/src/diff/planner.rs
@@ -1070,28 +1070,42 @@ impl MigrationGraph {
                         CommentObjectType::Function => {
                             // Overload-sensitive: must match the concrete signature.
                             // SetComment's OpKey carries `arguments` for this reason
-                            // (gh#249/#250).
-                            if let Some(args) = arguments {
-                                edges_to_add.push((
-                                    OpKey::CreateFunction {
-                                        name: qualified,
-                                        args: args.clone(),
-                                    },
-                                    key.clone(),
-                                ));
-                            }
+                            // (gh#249/#250). Fail loud if the invariant breaks —
+                            // every producer in diff/mod.rs and dump.rs emits
+                            // `arguments: Some(args_string)` for Function comments;
+                            // silently dropping the edge would reintroduce the
+                            // COMMENT-before-CREATE bug this fix exists to close.
+                            let args = arguments.clone().unwrap_or_else(|| {
+                                panic!(
+                                    "invariant violated: SetComment for Function {schema}.{name} has arguments=None; producer must set args_string()"
+                                )
+                            });
+                            edges_to_add.push((
+                                OpKey::CreateFunction {
+                                    name: qualified,
+                                    args,
+                                },
+                                key.clone(),
+                            ));
                         }
                         CommentObjectType::Aggregate => {
-                            if let Some(args) = arguments {
-                                edges_to_add.push((
-                                    OpKey::CreateAggregate {
-                                        name: qualified,
-                                        args: args.clone(),
-                                    },
-                                    key.clone(),
-                                ));
-                            }
+                            let args = arguments.clone().unwrap_or_else(|| {
+                                panic!(
+                                    "invariant violated: SetComment for Aggregate {schema}.{name} has arguments=None; producer must set args_string()"
+                                )
+                            });
+                            edges_to_add.push((
+                                OpKey::CreateAggregate {
+                                    name: qualified,
+                                    args,
+                                },
+                                key.clone(),
+                            ));
                         }
+                        // pgmold currently models every user-defined type under
+                        // `OpKey::CreateEnum` (see diff/op_key.rs). Range/composite/
+                        // base types are not in the model yet; if they arrive, add
+                        // a matching op-kind here.
                         CommentObjectType::Type => {
                             edges_to_add.push((OpKey::CreateEnum(qualified), key.clone()));
                         }
@@ -1103,16 +1117,20 @@ impl MigrationGraph {
                         }
                         CommentObjectType::Trigger => {
                             // Triggers are uniquely identified by (schema, target, name).
-                            // SetComment's `target` field carries the trigger's target table.
-                            if let Some(target_name) = target {
-                                edges_to_add.push((
-                                    OpKey::CreateTrigger {
-                                        target: QualifiedName::new(schema, target_name),
-                                        name: name.clone(),
-                                    },
-                                    key.clone(),
-                                ));
-                            }
+                            // Same invariant as Function/Aggregate: producers always
+                            // set `target` for trigger comments (see diff/mod.rs:312).
+                            let target_name = target.clone().unwrap_or_else(|| {
+                                panic!(
+                                    "invariant violated: SetComment for Trigger {schema}.{name} has target=None; producer must set trigger's target table"
+                                )
+                            });
+                            edges_to_add.push((
+                                OpKey::CreateTrigger {
+                                    target: QualifiedName::new(schema, &target_name),
+                                    name: name.clone(),
+                                },
+                                key.clone(),
+                            ));
                         }
                     }
                 }
@@ -6378,8 +6396,12 @@ mod tests {
         assert_comments_all_distinct(vec![trigger_comment("users"), trigger_comment("orders")]);
     }
 
-    /// Finds positions of the CreateXxx and SetComment ops in a planned migration
-    /// and asserts the Create comes strictly before the SetComment.
+    /// Asserts the CreateXxx op precedes every SetComment op in `planned`.
+    ///
+    /// `position` returns the first match — which is the minimum SetComment index —
+    /// so `creator_pos < first_setcomment_pos` is equivalent to "every SetComment
+    /// comes after the creator". Any SetComment placed before the creator pulls the
+    /// minimum below `creator_pos` and the assertion fails.
     fn assert_creator_precedes_comment(
         planned: &[MigrationOp],
         creator: impl Fn(&MigrationOp) -> bool,
@@ -6389,13 +6411,13 @@ mod tests {
             .iter()
             .position(&creator)
             .unwrap_or_else(|| panic!("{creator_label} not found in plan"));
-        let comment_pos = planned
+        let first_comment_pos = planned
             .iter()
             .position(|op| matches!(op, MigrationOp::SetComment { .. }))
             .expect("SetComment not found in plan");
         assert!(
-            creator_pos < comment_pos,
-            "{creator_label} must come before SetComment. {creator_label} at {creator_pos}, SetComment at {comment_pos}"
+            creator_pos < first_comment_pos,
+            "{creator_label} must come before every SetComment. {creator_label} at {creator_pos}, earliest SetComment at {first_comment_pos}"
         );
     }
 

--- a/src/diff/planner.rs
+++ b/src/diff/planner.rs
@@ -1034,8 +1034,8 @@ impl MigrationGraph {
                     schema,
                     name,
                     arguments,
+                    column,
                     target,
-                    ..
                 } => {
                     use crate::diff::CommentObjectType;
                     let qualified = qualified_name(schema, name);

--- a/src/diff/planner.rs
+++ b/src/diff/planner.rs
@@ -994,26 +994,20 @@ impl MigrationGraph {
                     }
                 }
 
-                // Grant/RevokePrivileges depend on the object existing
                 OpKey::GrantPrivileges {
                     object_kind,
                     schema,
                     name,
+                    args,
                     ..
                 }
                 | OpKey::RevokePrivileges {
                     object_kind,
                     schema,
                     name,
+                    args,
                     ..
                 } => {
-                    let args = match self.get_op(key) {
-                        Some(MigrationOp::GrantPrivileges { args: Some(a), .. })
-                        | Some(MigrationOp::RevokePrivileges { args: Some(a), .. }) => {
-                            Some(a.clone())
-                        }
-                        _ => None,
-                    };
                     add_privilege_dependency_edge(
                         &mut edges_to_add,
                         object_kind,
@@ -1024,11 +1018,9 @@ impl MigrationGraph {
                     );
                 }
 
-                // SetComment must follow the Create op for its target. Without this
-                // edge the topological sort is free to place COMMENT ON before the
-                // CREATE it targets (sagri-tokyo/mrv#3947: `COMMENT ON FUNCTION
-                // "mrv"."vcs_project_create"(...)` ran before `CREATE SCHEMA "mrv"`
-                // and aborted apply with `schema "mrv" does not exist`).
+                // SetComment has no tier edges; without content-aware edges
+                // topological sort may place COMMENT ON before the CREATE it
+                // targets. Each variant maps to the producer op for its target.
                 OpKey::SetComment {
                     object_type,
                     schema,
@@ -1038,6 +1030,13 @@ impl MigrationGraph {
                     target,
                 } => {
                     use crate::diff::CommentObjectType;
+                    let require = |opt: &Option<String>, kind: &str, field: &str| -> String {
+                        opt.clone().unwrap_or_else(|| {
+                            panic!(
+                                "invariant violated: SetComment for {kind} {schema}.{name} has {field}=None"
+                            )
+                        })
+                    };
                     let qualified = qualified_name(schema, name);
                     match object_type {
                         CommentObjectType::Schema => {
@@ -1068,18 +1067,7 @@ impl MigrationGraph {
                             edges_to_add.push((OpKey::CreateView(qualified), key.clone()));
                         }
                         CommentObjectType::Function => {
-                            // Overload-sensitive: must match the concrete signature.
-                            // SetComment's OpKey carries `arguments` for this reason
-                            // (gh#249/#250). Fail loud if the invariant breaks —
-                            // every producer in diff/mod.rs and dump.rs emits
-                            // `arguments: Some(args_string)` for Function comments;
-                            // silently dropping the edge would reintroduce the
-                            // COMMENT-before-CREATE bug this fix exists to close.
-                            let args = arguments.clone().unwrap_or_else(|| {
-                                panic!(
-                                    "invariant violated: SetComment for Function {schema}.{name} has arguments=None; producer must set args_string()"
-                                )
-                            });
+                            let args = require(arguments, "Function", "arguments");
                             edges_to_add.push((
                                 OpKey::CreateFunction {
                                     name: qualified,
@@ -1089,11 +1077,7 @@ impl MigrationGraph {
                             ));
                         }
                         CommentObjectType::Aggregate => {
-                            let args = arguments.clone().unwrap_or_else(|| {
-                                panic!(
-                                    "invariant violated: SetComment for Aggregate {schema}.{name} has arguments=None; producer must set args_string()"
-                                )
-                            });
+                            let args = require(arguments, "Aggregate", "arguments");
                             edges_to_add.push((
                                 OpKey::CreateAggregate {
                                     name: qualified,
@@ -1103,9 +1087,8 @@ impl MigrationGraph {
                             ));
                         }
                         // pgmold currently models every user-defined type under
-                        // `OpKey::CreateEnum` (see diff/op_key.rs). Range/composite/
-                        // base types are not in the model yet; if they arrive, add
-                        // a matching op-kind here.
+                        // `OpKey::CreateEnum`. Range/composite/base types are not
+                        // in the model yet; if they arrive, add a matching op kind.
                         CommentObjectType::Type => {
                             edges_to_add.push((OpKey::CreateEnum(qualified), key.clone()));
                         }
@@ -1116,14 +1099,7 @@ impl MigrationGraph {
                             edges_to_add.push((OpKey::CreateSequence(qualified), key.clone()));
                         }
                         CommentObjectType::Trigger => {
-                            // Triggers are uniquely identified by (schema, target, name).
-                            // Same invariant as Function/Aggregate: producers always
-                            // set `target` for trigger comments (see diff/mod.rs:312).
-                            let target_name = target.clone().unwrap_or_else(|| {
-                                panic!(
-                                    "invariant violated: SetComment for Trigger {schema}.{name} has target=None; producer must set trigger's target table"
-                                )
-                            });
+                            let target_name = require(target, "Trigger", "target");
                             edges_to_add.push((
                                 OpKey::CreateTrigger {
                                     target: QualifiedName::new(schema, &target_name),
@@ -6396,12 +6372,13 @@ mod tests {
         assert_comments_all_distinct(vec![trigger_comment("users"), trigger_comment("orders")]);
     }
 
-    /// Asserts the CreateXxx op precedes every SetComment op in `planned`.
+    /// Asserts the creator op precedes the SetComment op in `planned`.
     ///
-    /// `position` returns the first match — which is the minimum SetComment index —
-    /// so `creator_pos < first_setcomment_pos` is equivalent to "every SetComment
-    /// comes after the creator". Any SetComment placed before the creator pulls the
-    /// minimum below `creator_pos` and the assertion fails.
+    /// Precondition: `planned` contains exactly one SetComment. The helper
+    /// reads the first SetComment's index; if callers pass a plan with more
+    /// than one SetComment (e.g. comments for unrelated objects), the helper
+    /// does not disambiguate and the assertion may pass spuriously — add a
+    /// predicate-matching variant if that case arises.
     fn assert_creator_precedes_comment(
         planned: &[MigrationOp],
         creator: impl Fn(&MigrationOp) -> bool,
@@ -6411,13 +6388,21 @@ mod tests {
             .iter()
             .position(&creator)
             .unwrap_or_else(|| panic!("{creator_label} not found in plan"));
-        let first_comment_pos = planned
+        let comment_count = planned
+            .iter()
+            .filter(|op| matches!(op, MigrationOp::SetComment { .. }))
+            .count();
+        assert_eq!(
+            comment_count, 1,
+            "precondition: exactly one SetComment per call, got {comment_count}"
+        );
+        let comment_pos = planned
             .iter()
             .position(|op| matches!(op, MigrationOp::SetComment { .. }))
             .expect("SetComment not found in plan");
         assert!(
-            creator_pos < first_comment_pos,
-            "{creator_label} must come before every SetComment. {creator_label} at {creator_pos}, earliest SetComment at {first_comment_pos}"
+            creator_pos < comment_pos,
+            "{creator_label} must come before SetComment. {creator_label} at {creator_pos}, SetComment at {comment_pos}"
         );
     }
 
@@ -6447,9 +6432,8 @@ mod tests {
 
     #[test]
     fn function_comment_ordered_after_create_function_overload_aware() {
-        // gh#3947 repro: COMMENT ON FUNCTION "mrv"."vcs_project_create"(uuid, text, ...)
-        // IS '@deprecated …'; was planned before CREATE FUNCTION.
-        // Must hold per-signature: the COMMENT is keyed to the concrete overload.
+        // The SetComment edge must match the concrete signature, not just the
+        // qualified function name — otherwise two overloads collide on OpKey.
         let function = make_function_with_body(
             "vcs_project_create",
             "mrv",
@@ -6484,13 +6468,6 @@ mod tests {
                 )
             },
             "CreateFunction(mrv.vcs_project_create)",
-        );
-        // And CreateSchema before CreateFunction is already tier-enforced; re-assert
-        // the end-to-end CreateSchema → SetComment invariant holds transitively.
-        assert_creator_precedes_comment(
-            &planned,
-            |op| matches!(op, MigrationOp::CreateSchema(s) if s.name == "mrv"),
-            "CreateSchema(mrv)",
         );
     }
 

--- a/src/diff/planner.rs
+++ b/src/diff/planner.rs
@@ -1024,6 +1024,99 @@ impl MigrationGraph {
                     );
                 }
 
+                // SetComment must follow the Create op for its target. Without this
+                // edge the topological sort is free to place COMMENT ON before the
+                // CREATE it targets (sagri-tokyo/mrv#3947: `COMMENT ON FUNCTION
+                // "mrv"."vcs_project_create"(...)` ran before `CREATE SCHEMA "mrv"`
+                // and aborted apply with `schema "mrv" does not exist`).
+                OpKey::SetComment {
+                    object_type,
+                    schema,
+                    name,
+                    arguments,
+                    target,
+                    ..
+                } => {
+                    use crate::diff::CommentObjectType;
+                    let qualified = qualified_name(schema, name);
+                    match object_type {
+                        CommentObjectType::Schema => {
+                            // Schema comments carry `schema: ""` and `name: <schema>`.
+                            edges_to_add.push((OpKey::CreateSchema(name.clone()), key.clone()));
+                        }
+                        CommentObjectType::Table => {
+                            edges_to_add.push((OpKey::CreateTable(qualified), key.clone()));
+                        }
+                        CommentObjectType::Column => {
+                            // Column comments target a column on a table. The
+                            // parent table may be freshly created (columns inline)
+                            // or already exist (column added via AddColumn). Emit
+                            // both edges; only the one matching an op actually in
+                            // the graph takes effect (`add_edge` skips unknown keys).
+                            edges_to_add.push((OpKey::CreateTable(qualified.clone()), key.clone()));
+                            if let Some(column_name) = column {
+                                edges_to_add.push((
+                                    OpKey::AddColumn {
+                                        table: QualifiedName::new(schema, name),
+                                        column: column_name.clone(),
+                                    },
+                                    key.clone(),
+                                ));
+                            }
+                        }
+                        CommentObjectType::View | CommentObjectType::MaterializedView => {
+                            edges_to_add.push((OpKey::CreateView(qualified), key.clone()));
+                        }
+                        CommentObjectType::Function => {
+                            // Overload-sensitive: must match the concrete signature.
+                            // SetComment's OpKey carries `arguments` for this reason
+                            // (gh#249/#250).
+                            if let Some(args) = arguments {
+                                edges_to_add.push((
+                                    OpKey::CreateFunction {
+                                        name: qualified,
+                                        args: args.clone(),
+                                    },
+                                    key.clone(),
+                                ));
+                            }
+                        }
+                        CommentObjectType::Aggregate => {
+                            if let Some(args) = arguments {
+                                edges_to_add.push((
+                                    OpKey::CreateAggregate {
+                                        name: qualified,
+                                        args: args.clone(),
+                                    },
+                                    key.clone(),
+                                ));
+                            }
+                        }
+                        CommentObjectType::Type => {
+                            edges_to_add.push((OpKey::CreateEnum(qualified), key.clone()));
+                        }
+                        CommentObjectType::Domain => {
+                            edges_to_add.push((OpKey::CreateDomain(qualified), key.clone()));
+                        }
+                        CommentObjectType::Sequence => {
+                            edges_to_add.push((OpKey::CreateSequence(qualified), key.clone()));
+                        }
+                        CommentObjectType::Trigger => {
+                            // Triggers are uniquely identified by (schema, target, name).
+                            // SetComment's `target` field carries the trigger's target table.
+                            if let Some(target_name) = target {
+                                edges_to_add.push((
+                                    OpKey::CreateTrigger {
+                                        target: QualifiedName::new(schema, target_name),
+                                        name: name.clone(),
+                                    },
+                                    key.clone(),
+                                ));
+                            }
+                        }
+                    }
+                }
+
                 _ => {}
             }
         }
@@ -6283,5 +6376,220 @@ mod tests {
             comment: Some(format!("audit trigger on {target}")),
         };
         assert_comments_all_distinct(vec![trigger_comment("users"), trigger_comment("orders")]);
+    }
+
+    /// Finds positions of the CreateXxx and SetComment ops in a planned migration
+    /// and asserts the Create comes strictly before the SetComment.
+    fn assert_creator_precedes_comment(
+        planned: &[MigrationOp],
+        creator: impl Fn(&MigrationOp) -> bool,
+        creator_label: &str,
+    ) {
+        let creator_pos = planned
+            .iter()
+            .position(&creator)
+            .unwrap_or_else(|| panic!("{creator_label} not found in plan"));
+        let comment_pos = planned
+            .iter()
+            .position(|op| matches!(op, MigrationOp::SetComment { .. }))
+            .expect("SetComment not found in plan");
+        assert!(
+            creator_pos < comment_pos,
+            "{creator_label} must come before SetComment. {creator_label} at {creator_pos}, SetComment at {comment_pos}"
+        );
+    }
+
+    #[test]
+    fn schema_comment_ordered_after_create_schema() {
+        // Root cause of sagri-tokyo/mrv#3947: COMMENT ON SCHEMA "mrv" IS '…';
+        // planned before CREATE SCHEMA "mrv", so apply hit `schema "mrv" does not exist`.
+        let ops = vec![
+            MigrationOp::SetComment {
+                object_type: crate::diff::CommentObjectType::Schema,
+                schema: String::new(),
+                name: "mrv".to_string(),
+                arguments: None,
+                column: None,
+                target: None,
+                comment: Some("managed reporting & verification".to_string()),
+            },
+            MigrationOp::CreateSchema(make_schema("mrv")),
+        ];
+        let planned = plan_migration(ops);
+        assert_creator_precedes_comment(
+            &planned,
+            |op| matches!(op, MigrationOp::CreateSchema(s) if s.name == "mrv"),
+            "CreateSchema(mrv)",
+        );
+    }
+
+    #[test]
+    fn function_comment_ordered_after_create_function_overload_aware() {
+        // gh#3947 repro: COMMENT ON FUNCTION "mrv"."vcs_project_create"(uuid, text, ...)
+        // IS '@deprecated …'; was planned before CREATE FUNCTION.
+        // Must hold per-signature: the COMMENT is keyed to the concrete overload.
+        let function = make_function_with_body(
+            "vcs_project_create",
+            "mrv",
+            "BEGIN RETURN gen_random_uuid(); END;",
+            "uuid",
+        );
+        let args_string = function.args_string();
+        let ops = vec![
+            MigrationOp::SetComment {
+                object_type: crate::diff::CommentObjectType::Function,
+                schema: "mrv".to_string(),
+                name: "vcs_project_create".to_string(),
+                arguments: Some(args_string.clone()),
+                column: None,
+                target: None,
+                comment: Some("@deprecated".to_string()),
+            },
+            MigrationOp::CreateSchema(make_schema("mrv")),
+            MigrationOp::CreateFunction(function),
+        ];
+        let planned = plan_migration(ops);
+        let expected_args = args_string;
+        assert_creator_precedes_comment(
+            &planned,
+            move |op| {
+                matches!(
+                    op,
+                    MigrationOp::CreateFunction(f)
+                        if f.schema == "mrv"
+                            && f.name == "vcs_project_create"
+                            && f.args_string() == expected_args
+                )
+            },
+            "CreateFunction(mrv.vcs_project_create)",
+        );
+        // And CreateSchema before CreateFunction is already tier-enforced; re-assert
+        // the end-to-end CreateSchema → SetComment invariant holds transitively.
+        assert_creator_precedes_comment(
+            &planned,
+            |op| matches!(op, MigrationOp::CreateSchema(s) if s.name == "mrv"),
+            "CreateSchema(mrv)",
+        );
+    }
+
+    #[test]
+    fn table_comment_ordered_after_create_table() {
+        let ops = vec![
+            MigrationOp::SetComment {
+                object_type: crate::diff::CommentObjectType::Table,
+                schema: "public".to_string(),
+                name: "widgets".to_string(),
+                arguments: None,
+                column: None,
+                target: None,
+                comment: Some("widget table".to_string()),
+            },
+            MigrationOp::CreateTable(simple_table_with_fks("widgets", vec![])),
+        ];
+        let planned = plan_migration(ops);
+        assert_creator_precedes_comment(
+            &planned,
+            |op| matches!(op, MigrationOp::CreateTable(t) if t.schema == "public" && t.name == "widgets"),
+            "CreateTable(public.widgets)",
+        );
+    }
+
+    #[test]
+    fn column_comment_ordered_after_create_table() {
+        // Column-level COMMENT ON COLUMN "public"."widgets"."status" must wait for
+        // CREATE TABLE "public"."widgets" (which includes the column inline).
+        let ops = vec![
+            column_comment("public", "widgets", "status"),
+            MigrationOp::CreateTable(simple_table_with_fks("widgets", vec![])),
+        ];
+        let planned = plan_migration(ops);
+        assert_creator_precedes_comment(
+            &planned,
+            |op| matches!(op, MigrationOp::CreateTable(t) if t.schema == "public" && t.name == "widgets"),
+            "CreateTable(public.widgets)",
+        );
+    }
+
+    #[test]
+    fn trigger_comment_ordered_after_create_trigger() {
+        let ops = vec![
+            MigrationOp::SetComment {
+                object_type: crate::diff::CommentObjectType::Trigger,
+                schema: "public".to_string(),
+                name: "audit_trg".to_string(),
+                arguments: None,
+                column: None,
+                target: Some("users".to_string()),
+                comment: Some("audit trigger".to_string()),
+            },
+            MigrationOp::CreateTable(simple_table_with_fks("users", &[])),
+            MigrationOp::CreateFunction(make_simple_function("audit_fn", "public")),
+            MigrationOp::CreateTrigger(make_trigger("audit_trg", "public", "users", "audit_fn")),
+        ];
+        let planned = plan_migration(ops);
+        assert_creator_precedes_comment(
+            &planned,
+            |op| matches!(op, MigrationOp::CreateTrigger(t) if t.name == "audit_trg" && t.target_name == "users"),
+            "CreateTrigger(public.users.audit_trg)",
+        );
+    }
+
+    #[test]
+    fn view_comment_ordered_after_create_view() {
+        let ops = vec![
+            MigrationOp::SetComment {
+                object_type: crate::diff::CommentObjectType::View,
+                schema: "public".to_string(),
+                name: "active_users".to_string(),
+                arguments: None,
+                column: None,
+                target: None,
+                comment: Some("active users view".to_string()),
+            },
+            MigrationOp::CreateView(make_view(
+                "active_users",
+                "public",
+                "SELECT * FROM users WHERE active",
+            )),
+        ];
+        let planned = plan_migration(ops);
+        assert_creator_precedes_comment(
+            &planned,
+            |op| matches!(op, MigrationOp::CreateView(v) if v.schema == "public" && v.name == "active_users"),
+            "CreateView(public.active_users)",
+        );
+    }
+
+    #[test]
+    fn overloaded_function_grants_do_not_collide_on_opkey() {
+        use crate::model::Privilege;
+        // Latent companion of gh#249/#250: OpKey::GrantPrivileges was keyed by
+        // (kind, schema, name, grantee) without args, so a grant on two overloads
+        // of the same qualified function name panicked with `duplicate OpKey` in
+        // `MigrationGraph::add_vertex`. Surfaced while reproducing mrv#3947:
+        // `pgmold plan` against sagri's schema panicked on
+        // `mrv.vcs_project_create(authenticated)` being declared for two overloads.
+        let grant = |args: &str| MigrationOp::GrantPrivileges {
+            object_kind: GrantObjectKind::Function,
+            schema: "mrv".to_string(),
+            name: "vcs_project_create".to_string(),
+            args: Some(args.to_string()),
+            grantee: "authenticated".to_string(),
+            privileges: vec![Privilege::Execute],
+            with_grant_option: false,
+        };
+        let ops = vec![
+            grant("uuid, text"),
+            grant("uuid, text, text, date, date, uuid[]"),
+        ];
+        let planned = plan_migration(ops);
+        assert_eq!(
+            planned
+                .iter()
+                .filter(|op| matches!(op, MigrationOp::GrantPrivileges { .. }))
+                .count(),
+            2,
+            "both function-overload grants must survive the planner with distinct OpKeys"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Two planner bugs surfaced by reproducing sagri-tokyo/mrv#3947 locally on v0.34.6:

1. **`SetComment` had no ordering edges.** `NodeSets` at `src/diff/planner.rs:26-76` never collected it and `add_content_aware_edges` had no arm for it, so topological sort was free to place `COMMENT ON` ahead of the `CREATE` it targets. Reproduced with the sagri schema against a fresh postgres: apply ran `COMMENT ON FUNCTION "mrv"."vcs_project_create"(…) IS '@deprecated …';` before `CREATE SCHEMA "mrv"` and aborted with `schema "mrv" does not exist` — exactly the failure mode in sagri-tokyo/mrv#3947 and the `database-tests` job of sagri-tokyo/mrv#3934.

2. **`OpKey::GrantPrivileges` / `RevokePrivileges` collided on overloaded functions.** `pgmold plan` against the sagri schema panicked with `duplicate OpKey: GrantPrivileges { … "mrv" "vcs_project_create" … "authenticated" }` because two function overloads have the same `(kind, schema, name, grantee)`. Same class as gh#249/#250 for `SetComment`. Latent under mrv's CI (which passes `--no-manage-grants`) but a hard panic anywhere grants on overloaded functions are tracked.

## Fixes

- Content-aware edges for `OpKey::SetComment`, per `CommentObjectType`:
  - `Schema` → `CreateSchema`
  - `Table` → `CreateTable`
  - `Column` → `CreateTable` (+ `AddColumn` for existing tables)
  - `View` / `MaterializedView` → `CreateView`
  - `Function` → `CreateFunction { name, args }` — overload-aware, matching the SetComment OpKey from gh#249/#250
  - `Aggregate` → `CreateAggregate { name, args }`
  - `Type` → `CreateEnum`
  - `Domain` → `CreateDomain`
  - `Sequence` → `CreateSequence`
  - `Trigger` → `CreateTrigger { target, name }` — target-aware
- `OpKey::GrantPrivileges` and `RevokePrivileges` grow `args: Option<String>`. Existing match arms use `..` so no behavior change where args isn't consumed.

## Test plan

- [x] `cargo fmt --all --check` clean
- [x] 7 new planner unit tests covering each `CommentObjectType` the sagri schema exercises plus an overload-grant regression guard
- [ ] CI green on the full suite
- [ ] Verified externally: after release, sagri-tokyo/mrv#3934's `test / database-tests` job advances past `COMMENT ON FUNCTION mrv.vcs_project_create(...)`