### PR TITLE
docs(preprocess): tighten preprocess_sql doc comment

### DIFF
--- a/src/parser/preprocess.rs
+++ b/src/parser/preprocess.rs
@@ -311,9 +311,10 @@ pub(super) fn protect_alter_default_privileges(
     result
 }
 
-/// Strips syntax not supported by sqlparser 0.52.
-/// Statements stripped here are parsed separately via regex
-/// (GRANT, REVOKE, OWNER TO, COMMENT ON, DO blocks).
+/// Strips syntax not handled by the sqlparser AST.
+/// `GRANT` / `REVOKE` are reparsed in `grants.rs`. `ALTER` of `FUNCTION`,
+/// `MATERIALIZED VIEW`, `VIEW`, `SEQUENCE`, and `DOMAIN` is reparsed in
+/// `ownership.rs`. `SET search_path` is discarded outright.
 pub(super) fn preprocess_sql(sql: &str) -> String {
     let sql = strip_comments(sql);
     let sql = strip_do_blocks(&sql);


### PR DESCRIPTION
## Summary
- Tighten the `preprocess_sql` doc comment to match the current strip list. After pgmold-273 (`COMMENT ON` AST migration) and pgmold-289 (`ALTER TYPE` / `ALTER DEFAULT PRIVILEGES` AST migration), the parenthetical `(GRANT, REVOKE, OWNER TO, COMMENT ON, DO blocks)` is wrong on three counts: `COMMENT ON` is no longer stripped, the `OWNER TO` claim now applies only to `FUNCTION`/`MATERIALIZED VIEW`/`VIEW`/`SEQUENCE`/`DOMAIN`, and `DO blocks` were never in this strip pass — they are removed earlier by `strip_do_blocks`.
- Replace the parenthetical with the actual current strip targets and pointers to the regex re-parsers (`grants.rs`, `ownership.rs`).

Refs pgmold-288. No behavior change.

## Test plan
- [ ] `cargo test` (CI)
- [x] `cargo fmt --all --check` (clean)