### PR TITLE
chore: bump version to 0.34.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1587,7 +1587,7 @@ dependencies = [
 
 [[package]]
 name = "pgmold"
-version = "0.34.6"
+version = "0.34.7"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "pgmold"
-version = "0.34.6"
+version = "0.34.7"
 edition = "2021"
 exclude = [".auto-claude/", ".auto-claude-security.json", ".claude_settings.json"]
 description = "PostgreSQL schema-as-code management tool"


### PR DESCRIPTION
Release 0.34.7.

## Fixes

- fix(planner): order SetComment after its target; include args in Grant OpKey (#262) — sagri-tokyo/mrv#3947. Closes the `COMMENT ON FUNCTION mrv.vcs_project_create(…)` ran-before-`CREATE SCHEMA mrv` ordering bug that aborted apply with `schema "mrv" does not exist`, and the companion `duplicate OpKey: GrantPrivileges` panic on overloaded functions.