### PR TITLE
chore: bump pgmold-sqlparser to 0.61.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["command-line-utilities", "database"]
 clap = { version = "4.5", features = ["derive", "env"] }
 tokio = { version = "1.35", features = ["full"] }
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres"] }
-sqlparser = { package = "pgmold-sqlparser", version = "0.60.14", features = ["visitor"] }
+sqlparser = { package = "pgmold-sqlparser", version = "0.61.0", features = ["visitor"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 anyhow = "1.0"
@@ -37,11 +37,11 @@ sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres"] }
 tokio = { version = "1.35", features = ["full"] }
 assert_cmd = "2"
 criterion = { version = "0.5", features = ["html_reports"] }
-sqlparser = { package = "pgmold-sqlparser", version = "0.60.14", features = ["visitor"] }
+sqlparser = { package = "pgmold-sqlparser", version = "0.61.0", features = ["visitor"] }
 
 [[bench]]
 name = "performance"
 harness = false
 
 [build-dependencies]
-sqlparser = { package = "pgmold-sqlparser", version = "0.60.14", features = ["visitor"] }
+sqlparser = { package = "pgmold-sqlparser", version = "0.61.0", features = ["visitor"] }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -626,11 +626,16 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
                         }
                     }
                     AlterTypeOperation::Rename(_)
-                    | AlterTypeOperation::RenameValue(_)
-                    // PostgreSQL ALTER TYPE shapes pgmold does not yet model. Listed
-                    // explicitly so an upstream addition forces a compile-time review
-                    // here instead of silent fallthrough.
-                    | AlterTypeOperation::OwnerTo { .. }
+                    | AlterTypeOperation::RenameValue(_) => {}
+                    // The variants below are unreachable today: `preprocess_sql`
+                    // strips `ALTER TYPE ... OWNER TO`, `... SET SCHEMA`, and
+                    // `... (ADD|DROP|ALTER|RENAME) ATTRIBUTE` before sqlparser
+                    // sees them. Listed explicitly to keep the match exhaustive
+                    // after the pgmold-sqlparser 0.61.0 bump and to surface any
+                    // future upstream additions at compile time. Tracked by
+                    // pgmold-289 (retire the preprocess strips and migrate to
+                    // AST-driven handling).
+                    AlterTypeOperation::OwnerTo { .. }
                     | AlterTypeOperation::SetSchema { .. }
                     | AlterTypeOperation::AddAttribute { .. }
                     | AlterTypeOperation::DropAttribute { .. }
@@ -1156,8 +1161,12 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
             | Statement::Grant { .. }
             | Statement::Revoke { .. }
             | Statement::Deny(_)
-            // ALTER DEFAULT PRIVILEGES — handled via `parse_alter_default_privileges`
-            // on the raw SQL pass, same as Grant/Revoke. AST-level variant ignored.
+            // ALTER DEFAULT PRIVILEGES — currently unreachable: `preprocess_sql`
+            // strips the statement before sqlparser sees it. The actual handler
+            // is `parse_alter_default_privileges` on the raw SQL. Listed here to
+            // keep the match exhaustive after the pgmold-sqlparser 0.61.0 bump.
+            // Tracked by pgmold-289 (retire the preprocess strip and migrate to
+            // AST-driven handling).
             | Statement::AlterDefaultPrivileges(_)
             // Comments are processed by `parse_comment_statements` on the
             // raw SQL below; ignore the AST-level variant here.

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -625,7 +625,17 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
                             }
                         }
                     }
-                    AlterTypeOperation::Rename(_) | AlterTypeOperation::RenameValue(_) => {}
+                    AlterTypeOperation::Rename(_)
+                    | AlterTypeOperation::RenameValue(_)
+                    // PostgreSQL ALTER TYPE shapes pgmold does not yet model. Listed
+                    // explicitly so an upstream addition forces a compile-time review
+                    // here instead of silent fallthrough.
+                    | AlterTypeOperation::OwnerTo { .. }
+                    | AlterTypeOperation::SetSchema { .. }
+                    | AlterTypeOperation::AddAttribute { .. }
+                    | AlterTypeOperation::DropAttribute { .. }
+                    | AlterTypeOperation::AlterAttribute { .. }
+                    | AlterTypeOperation::RenameAttribute { .. } => {}
                 }
             }
             Statement::CreateFunction(CreateFunction {
@@ -1146,6 +1156,9 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
             | Statement::Grant { .. }
             | Statement::Revoke { .. }
             | Statement::Deny(_)
+            // ALTER DEFAULT PRIVILEGES — handled via `parse_alter_default_privileges`
+            // on the raw SQL pass, same as Grant/Revoke. AST-level variant ignored.
+            | Statement::AlterDefaultPrivileges(_)
             // Comments are processed by `parse_comment_statements` on the
             // raw SQL below; ignore the AST-level variant here.
             | Statement::Comment { .. }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -625,16 +625,18 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
                             }
                         }
                     }
+                    // Type-level rename and the type renames-a-value form are not
+                    // modelled; the actual enum mutations land via the AddValue
+                    // arm above.
                     AlterTypeOperation::Rename(_)
                     | AlterTypeOperation::RenameValue(_) => {}
                     // The variants below are unreachable today: `preprocess_sql`
                     // strips `ALTER TYPE ... OWNER TO`, `... SET SCHEMA`, and
                     // `... (ADD|DROP|ALTER|RENAME) ATTRIBUTE` before sqlparser
                     // sees them. Listed explicitly to keep the match exhaustive
-                    // after the pgmold-sqlparser 0.61.0 bump and to surface any
-                    // future upstream additions at compile time. Tracked by
-                    // pgmold-289 (retire the preprocess strips and migrate to
-                    // AST-driven handling).
+                    // and to surface any future upstream additions at compile
+                    // time. Tracked by pgmold-289 (retire the preprocess strips
+                    // and migrate to AST-driven handling).
                     AlterTypeOperation::OwnerTo { .. }
                     | AlterTypeOperation::SetSchema { .. }
                     | AlterTypeOperation::AddAttribute { .. }
@@ -1164,9 +1166,8 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
             // ALTER DEFAULT PRIVILEGES — currently unreachable: `preprocess_sql`
             // strips the statement before sqlparser sees it. The actual handler
             // is `parse_alter_default_privileges` on the raw SQL. Listed here to
-            // keep the match exhaustive after the pgmold-sqlparser 0.61.0 bump.
-            // Tracked by pgmold-289 (retire the preprocess strip and migrate to
-            // AST-driven handling).
+            // keep the match exhaustive. Tracked by pgmold-289 (retire the
+            // preprocess strip and migrate to AST-driven handling).
             | Statement::AlterDefaultPrivileges(_)
             // Comments are processed by `parse_comment_statements` on the
             // raw SQL below; ignore the AST-level variant here.

--- a/src/parser/preprocess.rs
+++ b/src/parser/preprocess.rs
@@ -302,6 +302,10 @@ pub(super) fn preprocess_sql(sql: &str) -> String {
         r"(?i)ALTER\s+MATERIALIZED\s+VIEW\s+[^;]+;",
         r"(?i)ALTER\s+VIEW\s+[^;]+;",
         r"(?i)ALTER\s+SEQUENCE\s+[^;]+;",
+        // ALTER TYPE attribute / ownership / schema strips and the
+        // ALTER DEFAULT PRIVILEGES strip below could retire now that
+        // pgmold-sqlparser 0.61.0 exposes the corresponding AST variants.
+        // Tracked by pgmold-289.
         r"(?i)ALTER\s+TYPE\s+[^;]+\s+OWNER\s+TO\s+[^;]+;",
         r"(?i)ALTER\s+TYPE\s+[^;]+\s+SET\s+SCHEMA\s+[^;]+;",
         r"(?i)ALTER\s+TYPE\s+[^;]+\s+(?:ADD|DROP|ALTER|RENAME)\s+ATTRIBUTE\s+[^;]+;",


### PR DESCRIPTION
Consume the 0.61.0 fork release at https://github.com/fmguerreiro/datafusion-sqlparser-rs/releases/tag/v0.61.0.

## Why this version

`pgmold-sqlparser 0.61.0` adds the AST capabilities pgmold-273 needs to retire the regex passes for COMMENT ON, GRANT/REVOKE on TYPE/DOMAIN, and (eventually) ALTER TYPE attribute ops + ALTER DEFAULT PRIVILEGES.

New surface available in this version:
- `GrantObjects::{Types, Domains}` — for `GRANT ON TYPE/DOMAIN`.
- `CommentObject::{Trigger, Aggregate, Policy}` plus `Statement::Comment` carrying `arguments: Option<Vec<DataType>>` and `relation: Option<ObjectName>`; `parse_literal_string` accepts dollar-quoted bodies.
- `AlterTypeOperation::{OwnerTo, SetSchema, *Attribute}` (six new variants).
- `Statement::AlterDefaultPrivileges` with `[FOR ROLE …] [IN SCHEMA …] {GRANT|REVOKE} <body>`.
- Pre-existing `Grantee::fmt` `"PUBLIC "` trailing-space bug fixed.

## Compile fallout to expect

Three sites in pgmold pattern-match `Statement::Comment` and `AlterTableOperation` exhaustively. They already use `..` or explicit ignore arms, so the field/variant additions should not break compilation. CI will confirm.

This bump is a precondition for pgmold-273 (regex → AST migration of `src/parser/comments.rs`).