### PR TITLE
pgmold-289: migrate ALTER TYPE / ALTER DEFAULT PRIVILEGES from regex to sqlparser AST

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1612,9 +1612,9 @@ dependencies = [
 
 [[package]]
 name = "pgmold-sqlparser"
-version = "0.60.14"
+version = "0.61.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "635386e668ee7420b6c375cb81edf8c7be7616c2cffae7a32f56c109034e88a0"
+checksum = "1523e0eb981fe3b0b5eeba975c49ba3db93aa107565244feedb4eca3b9739a1c"
 dependencies = [
  "log",
  "recursive",

--- a/src/parser/grants.rs
+++ b/src/parser/grants.rs
@@ -397,174 +397,107 @@ pub(super) fn parse_revoke_statements(sql: &str, schema: &mut Schema) -> Result<
     Ok(())
 }
 
-pub(super) fn parse_alter_default_privileges(sql: &str, schema: &mut Schema) -> Result<()> {
-    let grant_re = Regex::new(
-        r"(?is)ALTER\s+DEFAULT\s+PRIVILEGES\s+(?:FOR\s+ROLE\s+(\w+)\s+)?(?:IN\s+SCHEMA\s+(\w+)\s+)?GRANT\s+(.+?)\s+ON\s+(TABLES|SEQUENCES|FUNCTIONS|ROUTINES|TYPES|SCHEMAS)\s+TO\s+(\w+|PUBLIC)\s*(WITH\s+GRANT\s+OPTION)?\s*;"
-    ).unwrap();
+/// Expands `ALTER DEFAULT PRIVILEGES ... GRANT ...` into per-(role,schema,grantee)
+/// records on `schema.default_privileges`. Called from the AST handler in
+/// `parser/mod.rs`.
+pub(super) fn apply_default_privileges_grant(
+    schema: &mut Schema,
+    target_roles: &[String],
+    schema_scopes: &[Option<String>],
+    object_type: DefaultPrivilegeObjectType,
+    grantees: &[String],
+    privileges: BTreeSet<Privilege>,
+    with_grant_option: bool,
+) {
+    if privileges.is_empty() || grantees.is_empty() {
+        return;
+    }
 
-    for cap in grant_re.captures_iter(sql) {
-        let target_role = cap
-            .get(1)
-            .map(|m| m.as_str().to_string())
-            .unwrap_or_else(|| "CURRENT_ROLE".to_string());
-        let schema_scope = cap.get(2).map(|m| m.as_str().to_string());
-        let privileges_str = cap.get(3).unwrap().as_str();
-        let object_type_str = cap.get(4).unwrap().as_str().to_uppercase();
-        let grantee = cap.get(5).unwrap().as_str().to_string();
-        let with_grant_option = cap.get(6).is_some();
-
-        let object_type = match DefaultPrivilegeObjectType::from_sql_str(&object_type_str) {
-            Some(ot) => ot,
-            None => continue,
-        };
-
-        let mut privileges = BTreeSet::new();
-        let priv_upper = privileges_str.to_uppercase();
-        if priv_upper.contains("ALL") {
-            match object_type {
-                DefaultPrivilegeObjectType::Tables => {
-                    privileges.insert(Privilege::Select);
-                    privileges.insert(Privilege::Insert);
-                    privileges.insert(Privilege::Update);
-                    privileges.insert(Privilege::Delete);
-                    privileges.insert(Privilege::Truncate);
-                    privileges.insert(Privilege::References);
-                    privileges.insert(Privilege::Trigger);
-                }
-                DefaultPrivilegeObjectType::Sequences => {
-                    privileges.insert(Privilege::Usage);
-                    privileges.insert(Privilege::Select);
-                    privileges.insert(Privilege::Update);
-                }
-                DefaultPrivilegeObjectType::Functions | DefaultPrivilegeObjectType::Routines => {
-                    privileges.insert(Privilege::Execute);
-                }
-                DefaultPrivilegeObjectType::Types => {
-                    privileges.insert(Privilege::Usage);
-                }
-                DefaultPrivilegeObjectType::Schemas => {
-                    privileges.insert(Privilege::Usage);
-                    privileges.insert(Privilege::Create);
-                }
-            }
-        } else {
-            for priv_str in privileges_str.split(',') {
-                let priv_trimmed = priv_str.trim().to_uppercase();
-                match priv_trimmed.as_str() {
-                    "SELECT" => privileges.insert(Privilege::Select),
-                    "INSERT" => privileges.insert(Privilege::Insert),
-                    "UPDATE" => privileges.insert(Privilege::Update),
-                    "DELETE" => privileges.insert(Privilege::Delete),
-                    "TRUNCATE" => privileges.insert(Privilege::Truncate),
-                    "REFERENCES" => privileges.insert(Privilege::References),
-                    "TRIGGER" => privileges.insert(Privilege::Trigger),
-                    "USAGE" => privileges.insert(Privilege::Usage),
-                    "EXECUTE" => privileges.insert(Privilege::Execute),
-                    "CREATE" => privileges.insert(Privilege::Create),
-                    _ => continue,
-                };
+    for target_role in target_roles {
+        for schema_scope in schema_scopes {
+            for grantee in grantees {
+                schema.default_privileges.push(DefaultPrivilege {
+                    target_role: target_role.clone(),
+                    schema: schema_scope.clone(),
+                    object_type: object_type.clone(),
+                    grantee: grantee.clone(),
+                    privileges: privileges.clone(),
+                    with_grant_option,
+                });
             }
         }
+    }
+}
 
-        if privileges.is_empty() {
+/// Removes `privs_to_revoke` from any matching default privilege record on
+/// `schema.default_privileges`, dropping records that end up empty. Called
+/// from the AST handler for `ALTER DEFAULT PRIVILEGES ... REVOKE`.
+pub(super) fn apply_default_privileges_revoke(
+    schema: &mut Schema,
+    target_roles: &[String],
+    schema_scopes: &[Option<String>],
+    object_type: DefaultPrivilegeObjectType,
+    grantees: &[String],
+    privs_to_revoke: BTreeSet<Privilege>,
+) {
+    if privs_to_revoke.is_empty() || grantees.is_empty() {
+        return;
+    }
+
+    for dp in &mut schema.default_privileges {
+        if !target_roles.contains(&dp.target_role) {
             continue;
         }
-
-        schema.default_privileges.push(DefaultPrivilege {
-            target_role,
-            schema: schema_scope,
-            object_type,
-            grantee,
-            privileges,
-            with_grant_option,
-        });
+        if !schema_scopes.contains(&dp.schema) {
+            continue;
+        }
+        if dp.object_type != object_type {
+            continue;
+        }
+        if !grantees.contains(&dp.grantee) {
+            continue;
+        }
+        for privilege in &privs_to_revoke {
+            dp.privileges.remove(privilege);
+        }
     }
 
-    let revoke_re = Regex::new(
-        r"(?is)ALTER\s+DEFAULT\s+PRIVILEGES\s+(?:FOR\s+ROLE\s+(\w+)\s+)?(?:IN\s+SCHEMA\s+(\w+)\s+)?REVOKE\s+(.+?)\s+ON\s+(TABLES|SEQUENCES|FUNCTIONS|ROUTINES|TYPES|SCHEMAS)\s+FROM\s+(\w+|PUBLIC)\s*;"
-    ).unwrap();
+    schema
+        .default_privileges
+        .retain(|dp| !dp.privileges.is_empty());
+}
 
-    for cap in revoke_re.captures_iter(sql) {
-        let target_role = cap
-            .get(1)
-            .map(|m| m.as_str().to_string())
-            .unwrap_or_else(|| "CURRENT_ROLE".to_string());
-        let schema_scope = cap.get(2).map(|m| m.as_str().to_string());
-        let privileges_str = cap.get(3).unwrap().as_str();
-        let object_type_str = cap.get(4).unwrap().as_str().to_uppercase();
-        let grantee = cap.get(5).unwrap().as_str().to_string();
-
-        let object_type = match DefaultPrivilegeObjectType::from_sql_str(&object_type_str) {
-            Some(ot) => ot,
-            None => continue,
-        };
-
-        let mut privs_to_revoke = BTreeSet::new();
-        let priv_upper = privileges_str.to_uppercase();
-        if priv_upper.contains("ALL") {
-            match object_type {
-                DefaultPrivilegeObjectType::Tables => {
-                    privs_to_revoke.insert(Privilege::Select);
-                    privs_to_revoke.insert(Privilege::Insert);
-                    privs_to_revoke.insert(Privilege::Update);
-                    privs_to_revoke.insert(Privilege::Delete);
-                    privs_to_revoke.insert(Privilege::Truncate);
-                    privs_to_revoke.insert(Privilege::References);
-                    privs_to_revoke.insert(Privilege::Trigger);
-                }
-                DefaultPrivilegeObjectType::Sequences => {
-                    privs_to_revoke.insert(Privilege::Usage);
-                    privs_to_revoke.insert(Privilege::Select);
-                    privs_to_revoke.insert(Privilege::Update);
-                }
-                DefaultPrivilegeObjectType::Functions | DefaultPrivilegeObjectType::Routines => {
-                    privs_to_revoke.insert(Privilege::Execute);
-                }
-                DefaultPrivilegeObjectType::Types => {
-                    privs_to_revoke.insert(Privilege::Usage);
-                }
-                DefaultPrivilegeObjectType::Schemas => {
-                    privs_to_revoke.insert(Privilege::Usage);
-                    privs_to_revoke.insert(Privilege::Create);
-                }
-            }
-        } else {
-            for priv_str in privileges_str.split(',') {
-                let priv_trimmed = priv_str.trim().to_uppercase();
-                match priv_trimmed.as_str() {
-                    "SELECT" => privs_to_revoke.insert(Privilege::Select),
-                    "INSERT" => privs_to_revoke.insert(Privilege::Insert),
-                    "UPDATE" => privs_to_revoke.insert(Privilege::Update),
-                    "DELETE" => privs_to_revoke.insert(Privilege::Delete),
-                    "TRUNCATE" => privs_to_revoke.insert(Privilege::Truncate),
-                    "REFERENCES" => privs_to_revoke.insert(Privilege::References),
-                    "TRIGGER" => privs_to_revoke.insert(Privilege::Trigger),
-                    "USAGE" => privs_to_revoke.insert(Privilege::Usage),
-                    "EXECUTE" => privs_to_revoke.insert(Privilege::Execute),
-                    "CREATE" => privs_to_revoke.insert(Privilege::Create),
-                    _ => continue,
-                };
-            }
+/// Returns the canonical `ALL` privilege set for `object_type`, matching
+/// PostgreSQL's expansion of `ALL` / `ALL PRIVILEGES`.
+pub(super) fn all_privileges_for(object_type: &DefaultPrivilegeObjectType) -> BTreeSet<Privilege> {
+    let mut privileges = BTreeSet::new();
+    match object_type {
+        DefaultPrivilegeObjectType::Tables => {
+            privileges.insert(Privilege::Select);
+            privileges.insert(Privilege::Insert);
+            privileges.insert(Privilege::Update);
+            privileges.insert(Privilege::Delete);
+            privileges.insert(Privilege::Truncate);
+            privileges.insert(Privilege::References);
+            privileges.insert(Privilege::Trigger);
         }
-
-        for dp in &mut schema.default_privileges {
-            if dp.target_role == target_role
-                && dp.schema == schema_scope
-                && dp.object_type == object_type
-                && dp.grantee == grantee
-            {
-                for privilege in &privs_to_revoke {
-                    dp.privileges.remove(privilege);
-                }
-            }
+        DefaultPrivilegeObjectType::Sequences => {
+            privileges.insert(Privilege::Usage);
+            privileges.insert(Privilege::Select);
+            privileges.insert(Privilege::Update);
         }
-
-        schema
-            .default_privileges
-            .retain(|dp| !dp.privileges.is_empty());
+        DefaultPrivilegeObjectType::Functions | DefaultPrivilegeObjectType::Routines => {
+            privileges.insert(Privilege::Execute);
+        }
+        DefaultPrivilegeObjectType::Types => {
+            privileges.insert(Privilege::Usage);
+        }
+        DefaultPrivilegeObjectType::Schemas => {
+            privileges.insert(Privilege::Usage);
+            privileges.insert(Privilege::Create);
+        }
     }
-
-    Ok(())
+    privileges
 }
 
 fn parse_object_name(name: &str) -> (String, String) {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -31,21 +31,27 @@ use crate::model::*;
 use crate::pg::sqlgen::strip_ident_quotes;
 use crate::util::{normalize_sql_whitespace, Result, SchemaError};
 use sqlparser::ast::{
+    Action, AlterDefaultPrivileges, AlterDefaultPrivilegesAction, AlterDefaultPrivilegesObjectType,
     AlterFunction, AlterFunctionKind, AlterFunctionOperation, AlterIndexOperation, AlterTable,
     AlterTableOperation, AlterType, AlterTypeAddValue, AlterTypeAddValuePosition,
     AlterTypeOperation, CreateAggregate, CreateAggregateOption, CreateDomain, CreateExtension,
     CreateFunction, CreateServerStatement, CreateTrigger, CreateView, DeferrableInitial,
-    DropDomain, DropExtension, DropFunction, DropTrigger, FunctionParallel, ObjectType, Owner,
-    RenameTableNameKind, SchemaName, Statement, TableConstraint, TriggerEvent as SqlTriggerEvent,
-    TriggerPeriod, TriggerReferencingType, UserDefinedTypeRepresentation,
+    DropDomain, DropExtension, DropFunction, DropTrigger, FunctionParallel, Grantee, GranteeName,
+    GranteesType, ObjectType, Owner, Privileges, RenameTableNameKind, SchemaName, Statement,
+    TableConstraint, TriggerEvent as SqlTriggerEvent, TriggerPeriod, TriggerReferencingType,
+    UserDefinedTypeRepresentation,
 };
 use sqlparser::dialect::PostgreSqlDialect;
 use sqlparser::parser::Parser;
+use std::collections::BTreeSet;
 use std::fs;
 
 use comments::{apply_comment_statement, CommentStatement};
 use functions::parse_create_function;
-use grants::{parse_alter_default_privileges, parse_grant_statements, parse_revoke_statements};
+use grants::{
+    all_privileges_for, apply_default_privileges_grant, apply_default_privileges_revoke,
+    parse_grant_statements, parse_revoke_statements,
+};
 use ownership::parse_owner_statements;
 use preprocess::preprocess_sql;
 use sequences::parse_create_sequence;
@@ -625,25 +631,31 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
                             }
                         }
                     }
-                    // Type-level rename and the type renames-a-value form are not
-                    // modelled; the actual enum mutations land via the AddValue
-                    // arm above.
+                    AlterTypeOperation::OwnerTo { new_owner } => {
+                        if let Owner::Ident(ident) = new_owner {
+                            schema.pending_owners.push(PendingOwner {
+                                object_type: PendingOwnerObjectType::Enum,
+                                object_key: key.clone(),
+                                owner: ident.value.clone(),
+                            });
+                        }
+                    }
+                    // Type-level rename, renames-a-value, schema move, and
+                    // composite-type attribute mutations are accepted but not
+                    // modelled. enum AddValue is handled above; everything
+                    // else parses cleanly so users see no error, but the
+                    // resulting schema is unchanged.
                     AlterTypeOperation::Rename(_)
-                    | AlterTypeOperation::RenameValue(_) => {}
-                    // The variants below are unreachable today: `preprocess_sql`
-                    // strips `ALTER TYPE ... OWNER TO`, `... SET SCHEMA`, and
-                    // `... (ADD|DROP|ALTER|RENAME) ATTRIBUTE` before sqlparser
-                    // sees them. Listed explicitly to keep the match exhaustive
-                    // and to surface any future upstream additions at compile
-                    // time. Tracked by pgmold-289 (retire the preprocess strips
-                    // and migrate to AST-driven handling).
-                    AlterTypeOperation::OwnerTo { .. }
+                    | AlterTypeOperation::RenameValue(_)
                     | AlterTypeOperation::SetSchema { .. }
                     | AlterTypeOperation::AddAttribute { .. }
                     | AlterTypeOperation::DropAttribute { .. }
                     | AlterTypeOperation::AlterAttribute { .. }
                     | AlterTypeOperation::RenameAttribute { .. } => {}
                 }
+            }
+            Statement::AlterDefaultPrivileges(adp) => {
+                apply_alter_default_privileges(adp, &mut schema);
             }
             Statement::CreateFunction(CreateFunction {
                 name,
@@ -1163,12 +1175,6 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
             | Statement::Grant { .. }
             | Statement::Revoke { .. }
             | Statement::Deny(_)
-            // ALTER DEFAULT PRIVILEGES — currently unreachable: `preprocess_sql`
-            // strips the statement before sqlparser sees it. The actual handler
-            // is `parse_alter_default_privileges` on the raw SQL. Listed here to
-            // keep the match exhaustive. Tracked by pgmold-289 (retire the
-            // preprocess strip and migrate to AST-driven handling).
-            | Statement::AlterDefaultPrivileges(_)
             // Cluster-level and role / user management — not part of the
             // schema model pgmold tracks.
             | Statement::CreateRole(_)
@@ -1343,7 +1349,6 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
     parse_owner_statements(sql, &mut schema);
     parse_grant_statements(sql, &mut schema)?;
     parse_revoke_statements(sql, &mut schema)?;
-    parse_alter_default_privileges(sql, &mut schema)?;
 
     schema.pending_policies = schema.finalize_partial();
 
@@ -1491,6 +1496,130 @@ fn parse_alter_aggregate_owner(alter: AlterFunction, schema: &mut Schema) {
         object_key,
         owner: owner_name,
     });
+}
+
+fn map_default_privileges_object_type(
+    object_type: &AlterDefaultPrivilegesObjectType,
+) -> DefaultPrivilegeObjectType {
+    match object_type {
+        AlterDefaultPrivilegesObjectType::Tables => DefaultPrivilegeObjectType::Tables,
+        AlterDefaultPrivilegesObjectType::Sequences => DefaultPrivilegeObjectType::Sequences,
+        AlterDefaultPrivilegesObjectType::Functions => DefaultPrivilegeObjectType::Functions,
+        AlterDefaultPrivilegesObjectType::Routines => DefaultPrivilegeObjectType::Routines,
+        AlterDefaultPrivilegesObjectType::Types => DefaultPrivilegeObjectType::Types,
+        AlterDefaultPrivilegesObjectType::Schemas => DefaultPrivilegeObjectType::Schemas,
+    }
+}
+
+/// Returns the model `Privilege` for a `GRANT`/`REVOKE` action variant, or
+/// `None` for actions that have no `model::Privilege` counterpart (DDL-only
+/// rights like `ALTER`, vendor extensions like `Apply`, etc.). Unmapped
+/// actions are silently skipped — the goal is fidelity with the prior regex
+/// behavior, which only understood the ten core privileges.
+//
+// `Action` is a genuinely huge upstream enum (Snowflake/Databricks/PG
+// dialects all add variants), so per ARCHITECTURE.md § "Match Arm
+// Discipline" we exempt this single match from the wildcard lint rather
+// than enumerating ~50 variants we explicitly want to ignore.
+#[allow(clippy::wildcard_enum_match_arm)]
+fn map_action_to_privilege(action: &Action) -> Option<Privilege> {
+    match action {
+        Action::Select { .. } => Some(Privilege::Select),
+        Action::Insert { .. } => Some(Privilege::Insert),
+        Action::Update { .. } => Some(Privilege::Update),
+        Action::Delete => Some(Privilege::Delete),
+        Action::Truncate => Some(Privilege::Truncate),
+        Action::References { .. } => Some(Privilege::References),
+        Action::Trigger => Some(Privilege::Trigger),
+        Action::Usage => Some(Privilege::Usage),
+        Action::Execute { .. } => Some(Privilege::Execute),
+        Action::Create { .. } => Some(Privilege::Create),
+        _ => None,
+    }
+}
+
+fn convert_privileges(
+    privileges: &Privileges,
+    object_type: &DefaultPrivilegeObjectType,
+) -> BTreeSet<Privilege> {
+    match privileges {
+        Privileges::All { .. } => all_privileges_for(object_type),
+        Privileges::Actions(actions) => {
+            actions.iter().filter_map(map_action_to_privilege).collect()
+        }
+    }
+}
+
+/// Returns the role names a `Grantee` resolves to. `PUBLIC` is stored as
+/// the literal string `"PUBLIC"` to stay consistent with `pg_default_acl`
+/// introspection, which always emits uppercase `PUBLIC`. Grantees with no
+/// name and host-qualified principals are skipped — they have no
+/// representation in the schema model today.
+fn grantee_to_role_name(grantee: &Grantee) -> Option<String> {
+    if matches!(grantee.grantee_type, GranteesType::Public) {
+        return Some("PUBLIC".to_string());
+    }
+    match grantee.name.as_ref()? {
+        GranteeName::ObjectName(object_name) => Some(strip_ident_quotes(&object_name.to_string())),
+        GranteeName::UserHost { .. } => None,
+    }
+}
+
+fn apply_alter_default_privileges(adp: AlterDefaultPrivileges, schema: &mut Schema) {
+    let target_roles: Vec<String> = if adp.for_roles.is_empty() {
+        vec!["CURRENT_ROLE".to_string()]
+    } else {
+        adp.for_roles.into_iter().map(|i| i.value).collect()
+    };
+
+    let schema_scopes: Vec<Option<String>> = if adp.in_schemas.is_empty() {
+        vec![None]
+    } else {
+        adp.in_schemas.into_iter().map(|i| Some(i.value)).collect()
+    };
+
+    match adp.action {
+        AlterDefaultPrivilegesAction::Grant {
+            privileges,
+            object_type,
+            grantees,
+            with_grant_option,
+        } => {
+            let model_object_type = map_default_privileges_object_type(&object_type);
+            let model_privileges = convert_privileges(&privileges, &model_object_type);
+            let grantee_names: Vec<String> =
+                grantees.iter().filter_map(grantee_to_role_name).collect();
+            apply_default_privileges_grant(
+                schema,
+                &target_roles,
+                &schema_scopes,
+                model_object_type,
+                &grantee_names,
+                model_privileges,
+                with_grant_option,
+            );
+        }
+        AlterDefaultPrivilegesAction::Revoke {
+            grant_option_for: _,
+            privileges,
+            object_type,
+            grantees,
+            cascade: _,
+        } => {
+            let model_object_type = map_default_privileges_object_type(&object_type);
+            let model_privileges = convert_privileges(&privileges, &model_object_type);
+            let grantee_names: Vec<String> =
+                grantees.iter().filter_map(grantee_to_role_name).collect();
+            apply_default_privileges_revoke(
+                schema,
+                &target_roles,
+                &schema_scopes,
+                model_object_type,
+                &grantee_names,
+                model_privileges,
+            );
+        }
+    }
 }
 
 fn parse_create_server(stmt: CreateServerStatement, schema: &mut Schema) {

--- a/src/parser/ownership.rs
+++ b/src/parser/ownership.rs
@@ -23,24 +23,6 @@ pub(super) fn parse_owner_statements(sql: &str, schema: &mut Schema) {
         });
     }
 
-    let alter_type_owner_re = Regex::new(
-        r#"(?i)ALTER\s+TYPE\s+(?:["']?([^"'\s]+)["']?\.)?["']?([^"'\s;]+)["']?\s+OWNER\s+TO\s+["']?([^"'\s;]+)["']?"#
-    ).unwrap();
-
-    for cap in alter_type_owner_re.captures_iter(sql) {
-        let schema_part = cap.get(1).map(|m| unquote_ident(m.as_str()));
-        let type_name = unquote_ident(cap.get(2).unwrap().as_str());
-        let owner = unquote_ident(cap.get(3).unwrap().as_str());
-
-        let type_schema = schema_part.unwrap_or("public");
-        let object_key = qualified_name(type_schema, type_name);
-        schema.pending_owners.push(PendingOwner {
-            object_type: PendingOwnerObjectType::Enum,
-            object_key,
-            owner: owner.to_string(),
-        });
-    }
-
     let alter_domain_owner_re = Regex::new(
         r#"(?i)ALTER\s+DOMAIN\s+(?:["']?([^"'\s]+)["']?\.)?["']?([^"'\s;]+)["']?\s+OWNER\s+TO\s+["']?([^"'\s;]+)["']?"#
     ).unwrap();

--- a/src/parser/preprocess.rs
+++ b/src/parser/preprocess.rs
@@ -290,7 +290,7 @@ fn restore_quoted_content(mut sql: String, replacements: &[(String, String)]) ->
 /// identifier-style placeholders so the GRANT/REVOKE strip patterns below
 /// don't shred the inline GRANT/REVOKE body. Restored alongside quoted
 /// content via [`restore_quoted_content`].
-fn protect_alter_default_privileges(
+pub(super) fn protect_alter_default_privileges(
     sql: String,
     replacements: &mut Vec<(String, String)>,
 ) -> String {
@@ -688,6 +688,27 @@ $$;"
         let sql = "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO readonly;";
         let result = preprocess_sql(sql);
         assert_eq!(result, sql);
+    }
+
+    #[test]
+    fn preprocess_preserves_alter_default_privileges_revoke() {
+        let sql =
+            "ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE SELECT ON TABLES FROM readonly;";
+        let result = preprocess_sql(sql);
+        assert_eq!(result, sql);
+    }
+
+    #[test]
+    fn preprocess_preserves_multiple_alter_default_privileges() {
+        let sql = "\
+ALTER DEFAULT PRIVILEGES IN SCHEMA api GRANT SELECT ON TABLES TO reporter;
+ALTER DEFAULT PRIVILEGES IN SCHEMA api REVOKE INSERT ON TABLES FROM reporter;
+GRANT SELECT ON public.users TO readonly;
+";
+        let result = preprocess_sql(sql);
+        assert!(result.contains("ALTER DEFAULT PRIVILEGES IN SCHEMA api GRANT SELECT"));
+        assert!(result.contains("ALTER DEFAULT PRIVILEGES IN SCHEMA api REVOKE INSERT"));
+        assert!(!result.contains("GRANT SELECT ON public.users"));
     }
 
     #[test]

--- a/src/parser/preprocess.rs
+++ b/src/parser/preprocess.rs
@@ -288,7 +288,7 @@ fn restore_quoted_content(mut sql: String, replacements: &[(String, String)]) ->
 
 /// Strips syntax not supported by sqlparser 0.52.
 /// Statements stripped here are parsed separately via regex
-/// (GRANT, REVOKE, ALTER DEFAULT PRIVILEGES, OWNER TO, COMMENT ON, DO blocks).
+/// (GRANT, REVOKE, OWNER TO, COMMENT ON, DO blocks).
 pub(super) fn preprocess_sql(sql: &str) -> String {
     let sql = strip_comments(sql);
     let sql = strip_do_blocks(&sql);
@@ -302,17 +302,13 @@ pub(super) fn preprocess_sql(sql: &str) -> String {
         r"(?i)ALTER\s+MATERIALIZED\s+VIEW\s+[^;]+;",
         r"(?i)ALTER\s+VIEW\s+[^;]+;",
         r"(?i)ALTER\s+SEQUENCE\s+[^;]+;",
-        // ALTER TYPE attribute / ownership / schema strips and the
-        // ALTER DEFAULT PRIVILEGES strip below could retire now that
-        // pgmold-sqlparser 0.61.0 exposes the corresponding AST variants.
-        // Tracked by pgmold-289.
-        r"(?i)ALTER\s+TYPE\s+[^;]+\s+OWNER\s+TO\s+[^;]+;",
-        r"(?i)ALTER\s+TYPE\s+[^;]+\s+SET\s+SCHEMA\s+[^;]+;",
-        r"(?i)ALTER\s+TYPE\s+[^;]+\s+(?:ADD|DROP|ALTER|RENAME)\s+ATTRIBUTE\s+[^;]+;",
         r"(?i)ALTER\s+DOMAIN\s+[^;]+;",
-        r"(?i)ALTER\s+DEFAULT\s+PRIVILEGES\s+[^;]+;",
         // COMMENT ON statements are now handled via the sqlparser AST; see
         // `comments::apply_comment_statement` (pgmold-273).
+        // ALTER TYPE OWNER TO / SET SCHEMA / *_ATTRIBUTE and ALTER DEFAULT
+        // PRIVILEGES are now handled via the sqlparser AST; see the
+        // `Statement::AlterType` and `Statement::AlterDefaultPrivileges`
+        // arms in parser/mod.rs (pgmold-289).
         r"(?i)REVOKE\s+[^;]+;",
         r"(?i)GRANT\s+[^;]+;",
     ];
@@ -641,10 +637,31 @@ $$;"
     }
 
     #[test]
-    fn preprocess_strips_alter_type_rename_attribute() {
+    fn preprocess_preserves_alter_type_rename_attribute() {
         let sql = "ALTER TYPE composite_t RENAME ATTRIBUTE a TO aa;\nSELECT 1;";
         let result = preprocess_sql(sql);
-        assert_eq!(result, "\nSELECT 1;");
+        assert_eq!(result, sql);
+    }
+
+    #[test]
+    fn preprocess_preserves_alter_type_owner_to() {
+        let sql = "ALTER TYPE user_role OWNER TO admin;";
+        let result = preprocess_sql(sql);
+        assert_eq!(result, sql);
+    }
+
+    #[test]
+    fn preprocess_preserves_alter_type_set_schema() {
+        let sql = "ALTER TYPE user_role SET SCHEMA staging;";
+        let result = preprocess_sql(sql);
+        assert_eq!(result, sql);
+    }
+
+    #[test]
+    fn preprocess_preserves_alter_default_privileges() {
+        let sql = "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO readonly;";
+        let result = preprocess_sql(sql);
+        assert_eq!(result, sql);
     }
 
     #[test]

--- a/src/parser/preprocess.rs
+++ b/src/parser/preprocess.rs
@@ -286,6 +286,31 @@ fn restore_quoted_content(mut sql: String, replacements: &[(String, String)]) ->
     sql
 }
 
+/// Replaces complete `ALTER DEFAULT PRIVILEGES ... ;` statements with
+/// identifier-style placeholders so the GRANT/REVOKE strip patterns below
+/// don't shred the inline GRANT/REVOKE body. Restored alongside quoted
+/// content via [`restore_quoted_content`].
+fn protect_alter_default_privileges(
+    sql: String,
+    replacements: &mut Vec<(String, String)>,
+) -> String {
+    use std::sync::LazyLock;
+    static ADP_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(?is)\bALTER\s+DEFAULT\s+PRIVILEGES\s+[^;]+;").unwrap());
+
+    let mut result = String::with_capacity(sql.len());
+    let mut last_end = 0;
+    for matched in ADP_RE.find_iter(&sql) {
+        result.push_str(&sql[last_end..matched.start()]);
+        let placeholder = format!("__pgmold_adp_{}__", replacements.len());
+        replacements.push((placeholder.clone(), matched.as_str().to_string()));
+        result.push_str(&placeholder);
+        last_end = matched.end();
+    }
+    result.push_str(&sql[last_end..]);
+    result
+}
+
 /// Strips syntax not supported by sqlparser 0.52.
 /// Statements stripped here are parsed separately via regex
 /// (GRANT, REVOKE, OWNER TO, COMMENT ON, DO blocks).
@@ -294,7 +319,8 @@ pub(super) fn preprocess_sql(sql: &str) -> String {
     let sql = strip_do_blocks(&sql);
     let sql = reorder_sequence_options(&sql);
 
-    let (protected, replacements) = protect_quoted_content(&sql);
+    let (protected, mut replacements) = protect_quoted_content(&sql);
+    let protected = protect_alter_default_privileges(protected, &mut replacements);
 
     let strip_patterns = [
         r"(?i)\bSET\s+search_path\s+TO\s+'[^']*'(?:\s*,\s*'[^']*')*",

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -4,7 +4,7 @@
 #![allow(clippy::wildcard_enum_match_arm)]
 
 use super::*;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use super::tables::detect_serial_type;
 
@@ -3376,6 +3376,150 @@ fn parses_alter_default_privileges_revoke() {
 
     let schema = parse_sql_string(sql).unwrap();
     assert_eq!(schema.default_privileges.len(), 0);
+}
+
+#[test]
+fn parses_alter_type_owner_to_quoted_role() {
+    let sql = r#"
+        CREATE TYPE user_role AS ENUM ('admin', 'user');
+        ALTER TYPE user_role OWNER TO "Owner With Spaces";
+    "#;
+    let schema = parse_sql_string(sql).unwrap();
+    let enum_type = schema.enums.get("public.user_role").unwrap();
+    assert_eq!(enum_type.owner, Some("Owner With Spaces".to_string()));
+}
+
+#[test]
+fn ignores_alter_type_owner_to_current_role() {
+    let sql = r#"
+        CREATE TYPE user_role AS ENUM ('admin', 'user');
+        ALTER TYPE user_role OWNER TO CURRENT_ROLE;
+    "#;
+    let schema = parse_sql_string(sql).unwrap();
+    let enum_type = schema.enums.get("public.user_role").unwrap();
+    assert_eq!(enum_type.owner, None);
+}
+
+#[test]
+fn ignores_alter_type_owner_to_current_user() {
+    let sql = r#"
+        CREATE TYPE user_role AS ENUM ('admin', 'user');
+        ALTER TYPE user_role OWNER TO CURRENT_USER;
+    "#;
+    let schema = parse_sql_string(sql).unwrap();
+    let enum_type = schema.enums.get("public.user_role").unwrap();
+    assert_eq!(enum_type.owner, None);
+}
+
+#[test]
+fn ignores_alter_type_owner_to_session_user() {
+    let sql = r#"
+        CREATE TYPE user_role AS ENUM ('admin', 'user');
+        ALTER TYPE user_role OWNER TO SESSION_USER;
+    "#;
+    let schema = parse_sql_string(sql).unwrap();
+    let enum_type = schema.enums.get("public.user_role").unwrap();
+    assert_eq!(enum_type.owner, None);
+}
+
+#[test]
+fn parses_alter_type_set_schema_no_model_effect() {
+    let sql = r#"
+        CREATE SCHEMA staging;
+        CREATE TYPE user_role AS ENUM ('admin', 'user');
+        ALTER TYPE user_role SET SCHEMA staging;
+    "#;
+    let schema = parse_sql_string(sql).expect("ALTER TYPE SET SCHEMA must parse without error");
+    assert!(schema.enums.contains_key("public.user_role"));
+}
+
+#[test]
+fn parses_alter_type_attribute_ops_no_model_effect() {
+    let sql = r#"
+        CREATE TYPE composite_t AS (a int);
+        ALTER TYPE composite_t ADD ATTRIBUTE b text;
+        ALTER TYPE composite_t ALTER ATTRIBUTE b SET DATA TYPE varchar(64);
+        ALTER TYPE composite_t RENAME ATTRIBUTE b TO bb;
+        ALTER TYPE composite_t DROP ATTRIBUTE bb;
+    "#;
+    parse_sql_string(sql).expect("ALTER TYPE attribute ops must parse without error");
+}
+
+#[test]
+fn parses_alter_default_privileges_multi_grantee() {
+    let sql = r#"
+        ALTER DEFAULT PRIVILEGES FOR ROLE admin IN SCHEMA public
+        GRANT SELECT ON TABLES TO app_user, reporting_user;
+    "#;
+    let schema = parse_sql_string(sql).unwrap();
+    let grantees: BTreeSet<String> = schema
+        .default_privileges
+        .iter()
+        .map(|dp| dp.grantee.clone())
+        .collect();
+    assert_eq!(
+        grantees,
+        BTreeSet::from(["app_user".to_string(), "reporting_user".to_string()])
+    );
+    for dp in &schema.default_privileges {
+        assert_eq!(dp.target_role, "admin");
+        assert_eq!(dp.schema, Some("public".to_string()));
+        assert_eq!(dp.object_type, DefaultPrivilegeObjectType::Tables);
+        assert_eq!(dp.privileges, BTreeSet::from([Privilege::Select]));
+        assert!(!dp.with_grant_option);
+    }
+}
+
+#[test]
+fn parses_alter_default_privileges_multi_schema() {
+    let sql = r#"
+        ALTER DEFAULT PRIVILEGES FOR ROLE admin IN SCHEMA public, api
+        GRANT SELECT ON TABLES TO app_user;
+    "#;
+    let schema = parse_sql_string(sql).unwrap();
+    let schemas: BTreeSet<Option<String>> = schema
+        .default_privileges
+        .iter()
+        .map(|dp| dp.schema.clone())
+        .collect();
+    assert_eq!(
+        schemas,
+        BTreeSet::from([Some("public".to_string()), Some("api".to_string())])
+    );
+}
+
+#[test]
+fn parses_alter_default_privileges_multi_role() {
+    let sql = r#"
+        ALTER DEFAULT PRIVILEGES FOR ROLE admin, deployer IN SCHEMA public
+        GRANT SELECT ON TABLES TO app_user;
+    "#;
+    let schema = parse_sql_string(sql).unwrap();
+    let roles: BTreeSet<String> = schema
+        .default_privileges
+        .iter()
+        .map(|dp| dp.target_role.clone())
+        .collect();
+    assert_eq!(
+        roles,
+        BTreeSet::from(["admin".to_string(), "deployer".to_string()])
+    );
+}
+
+#[test]
+fn parses_alter_default_privileges_revoke_multi_grantee() {
+    let sql = r#"
+        ALTER DEFAULT PRIVILEGES FOR ROLE admin IN SCHEMA public
+        GRANT SELECT, INSERT ON TABLES TO app_user, reporting_user;
+
+        ALTER DEFAULT PRIVILEGES FOR ROLE admin IN SCHEMA public
+        REVOKE INSERT ON TABLES FROM app_user, reporting_user;
+    "#;
+    let schema = parse_sql_string(sql).unwrap();
+    assert_eq!(schema.default_privileges.len(), 2);
+    for dp in &schema.default_privileges {
+        assert_eq!(dp.privileges, BTreeSet::from([Privilege::Select]));
+    }
 }
 
 #[test]

--- a/src/parser/unrecognized.rs
+++ b/src/parser/unrecognized.rs
@@ -1,13 +1,17 @@
 //! Detection of top-level SQL statements that pgmold's regex-based parse
 //! passes silently drop.
 //!
-//! When a `COMMENT ON`, `GRANT`, `REVOKE`, `ALTER ... OWNER TO`, or
-//! `ALTER DEFAULT PRIVILEGES` is syntactically valid but does not match one
-//! of the specific pgmold regex variants, `preprocess_sql` still strips it
-//! out before sqlparser runs — so sqlparser never sees it and pgmold never
-//! records it. Silent drop. This module surfaces those drops as warnings
-//! (and, under strict mode, as errors) so downstream users do not discover
-//! them months later as schema drift.
+//! When a `COMMENT ON`, `GRANT`, `REVOKE`, or `ALTER ... OWNER TO` is
+//! syntactically valid but does not match one of the specific pgmold regex
+//! variants, `preprocess_sql` still strips it out before sqlparser runs —
+//! so sqlparser never sees it and pgmold never records it. Silent drop.
+//! This module surfaces those drops as warnings (and, under strict mode,
+//! as errors) so downstream users do not discover them months later as
+//! schema drift.
+//!
+//! `ALTER DEFAULT PRIVILEGES` is included in the safety net even though it
+//! flows through the AST since pgmold-289: the broad recognizer triggers
+//! whenever the statement does not match the AST handler's coverage.
 //!
 //! See pgmold-271 (and gh#246, which was only diagnosable after quiet
 //! failure masked it for months).
@@ -121,19 +125,12 @@ static ALTER_VIEW_OWNER_CLAIM: LazyLock<Regex> =
 static ALTER_SEQUENCE_OWNER_CLAIM: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"(?is)\bALTER\s+SEQUENCE\s+.+?\s+OWNER\s+TO\s+").unwrap());
 
-static ALTER_DEFAULT_PRIVILEGES_GRANT_CLAIM: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(
-        r"(?is)\bALTER\s+DEFAULT\s+PRIVILEGES\s+(?:FOR\s+ROLE\s+\w+\s+)?(?:IN\s+SCHEMA\s+\w+\s+)?GRANT\s+.+?\s+ON\s+(?:TABLES|SEQUENCES|FUNCTIONS|ROUTINES|TYPES|SCHEMAS)\s+TO\s+",
-    )
-    .unwrap()
-});
-
-static ALTER_DEFAULT_PRIVILEGES_REVOKE_CLAIM: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(
-        r"(?is)\bALTER\s+DEFAULT\s+PRIVILEGES\s+(?:FOR\s+ROLE\s+\w+\s+)?(?:IN\s+SCHEMA\s+\w+\s+)?REVOKE\s+.+?\s+ON\s+(?:TABLES|SEQUENCES|FUNCTIONS|ROUTINES|TYPES|SCHEMAS)\s+FROM\s+",
-    )
-    .unwrap()
-});
+// AST-handled since pgmold-289: any well-formed statement is processed by
+// `apply_alter_default_privileges` regardless of role/schema/grantee count
+// or specific privilege list. Treat all `ALTER DEFAULT PRIVILEGES ...;` as
+// claimed; let sqlparser surface true syntactic errors elsewhere.
+static ALTER_DEFAULT_PRIVILEGES_CLAIM: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?is)\bALTER\s+DEFAULT\s+PRIVILEGES\b").unwrap());
 
 struct BroadRecognizer {
     kind: &'static str,
@@ -185,10 +182,7 @@ static RECOGNIZERS: &[BroadRecognizer] = &[
     BroadRecognizer {
         kind: "ALTER DEFAULT PRIVILEGES",
         broad: &ALTER_DEFAULT_PRIVILEGES_BROAD,
-        claims: &[
-            &ALTER_DEFAULT_PRIVILEGES_GRANT_CLAIM,
-            &ALTER_DEFAULT_PRIVILEGES_REVOKE_CLAIM,
-        ],
+        claims: &[&ALTER_DEFAULT_PRIVILEGES_CLAIM],
     },
 ];
 

--- a/src/parser/unrecognized.rs
+++ b/src/parser/unrecognized.rs
@@ -18,7 +18,7 @@
 use regex::Regex;
 use std::sync::LazyLock;
 
-use super::preprocess::{protect_quoted_content, strip_comments};
+use super::preprocess::{protect_alter_default_privileges, protect_quoted_content, strip_comments};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UnrecognizedStatement {
@@ -197,7 +197,13 @@ pub fn find_unrecognized_statements(sql: &str) -> Vec<UnrecognizedStatement> {
     // each literal with a placeholder. For multi-line literals the line
     // number may drift downward, which is acceptable for a warning.
     let stripped = strip_comments(sql);
-    let (sanitized, _replacements) = protect_quoted_content(&stripped);
+    let (sanitized, mut replacements) = protect_quoted_content(&stripped);
+    // Protect ALTER DEFAULT PRIVILEGES so the GRANT_BROAD / REVOKE_BROAD
+    // recognizers don't latch onto the inner body and report a position
+    // anchored on the wrong keyword. The replacements vec is consumed by
+    // the protect helper but not restored — sanitized SQL is used only
+    // for offset arithmetic and pattern matching, never handed to a parser.
+    let sanitized = protect_alter_default_privileges(sanitized, &mut replacements);
 
     let mut findings: Vec<UnrecognizedStatement> = Vec::new();
 

--- a/tests/corpus/upstream_pg/privileges.silent_drops.txt
+++ b/tests/corpus/upstream_pg/privileges.silent_drops.txt
@@ -5,7 +5,6 @@
 #
 # Regenerate via:  PGMOLD_UPDATE_SILENT_DROPS=1 cargo test --test corpus_upstream_pg
 
-ALTER DEFAULT PRIVILEGES GRANT ON TABLES
 ALTER SCHEMA OWNER TO
 GRANT ... ON <implicit>
 GRANT <role> TO ...


### PR DESCRIPTION
Retires four `preprocess_sql` strip patterns that were redundant after pgmold-sqlparser 0.61.0 (consumed in #268) added AST surface for them, and wires the previously-empty match arms in `parser/mod.rs` to real handlers.

## Scope

Strips removed from `src/parser/preprocess.rs`:
- `ALTER TYPE … OWNER TO …`
- `ALTER TYPE … SET SCHEMA …`
- `ALTER TYPE … (ADD|DROP|ALTER|RENAME) ATTRIBUTE …`
- `ALTER DEFAULT PRIVILEGES …`

`ALTER DOMAIN` strip stays (out of scope; tracked separately).

## Behavior changes

- `AlterTypeOperation::OwnerTo` now records `PendingOwner { object_type: Enum }` for `Owner::Ident` forms, mirroring the `ALTER TABLE OWNER TO` migration in pgmold-274. `CURRENT_ROLE` / `CURRENT_USER` / `SESSION_USER` are silently ignored, consistent with `parse_alter_aggregate_owner`.
- `Statement::AlterDefaultPrivileges` is dispatched to `apply_alter_default_privileges`, which walks the `for_roles × in_schemas × grantees` cross-product. The regex-based handler only supported a single value in each position; the AST handler covers all PostgreSQL forms.
- `GranteesType::Public` is stored as the literal `"PUBLIC"` to stay aligned with `introspect_default_privileges`, which emits uppercase from `pg_default_acl`.
- `unrecognized.rs` claim regex for ALTER DEFAULT PRIVILEGES is broadened — the AST handler now claims every well-formed shape, so the previous narrow regex would have flagged multi-role / multi-schema statements as silent drops despite the AST processing them correctly.

## Tests

Existing tests cover the single-value cases (`parses_alter_default_privileges_for_role_in_schema`, `_global`, `_implicit_role`, `_revoke`, and `parses_alter_type_owner_to`). New tests added in `src/parser/tests.rs`:

- `parses_alter_type_owner_to_quoted_role` — `\"Owner With Spaces\"`
- `ignores_alter_type_owner_to_current_role` / `_current_user` / `_session_user`
- `parses_alter_type_set_schema_no_model_effect`
- `parses_alter_type_attribute_ops_no_model_effect`
- `parses_alter_default_privileges_multi_grantee` / `_multi_schema` / `_multi_role`
- `parses_alter_default_privileges_revoke_multi_grantee`

Updated `preprocess.rs` tests now assert pass-through for the four shapes that no longer get stripped.

## Test plan

- [ ] CI green on stable
- [ ] CI green on integration tests (testcontainers PostgreSQL)
- [ ] No regression in `tests/convergence.rs::default_privileges_*` against a real DB

## Follow-ups

Filed as discovered-from pgmold-289:
- pgmold-290: surface `GranteesType::UserHost` skip in the AST handler (Redshift dialect; silent drop today)
- pgmold-291: retire the dead ALTER DEFAULT PRIVILEGES recognizer in `unrecognized.rs` (broad/claim now tautologically claimed)