### PR TITLE
fix(diff): treat source-silent GENERATED as unmanaged (gh#265)

### DIFF
--- a/src/diff/table_elements.rs
+++ b/src/diff/table_elements.rs
@@ -57,6 +57,9 @@ pub(super) fn diff_columns(from_table: &Table, to_table: &Table) -> Vec<Migratio
 
     for (name, column) in &to_table.columns {
         if let Some(from_column) = from_table.columns.get(name) {
+            if is_unmanaged_generated_column(from_column, column) {
+                continue;
+            }
             if generated_expression_changed(from_column, column) {
                 ops.push(MigrationOp::DropColumn {
                     table: QualifiedName::new(&from_table.schema, &from_table.name),
@@ -98,6 +101,17 @@ pub(super) fn diff_columns(from_table: &Table, to_table: &Table) -> Vec<Migratio
 
 fn generated_expression_changed(from: &Column, to: &Column) -> bool {
     !optional_expressions_equal(&from.generated, &to.generated)
+}
+
+// Source-silent means the column's generation aspect is unmanaged: never emit
+// destructive DDL (DROP+ADD) or ALTER COLUMN ops against a DB-side generated
+// column just because the source doesn't repeat the GENERATED clause.
+// PostgreSQL rejects ALTER COLUMN TYPE/SET NOT NULL/SET DEFAULT on generated
+// columns anyway, so any emission here is unsafe.
+// TODO: if a user genuinely needs to convert a generated column back to plain,
+// they have no way to express that intent through the source schema today.
+fn is_unmanaged_generated_column(from: &Column, to: &Column) -> bool {
+    from.generated.is_some() && to.generated.is_none()
 }
 
 pub(super) fn compute_column_changes(from: &Column, to: &Column) -> ColumnChanges {

--- a/tests/generated_columns.rs
+++ b/tests/generated_columns.rs
@@ -144,6 +144,47 @@ fn diff_changing_generated_expression_produces_drop_then_add() {
     );
 }
 
+#[test]
+fn diff_source_silent_on_generated_does_not_drop_add_column() {
+    // Silence in the source about a column's GENERATED clause means the
+    // generation aspect is unmanaged, not "force the column back to plain".
+    let sql_from_db = r#"
+        CREATE TABLE public.products (
+            id          BIGSERIAL      NOT NULL,
+            price_cents INTEGER        NOT NULL,
+            price_usd   NUMERIC(10, 2) GENERATED ALWAYS AS (price_cents / 100.0) STORED,
+            PRIMARY KEY (id)
+        );
+    "#;
+    let sql_from_source = r#"
+        CREATE TABLE public.products (
+            id          BIGSERIAL      NOT NULL,
+            price_cents INTEGER        NOT NULL,
+            price_usd   NUMERIC(10, 2),
+            PRIMARY KEY (id)
+        );
+    "#;
+
+    let from = parse_sql_string(sql_from_db).unwrap();
+    let to = parse_sql_string(sql_from_source).unwrap();
+    let ops = compute_diff(&from, &to);
+
+    let drop_add_ops: Vec<&MigrationOp> = ops
+        .iter()
+        .filter(|op| {
+            matches!(op, MigrationOp::DropColumn { table, column }
+                if table == "public.products" && column == "price_usd")
+                || matches!(op, MigrationOp::AddColumn { table, column }
+                if table == "public.products" && column.name == "price_usd")
+        })
+        .collect();
+
+    assert!(
+        drop_add_ops.is_empty(),
+        "should not emit DROP+ADD when source is silent about GENERATED and DB has it; got: {drop_add_ops:?}",
+    );
+}
+
 #[tokio::test]
 async fn generated_column_convergence() {
     let (_container, url) = setup_postgres().await;
@@ -193,6 +234,53 @@ async fn generated_column_convergence() {
     assert!(
         non_seq_ops.is_empty(),
         "second plan should be empty (convergence). Got: {non_seq_ops:?}"
+    );
+}
+
+#[tokio::test]
+async fn plan_does_not_emit_phantom_column_ops_against_db_with_generated_column() {
+    // Against a real DB that has a GENERATED column, a source schema declaring
+    // the same column as plain must not produce any column DDL for it.
+    let (_container, url) = setup_postgres().await;
+    let connection = PgConnection::new(&url).await.unwrap();
+
+    sqlx::query(
+        "CREATE TABLE public.products (
+            id          BIGSERIAL NOT NULL PRIMARY KEY,
+            price_cents INTEGER NOT NULL,
+            price_usd   NUMERIC(10, 2) GENERATED ALWAYS AS (price_cents / 100.0) STORED
+        );",
+    )
+    .execute(connection.pool())
+    .await
+    .unwrap();
+
+    let source_sql = r#"
+        CREATE TABLE public.products (
+            id          BIGSERIAL      NOT NULL,
+            price_cents INTEGER        NOT NULL,
+            price_usd   NUMERIC(10, 2),
+            PRIMARY KEY (id)
+        );
+    "#;
+    let parsed = parse_sql_string(source_sql).unwrap();
+    let db_schema = introspect_schema(&connection, &["public".to_string()], false)
+        .await
+        .unwrap();
+
+    let ops = compute_diff(&db_schema, &parsed);
+    let add_drop: Vec<&MigrationOp> = ops
+        .iter()
+        .filter(|op| {
+            matches!(op, MigrationOp::AddColumn { table, column }
+                if table == "public.products" && column.name == "price_usd")
+                || matches!(op, MigrationOp::DropColumn { table, column }
+                if table == "public.products" && column == "price_usd")
+        })
+        .collect();
+    assert!(
+        add_drop.is_empty(),
+        "plan must not contain ADD+DROP for a column that exists in both source and DB; got: {add_drop:?}",
     );
 }
 


### PR DESCRIPTION
Closes #265.

## Summary

Against a DB where a column is GENERATED but the source schema declares the same column as plain, `pgmold plan` emits both `ADD COLUMN` and `DROP COLUMN CASCADE` for that column in one plan. The planner cannot safely order that pair against dependent views, so `apply` fails with `column "X" of relation "users" already exists`.

The canonical repro is Supabase Auth's `auth.users.confirmed_at` (installed by Supabase as `GENERATED ALWAYS AS (LEAST(email_confirmed_at, phone_confirmed_at)) STORED`) against a source schema that vendored the older plain `TIMESTAMP WITH TIME ZONE` declaration.

Silence in the source now means "don't manage the generation aspect of this column" — consistent with the reality that `ALTER COLUMN TYPE/SET NOT NULL/SET DEFAULT` is rejected by PostgreSQL on generated columns anyway. DROP+ADD and any ALTER COLUMN are only emitted when the source explicitly declares a differing GENERATED clause.

## Test plan

- [x] `cargo test --lib` — 1221 passed
- [x] `cargo test --test generated_columns` — 9 passed, including new `diff_source_silent_on_generated_does_not_drop_add_column` (unit) and `plan_does_not_emit_phantom_column_ops_against_db_with_generated_column` (DB-backed)
- [x] `cargo test --test convergence --test tables --test views --test constraints --test apply` — all green
- [x] End-to-end verification against a Postgres 15 DB loaded with the sagri monorepo schema plus the Supabase-style generated `auth.users.confirmed_at` and `auth.identities.email`:
  - Before the fix: plan emits `ADD COLUMN` then `DROP COLUMN CASCADE` for both columns; apply fails on `column already exists`
  - After the fix: plan has no column DDL for either; `apply` succeeds; a follow-up `plan` is a no-op for those columns; introspection confirms `attgenerated = 's'` is preserved

## Known limitation

A user who genuinely wants to convert a generated column back to plain cannot express that intent through the source schema today. Documented as a TODO alongside the new `is_unmanaged_generated_column` helper.