### PR TITLE
test(parser): pin COMMENT ON tagged dollar / Unicode literal coverage (pgmold-280)

### DIFF
--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -2404,6 +2404,39 @@ fn comment_on_table_accepts_dollar_quoted_literal() {
 }
 
 #[test]
+fn comment_on_table_accepts_tagged_dollar_quoted_literal() {
+    let sql = r#"
+        CREATE TABLE t (id integer PRIMARY KEY);
+        COMMENT ON TABLE t IS $tag$body with $$ inside$tag$;
+    "#;
+    let schema = parse_sql_string(sql).unwrap();
+    let table = schema.tables.get("public.t").unwrap();
+    assert_eq!(table.comment.as_deref(), Some("body with $$ inside"));
+}
+
+#[test]
+fn comment_on_function_accepts_tagged_dollar_quoted_literal() {
+    let sql = r#"
+        CREATE FUNCTION foo() RETURNS void LANGUAGE sql AS $$ SELECT 1 $$;
+        COMMENT ON FUNCTION foo() IS $fn$body with $$ and ' inside$fn$;
+    "#;
+    let schema = parse_sql_string(sql).unwrap();
+    let func = schema.functions.get("public.foo()").unwrap();
+    assert_eq!(func.comment.as_deref(), Some("body with $$ and ' inside"));
+}
+
+#[test]
+fn comment_on_table_accepts_unicode_string_literal() {
+    let sql = r#"
+        CREATE TABLE t (id integer PRIMARY KEY);
+        COMMENT ON TABLE t IS U&'caf\00e9';
+    "#;
+    let schema = parse_sql_string(sql).unwrap();
+    let table = schema.tables.get("public.t").unwrap();
+    assert_eq!(table.comment.as_deref(), Some("café"));
+}
+
+#[test]
 fn comment_on_function_null_clears_comment() {
     let sql = r#"
         CREATE FUNCTION foo() RETURNS void LANGUAGE sql AS $$ SELECT 1 $$;


### PR DESCRIPTION
## Summary

Closes pgmold-280.

pgmold-280 was filed when the regex parser silently dropped tagged dollar-quoted (`$tag$..$tag$`) and Unicode (`U&'..'`) comment bodies. The regex-to-AST migration in pgmold-273 (commit e860e3d) routed COMMENT ON through sqlparser's `parse_literal_string`, which already handles all six literal token types (Single, Double, Escaped, Unicode, DollarQuoted, Word). This PR adds three regression tests pinning the previously-uncovered shapes:

- `comment_on_table_accepts_tagged_dollar_quoted_literal` — `$tag$body$tag$` body containing `$$` that must not terminate early
- `comment_on_function_accepts_tagged_dollar_quoted_literal` — same shape on the function path, with embedded single quote to confirm the dollar-quote tokenizer is taken
- `comment_on_table_accepts_unicode_string_literal` — `U&'caf\00e9'` decoding to `"café"`

## Test plan

- [x] cargo fmt --all clean
- [x] code-simplifier review: CLEAN
- [x] code-reviewer: APPROVED, 0 blockers
- [ ] CI green on the new tests
- [ ] CI green on the rest of the suite (no incidental regressions)