### PR TITLE
pgmold-294: bump pgmold-sqlparser to 0.62.0 + adopt table_name rename

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1612,9 +1612,9 @@ dependencies = [
 
 [[package]]
 name = "pgmold-sqlparser"
-version = "0.61.1"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1523e0eb981fe3b0b5eeba975c49ba3db93aa107565244feedb4eca3b9739a1c"
+checksum = "656c7eda01a307b0d5f8ade93d3b701d7bef9b89e7587913f9e1203a50916702"
 dependencies = [
  "log",
  "recursive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["command-line-utilities", "database"]
 clap = { version = "4.5", features = ["derive", "env"] }
 tokio = { version = "1.35", features = ["full"] }
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres"] }
-sqlparser = { package = "pgmold-sqlparser", version = "0.61.1", features = ["visitor"] }
+sqlparser = { package = "pgmold-sqlparser", version = "0.62.0", features = ["visitor"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 anyhow = "1.0"
@@ -37,11 +37,11 @@ sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres"] }
 tokio = { version = "1.35", features = ["full"] }
 assert_cmd = "2"
 criterion = { version = "0.5", features = ["html_reports"] }
-sqlparser = { package = "pgmold-sqlparser", version = "0.61.1", features = ["visitor"] }
+sqlparser = { package = "pgmold-sqlparser", version = "0.62.0", features = ["visitor"] }
 
 [[bench]]
 name = "performance"
 harness = false
 
 [build-dependencies]
-sqlparser = { package = "pgmold-sqlparser", version = "0.61.1", features = ["visitor"] }
+sqlparser = { package = "pgmold-sqlparser", version = "0.62.0", features = ["visitor"] }

--- a/src/parser/comments.rs
+++ b/src/parser/comments.rs
@@ -31,7 +31,7 @@ pub(super) struct CommentStatement<'a> {
     pub object_type: CommentObject,
     pub object_name: &'a ObjectName,
     pub arguments: Option<&'a [DataType]>,
-    pub relation: Option<&'a ObjectName>,
+    pub table_name: Option<&'a ObjectName>,
     pub comment: Option<String>,
 }
 
@@ -47,7 +47,7 @@ pub(super) fn apply_comment_statement(
         object_type,
         object_name,
         arguments,
-        relation,
+        table_name: partner_table,
         comment,
     } = stmt;
 
@@ -155,12 +155,12 @@ pub(super) fn apply_comment_statement(
                 )));
             }
             let trigger_name = trigger_parts.into_iter().next().unwrap();
-            let Some(relation) = relation else {
+            let Some(partner_table) = partner_table else {
                 return Err(SchemaError::ParseError(
                     "COMMENT ON TRIGGER missing ON <table> tail".into(),
                 ));
             };
-            let (table_schema, table_name) = extract_qualified_name(relation);
+            let (table_schema, table_name) = extract_qualified_name(partner_table);
             let key = format!("{table_schema}.{table_name}.{trigger_name}");
             push(schema, PendingCommentObjectType::Trigger, key, comment);
         }
@@ -169,7 +169,7 @@ pub(super) fn apply_comment_statement(
         // these via its preprocess-stage scan and turn them into errors
         // under `--strict`.
         CommentObject::Policy => {
-            let target = match relation {
+            let target = match partner_table {
                 Some(rel) => {
                     let (rs, rn) = extract_qualified_name(rel);
                     format!("{object_name} ON {rs}.{rn}")

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1328,7 +1328,7 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
                 object_type,
                 object_name,
                 arguments,
-                relation,
+                table_name,
                 comment,
                 if_exists: _,
             } => {
@@ -1337,7 +1337,7 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
                         object_type,
                         object_name: &object_name,
                         arguments: arguments.as_deref(),
-                        relation: relation.as_ref(),
+                        table_name: table_name.as_ref(),
                         comment,
                     },
                     &mut schema,


### PR DESCRIPTION
## Summary

Bump the `pgmold-sqlparser` dependency from `0.61.1` to `0.62.0`. The 0.62.0 fork release (fmguerreiro/datafusion-sqlparser-rs#32) renames `Statement::Comment.relation` → `table_name` for consistency with sibling AST nodes (`AlterPolicy.table_name`, `CreatePolicy.table_name`, `DropPolicy.table_name`, `AlterTrigger.table_name`).

## Discovered scope

pgmold-293's pre-ship audit concluded the bump would be `Cargo.toml`-only because pgmold matched `Statement::Comment { .. }` (wildcard, no field-name destructure). That audit was stale by the time of the bump:

- Audit recorded: 2026-04-25, before pgmold-273 landed.
- pgmold-273 (commit e860e3d) added a field-name destructure in `src/parser/mod.rs:1327` that bound `relation`.

So in addition to the version-string change, this PR:

1. Updates the `Statement::Comment` destructure in `src/parser/mod.rs` to use the new `table_name` field name.
2. Renames pgmold's internal `CommentStatement.relation` → `table_name` so the internal struct mirrors the upstream AST.
3. Aliases the field to local `partner_table` at the destructure site in `src/parser/comments.rs`, to avoid shadowing the inner `table_name` produced by `extract_qualified_name` in the Trigger arm.

## Files

- `Cargo.toml` — three sites: `[dependencies]`, `[dev-dependencies]`, `[build-dependencies]`. All bumped `0.61.1` → `0.62.0`.
- `Cargo.lock` — `pgmold-sqlparser` entry refreshed to `0.62.0`.
- `src/parser/mod.rs` — `Statement::Comment` destructure + `CommentStatement` constructor.
- `src/parser/comments.rs` — struct field, destructure binding, Trigger arm, Policy arm.

## Test plan

- [ ] CI: build + clippy + tests + fmt all green.
- [ ] CI integration tests still pass against real PostgreSQL (testcontainers): COMMENT ON TRIGGER and COMMENT ON POLICY round-trip continues to surface a partner table where applicable.

Closes pgmold-294.