### PR TITLE
pgmold-274: migrate ALTER TABLE OWNER TO from regex to sqlparser AST

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -511,11 +511,10 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
                         }
                         AlterTableOperation::OwnerTo { new_owner } => {
                             if let Owner::Ident(ident) = new_owner {
-                                let owner = unquote_ident(&ident.value).to_string();
                                 schema.pending_owners.push(PendingOwner {
                                     object_type: PendingOwnerObjectType::Table,
                                     object_key: tbl_key.clone(),
-                                    owner,
+                                    owner: ident.value.clone(),
                                 });
                             }
                         }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -509,6 +509,16 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
                             // table; re-insert into schema.tables to model that.
                             schema.partitions.remove(&child_key);
                         }
+                        AlterTableOperation::OwnerTo { new_owner } => {
+                            if let Owner::Ident(ident) = new_owner {
+                                let owner = unquote_ident(&ident.value).to_string();
+                                schema.pending_owners.push(PendingOwner {
+                                    object_type: PendingOwnerObjectType::Table,
+                                    object_key: tbl_key.clone(),
+                                    owner,
+                                });
+                            }
+                        }
                         // PostgreSQL `ALTER TABLE` variants pgmold does not yet
                         // consume. Tracked as future work; listed explicitly
                         // so an upstream addition to `AlterTableOperation`
@@ -518,7 +528,6 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
                         | AlterTableOperation::ValidateConstraint { .. }
                         | AlterTableOperation::DropPrimaryKey { .. }
                         | AlterTableOperation::ReplicaIdentity { .. }
-                        | AlterTableOperation::OwnerTo { .. }
                         | AlterTableOperation::SetOptionsParens { .. }
                         | AlterTableOperation::EnableRule { .. }
                         | AlterTableOperation::DisableRule { .. }

--- a/src/parser/ownership.rs
+++ b/src/parser/ownership.rs
@@ -59,24 +59,6 @@ pub(super) fn parse_owner_statements(sql: &str, schema: &mut Schema) {
         });
     }
 
-    let alter_table_owner_re = Regex::new(
-        r#"(?i)ALTER\s+TABLE\s+(?:["']?([^"'\s]+)["']?\.)?["']?([^"'\s;]+)["']?\s+OWNER\s+TO\s+["']?([^"'\s;]+)["']?"#
-    ).unwrap();
-
-    for cap in alter_table_owner_re.captures_iter(sql) {
-        let schema_part = cap.get(1).map(|m| unquote_ident(m.as_str()));
-        let table_name = unquote_ident(cap.get(2).unwrap().as_str());
-        let owner = unquote_ident(cap.get(3).unwrap().as_str());
-
-        let table_schema = schema_part.unwrap_or("public");
-        let object_key = qualified_name(table_schema, table_name);
-        schema.pending_owners.push(PendingOwner {
-            object_type: PendingOwnerObjectType::Table,
-            object_key,
-            owner: owner.to_string(),
-        });
-    }
-
     let alter_materialized_view_owner_re = Regex::new(
         r#"(?i)ALTER\s+MATERIALIZED\s+VIEW\s+(?:["']?([^"'\s]+)["']?\.)?["']?([^"'\s;]+)["']?\s+OWNER\s+TO\s+["']?([^"'\s;]+)["']?"#
     ).unwrap();

--- a/src/parser/preprocess.rs
+++ b/src/parser/preprocess.rs
@@ -298,7 +298,6 @@ pub(super) fn preprocess_sql(sql: &str) -> String {
 
     let strip_patterns = [
         r"(?i)\bSET\s+search_path\s+TO\s+'[^']*'(?:\s*,\s*'[^']*')*",
-        r"(?i)ALTER\s+TABLE\s+[^;]+\s+OWNER\s+TO\s+[^;]+;",
         r"(?i)ALTER\s+FUNCTION\s+[^;]+;",
         r"(?i)ALTER\s+MATERIALIZED\s+VIEW\s+[^;]+;",
         r"(?i)ALTER\s+VIEW\s+[^;]+;",


### PR DESCRIPTION
## Summary

Pilot migration for pgmold-273: lift `ALTER TABLE ... OWNER TO` parsing from
the hand-rolled regex pass onto sqlparser's `AlterTableOperation::OwnerTo`
AST variant. This is the one regex-strip pattern that can migrate cleanly
without fork work - the pgmold-sqlparser fork already models it faithfully.

## What was wrong

`ALTER TABLE ... OWNER TO` was triple-handled:

- `src/parser/preprocess.rs` stripped the statement before sqlparser saw it.
- `src/parser/ownership.rs` re-parsed it via a regex against the raw SQL.
- `src/parser/mod.rs` explicitly listed `AlterTableOperation::OwnerTo` in
  the ignored-operations catch-all arm.

Three sources of truth, one of which (the regex) silently diverges on edge
cases like quoted identifiers and schema-qualified names that the hand-rolled
regex cannot fully model.

## What changed

- `src/parser/mod.rs`: added a dedicated `AlterTableOperation::OwnerTo` arm
  that pushes a `PendingOwner` for the current table. Only `Owner::Ident` is
  recorded; `CurrentRole` / `CurrentUser` / `SessionUser` are dynamic and
  cannot be statically resolved, so they fall through silently (matches the
  existing `parse_alter_aggregate_owner` template).
- `src/parser/preprocess.rs`: dropped the `ALTER TABLE ... OWNER TO` strip
  pattern so sqlparser sees the statement.
- `src/parser/ownership.rs`: dropped the `alter_table_owner_re` arm. The
  DOMAIN / MATERIALIZED VIEW / VIEW / SEQUENCE arms stay - their AST
  counterparts still lack `OwnerTo` in the fork (tracked by pgmold-276).

Net diff: +10 / -20.

## Bead

pgmold-274 (pilot under pgmold-273).

## Verification

- `parses_alter_table_owner_to` and `owner_roundtrip_preserves_table_owner`
  in `src/parser/tests.rs` cover the happy path and round-trip through
  `generate_dump`; they must stay green.
- Sibling owner tests (`parses_alter_view_owner_to`,
  `parses_alter_sequence_owner_to`, etc.) must stay green since their
  regex arms are untouched.
- CI at `.github/workflows/ci.yml` runs the full suite on push.