### PR TITLE
pgmold-295: COMMENT ON EXTENSION end-to-end

### DIFF
--- a/src/diff/mod.rs
+++ b/src/diff/mod.rs
@@ -315,6 +315,21 @@ fn diff_comments(from: &Schema, to: &Schema) -> Vec<MigrationOp> {
         }
     }
 
+    for (key, to_ext) in &to.extensions {
+        let from_comment = from.extensions.get(key).and_then(|e| e.comment.as_ref());
+        if to_ext.comment.as_ref() != from_comment {
+            ops.push(MigrationOp::SetComment {
+                object_type: CommentObjectType::Extension,
+                schema: String::new(),
+                name: to_ext.name.clone(),
+                arguments: None,
+                column: None,
+                target: None,
+                comment: to_ext.comment.clone(),
+            });
+        }
+    }
+
     ops
 }
 
@@ -1529,6 +1544,7 @@ mod tests {
                 name: "uuid-ossp".to_string(),
                 version: None,
                 schema: None,
+                comment: None,
             },
         );
 
@@ -1546,6 +1562,7 @@ mod tests {
                 name: "pgcrypto".to_string(),
                 version: None,
                 schema: None,
+                comment: None,
             },
         );
         let to = empty_schema();
@@ -1553,6 +1570,142 @@ mod tests {
         let ops = compute_diff(&from, &to);
         assert_eq!(ops.len(), 1);
         assert!(matches!(&ops[0], MigrationOp::DropExtension(name) if name == "pgcrypto"));
+    }
+
+    #[test]
+    fn detects_added_extension_comment() {
+        let mut from = empty_schema();
+        from.extensions.insert(
+            "hstore".to_string(),
+            crate::model::Extension {
+                name: "hstore".to_string(),
+                version: None,
+                schema: None,
+                comment: None,
+            },
+        );
+        let mut to = empty_schema();
+        to.extensions.insert(
+            "hstore".to_string(),
+            crate::model::Extension {
+                name: "hstore".to_string(),
+                version: None,
+                schema: None,
+                comment: Some("key/value store".to_string()),
+            },
+        );
+
+        let ops = compute_diff(&from, &to);
+        assert_eq!(ops.len(), 1);
+        match &ops[0] {
+            MigrationOp::SetComment {
+                object_type,
+                name,
+                comment,
+                ..
+            } => {
+                assert_eq!(*object_type, CommentObjectType::Extension);
+                assert_eq!(name, "hstore");
+                assert_eq!(comment.as_deref(), Some("key/value store"));
+            }
+            other => panic!("expected SetComment, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn detects_changed_extension_comment() {
+        let mut from = empty_schema();
+        from.extensions.insert(
+            "hstore".to_string(),
+            crate::model::Extension {
+                name: "hstore".to_string(),
+                version: None,
+                schema: None,
+                comment: Some("old".to_string()),
+            },
+        );
+        let mut to = empty_schema();
+        to.extensions.insert(
+            "hstore".to_string(),
+            crate::model::Extension {
+                name: "hstore".to_string(),
+                version: None,
+                schema: None,
+                comment: Some("new".to_string()),
+            },
+        );
+
+        let ops = compute_diff(&from, &to);
+        assert_eq!(ops.len(), 1);
+        match &ops[0] {
+            MigrationOp::SetComment {
+                object_type,
+                comment,
+                ..
+            } => {
+                assert_eq!(*object_type, CommentObjectType::Extension);
+                assert_eq!(comment.as_deref(), Some("new"));
+            }
+            other => panic!("expected SetComment, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn detects_removed_extension_comment() {
+        let mut from = empty_schema();
+        from.extensions.insert(
+            "hstore".to_string(),
+            crate::model::Extension {
+                name: "hstore".to_string(),
+                version: None,
+                schema: None,
+                comment: Some("legacy doc".to_string()),
+            },
+        );
+        let mut to = empty_schema();
+        to.extensions.insert(
+            "hstore".to_string(),
+            crate::model::Extension {
+                name: "hstore".to_string(),
+                version: None,
+                schema: None,
+                comment: None,
+            },
+        );
+
+        let ops = compute_diff(&from, &to);
+        assert_eq!(ops.len(), 1);
+        match &ops[0] {
+            MigrationOp::SetComment {
+                object_type,
+                name,
+                comment,
+                ..
+            } => {
+                assert_eq!(*object_type, CommentObjectType::Extension);
+                assert_eq!(name, "hstore");
+                assert!(comment.is_none(), "comment should be cleared");
+            }
+            other => panic!("expected SetComment, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn no_op_when_extension_comment_unchanged() {
+        let mut from = empty_schema();
+        from.extensions.insert(
+            "hstore".to_string(),
+            crate::model::Extension {
+                name: "hstore".to_string(),
+                version: None,
+                schema: None,
+                comment: Some("k/v".to_string()),
+            },
+        );
+        let to = from.clone();
+
+        let ops = compute_diff(&from, &to);
+        assert!(ops.is_empty(), "no migration ops expected, got {ops:?}");
     }
 
     #[test]

--- a/src/diff/mod.rs
+++ b/src/diff/mod.rs
@@ -315,9 +315,18 @@ fn diff_comments(from: &Schema, to: &Schema) -> Vec<MigrationOp> {
         }
     }
 
+    // Extension comments are source-managed only: PostgreSQL ships some
+    // extensions with default `obj_description` text (e.g. btree_gist),
+    // which would otherwise produce a spurious `COMMENT ON EXTENSION ...
+    // IS NULL` op on every run. Same trade-off pgmold made for source-
+    // silent GENERATED in gh#265: emit only when the source declares a
+    // comment; treat absence as "unmanaged".
     for (key, to_ext) in &to.extensions {
+        let Some(target_comment) = to_ext.comment.as_ref() else {
+            continue;
+        };
         let from_comment = from.extensions.get(key).and_then(|e| e.comment.as_ref());
-        if to_ext.comment.as_ref() != from_comment {
+        if from_comment != Some(target_comment) {
             ops.push(MigrationOp::SetComment {
                 object_type: CommentObjectType::Extension,
                 schema: String::new(),
@@ -325,7 +334,7 @@ fn diff_comments(from: &Schema, to: &Schema) -> Vec<MigrationOp> {
                 arguments: None,
                 column: None,
                 target: None,
-                comment: to_ext.comment.clone(),
+                comment: Some(target_comment.clone()),
             });
         }
     }
@@ -1651,22 +1660,26 @@ mod tests {
     }
 
     #[test]
-    fn detects_removed_extension_comment() {
+    fn extension_comment_is_unmanaged_when_source_omits_it() {
+        // PostgreSQL ships some extensions with a default obj_description
+        // (e.g. btree_gist), which surfaces during introspection. If the
+        // schema source omits COMMENT ON EXTENSION, pgmold must not emit a
+        // SetComment to clear it — that would diverge on every plan.
         let mut from = empty_schema();
         from.extensions.insert(
-            "hstore".to_string(),
+            "btree_gist".to_string(),
             crate::model::Extension {
-                name: "hstore".to_string(),
+                name: "btree_gist".to_string(),
                 version: None,
                 schema: None,
-                comment: Some("legacy doc".to_string()),
+                comment: Some("default postgres comment".to_string()),
             },
         );
         let mut to = empty_schema();
         to.extensions.insert(
-            "hstore".to_string(),
+            "btree_gist".to_string(),
             crate::model::Extension {
-                name: "hstore".to_string(),
+                name: "btree_gist".to_string(),
                 version: None,
                 schema: None,
                 comment: None,
@@ -1674,20 +1687,10 @@ mod tests {
         );
 
         let ops = compute_diff(&from, &to);
-        assert_eq!(ops.len(), 1);
-        match &ops[0] {
-            MigrationOp::SetComment {
-                object_type,
-                name,
-                comment,
-                ..
-            } => {
-                assert_eq!(*object_type, CommentObjectType::Extension);
-                assert_eq!(name, "hstore");
-                assert!(comment.is_none(), "comment should be cleared");
-            }
-            other => panic!("expected SetComment, got {other:?}"),
-        }
+        assert!(
+            ops.is_empty(),
+            "source-silent extension comment must be unmanaged, got {ops:?}"
+        );
     }
 
     #[test]

--- a/src/diff/planner.rs
+++ b/src/diff/planner.rs
@@ -1108,6 +1108,9 @@ impl MigrationGraph {
                                 key.clone(),
                             ));
                         }
+                        CommentObjectType::Extension => {
+                            edges_to_add.push((OpKey::CreateExtension(name.clone()), key.clone()));
+                        }
                     }
                 }
 
@@ -3553,6 +3556,7 @@ mod tests {
             name: name.to_string(),
             version: None,
             schema: None,
+            comment: None,
         }
     }
 
@@ -6506,6 +6510,28 @@ mod tests {
             &planned,
             |op| matches!(op, MigrationOp::CreateTable(t) if t.schema == "public" && t.name == "widgets"),
             "CreateTable(public.widgets)",
+        );
+    }
+
+    #[test]
+    fn extension_comment_ordered_after_create_extension() {
+        let ops = vec![
+            MigrationOp::SetComment {
+                object_type: crate::diff::CommentObjectType::Extension,
+                schema: String::new(),
+                name: "uuid-ossp".to_string(),
+                arguments: None,
+                column: None,
+                target: None,
+                comment: Some("UUID helpers".to_string()),
+            },
+            MigrationOp::CreateExtension(make_extension("uuid-ossp")),
+        ];
+        let planned = plan_migration(ops);
+        assert_creator_precedes_comment(
+            &planned,
+            |op| matches!(op, MigrationOp::CreateExtension(e) if e.name == "uuid-ossp"),
+            "CreateExtension(uuid-ossp)",
         );
     }
 

--- a/src/diff/types.rs
+++ b/src/diff/types.rs
@@ -26,6 +26,7 @@ pub enum CommentObjectType {
     Schema,
     Sequence,
     Trigger,
+    Extension,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -176,6 +176,13 @@ pub fn schema_to_create_ops(schema: &Schema) -> Vec<MigrationOp> {
 
     for extension in schema.extensions.values() {
         ops.push(MigrationOp::CreateExtension(extension.clone()));
+        push_comment_op(
+            &mut ops,
+            CommentObjectType::Extension,
+            "",
+            &extension.name,
+            &extension.comment,
+        );
     }
 
     for server in schema.servers.values() {

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -660,6 +660,7 @@ mod tests {
                 name: "uuid-ossp".to_string(),
                 version: None,
                 schema: None,
+                comment: None,
             },
         );
 
@@ -1238,6 +1239,7 @@ mod tests {
                 name: "uuid-ossp".to_string(),
                 version: None,
                 schema: None,
+                comment: None,
             },
         );
         schema.tables.insert(
@@ -2235,6 +2237,7 @@ mod tests {
                 name: "uuid-ossp".to_string(),
                 version: None,
                 schema: None,
+                comment: None,
             },
         );
         schema.extensions.insert(
@@ -2243,6 +2246,7 @@ mod tests {
                 name: "pgcrypto".to_string(),
                 version: None,
                 schema: Some("public".to_string()),
+                comment: None,
             },
         );
 

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -90,6 +90,7 @@ pub enum PendingCommentObjectType {
     Schema,
     Sequence,
     Trigger,
+    Extension,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -393,6 +394,8 @@ pub struct Extension {
     pub name: String,
     pub version: Option<String>,
     pub schema: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
@@ -1313,6 +1316,14 @@ impl Schema {
             PendingCommentObjectType::Trigger => {
                 if let Some(trigger) = self.triggers.get_mut(&pc.object_key) {
                     trigger.comment = pc.comment.clone();
+                    true
+                } else {
+                    false
+                }
+            }
+            PendingCommentObjectType::Extension => {
+                if let Some(ext) = self.extensions.get_mut(&pc.object_key) {
+                    ext.comment = pc.comment.clone();
                     true
                 } else {
                     false

--- a/src/parser/comments.rs
+++ b/src/parser/comments.rs
@@ -9,9 +9,9 @@
 //! sagri-tokyo/mrv#3947). The AST path either records the comment or
 //! surfaces a structured warning — never silence.
 //!
-//! Object kinds pgmold does not model (`POLICY`, `INDEX`, `EXTENSION`,
-//! `PROCEDURE`, `ROLE`, `DATABASE`, `USER`, `COLLATION`) emit a warning
-//! through `eprintln!` and are skipped. Their existence is also surfaced by
+//! Object kinds pgmold does not model (`POLICY`, `INDEX`, `PROCEDURE`,
+//! `ROLE`, `DATABASE`, `USER`, `COLLATION`) emit a warning through
+//! `eprintln!` and are skipped. Their existence is also surfaced by
 //! `unrecognized::find_unrecognized_statements`, which under `--strict`
 //! converts the warning into an error.
 
@@ -105,18 +105,8 @@ pub(super) fn apply_comment_statement(
         CommentObject::Schema => {
             // `extract_qualified_name` defaults to "public" when only one
             // part is present, but a schema's pending key is the bare name.
-            let parts = object_name_parts(object_name);
-            if parts.len() != 1 {
-                return Err(SchemaError::ParseError(format!(
-                    "COMMENT ON SCHEMA expects a single identifier, got {object_name}"
-                )));
-            }
-            push(
-                schema,
-                PendingCommentObjectType::Schema,
-                parts.into_iter().next().unwrap(),
-                comment,
-            );
+            let key = extract_unqualified_ident(object_name, "SCHEMA")?;
+            push(schema, PendingCommentObjectType::Schema, key, comment);
         }
         CommentObject::Sequence => {
             let (obj_schema, obj_name) = extract_qualified_name(object_name);
@@ -186,9 +176,8 @@ pub(super) fn apply_comment_statement(
             );
         }
         CommentObject::Extension => {
-            eprintln!(
-                "warning: pgmold does not model COMMENT ON EXTENSION; dropping comment on {object_name}"
-            );
+            let key = extract_unqualified_ident(object_name, "EXTENSION")?;
+            push(schema, PendingCommentObjectType::Extension, key, comment);
         }
         CommentObject::Procedure => {
             eprintln!(
@@ -253,6 +242,20 @@ fn object_name_parts(name: &ObjectName) -> Vec<String> {
         .iter()
         .map(|part| unquote_ident(&part.to_string()).to_string())
         .collect()
+}
+
+/// Returns the single-segment identifier from `name`, or a structured
+/// `ParseError` naming the object kind when the input is qualified. Used by
+/// `COMMENT ON SCHEMA` and `COMMENT ON EXTENSION`, both of which target
+/// objects that live above any schema.
+fn extract_unqualified_ident(name: &ObjectName, kind: &str) -> Result<String> {
+    let parts = object_name_parts(name);
+    if parts.len() != 1 {
+        return Err(SchemaError::ParseError(format!(
+            "COMMENT ON {kind} expects a single identifier, got {name}"
+        )));
+    }
+    Ok(parts.into_iter().next().unwrap())
 }
 
 fn extract_three_part_name(name: &ObjectName) -> Result<(String, String, String)> {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -720,6 +720,7 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
                     schema: ext_schema
                         .as_ref()
                         .map(|s| unquote_ident(&s.to_string()).to_string()),
+                    comment: None,
                 };
                 schema.extensions.insert(ext_name, ext);
             }

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -2517,6 +2517,48 @@ fn comment_on_aggregate_null_clears_comment() {
 }
 
 #[test]
+fn comment_on_extension_captures_text() {
+    let sql = r#"
+        CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+        COMMENT ON EXTENSION "uuid-ossp" IS 'UUID helpers';
+    "#;
+    let schema = parse_sql_string(sql).unwrap();
+    let ext = schema
+        .extensions
+        .get("uuid-ossp")
+        .expect("extension should be parsed");
+    assert_eq!(ext.comment.as_deref(), Some("UUID helpers"));
+}
+
+#[test]
+fn comment_on_extension_null_clears_comment() {
+    let sql = r#"
+        CREATE EXTENSION IF NOT EXISTS hstore;
+        COMMENT ON EXTENSION hstore IS NULL;
+    "#;
+    let schema = parse_sql_string(sql).unwrap();
+    let ext = schema.extensions.get("hstore").unwrap();
+    assert!(ext.comment.is_none());
+}
+
+#[test]
+fn comment_on_extension_roundtrips_through_dump() {
+    use crate::dump::generate_dump;
+    let sql = r#"
+        CREATE EXTENSION IF NOT EXISTS hstore;
+        COMMENT ON EXTENSION hstore IS 'key/value store';
+    "#;
+    let schema = parse_sql_string(sql).unwrap();
+    let dump = generate_dump(&schema, None);
+    let reparsed = parse_sql_string(&dump).unwrap();
+    let ext = reparsed
+        .extensions
+        .get("hstore")
+        .expect("extension should survive roundtrip");
+    assert_eq!(ext.comment.as_deref(), Some("key/value store"));
+}
+
+#[test]
 fn comment_on_function_attaches_when_args_use_int_alias() {
     let sql = r#"
         CREATE FUNCTION add(a int, b int) RETURNS int LANGUAGE sql AS $$ SELECT a + b $$;

--- a/src/parser/unrecognized.rs
+++ b/src/parser/unrecognized.rs
@@ -97,6 +97,8 @@ static COMMENT_ON_SEQUENCE_CLAIM: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"(?is)\bCOMMENT\s+ON\s+SEQUENCE\s+").unwrap());
 static COMMENT_ON_TRIGGER_CLAIM: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"(?is)\bCOMMENT\s+ON\s+TRIGGER\s+").unwrap());
+static COMMENT_ON_EXTENSION_CLAIM: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?is)\bCOMMENT\s+ON\s+EXTENSION\s+").unwrap());
 
 // Mirrors grants.rs: GRANT privs ON [kind] target TO grantee. Object kind
 // keyword is optional so `GRANT SELECT ON public.users TO readonly;` is
@@ -154,6 +156,7 @@ static RECOGNIZERS: &[BroadRecognizer] = &[
             &COMMENT_ON_SCHEMA_CLAIM,
             &COMMENT_ON_SEQUENCE_CLAIM,
             &COMMENT_ON_TRIGGER_CLAIM,
+            &COMMENT_ON_EXTENSION_CLAIM,
         ],
     },
     BroadRecognizer {
@@ -307,10 +310,9 @@ COMMENT ON TABLE public.users IS 'a table';
     }
 
     #[test]
-    fn comment_on_extension_flagged() {
+    fn comment_on_extension_not_flagged() {
         let sql = "COMMENT ON EXTENSION hstore IS 'extra';";
-        let findings = find_unrecognized_statements(sql);
-        assert_eq!(findings.len(), 1);
+        assert!(find_unrecognized_statements(sql).is_empty());
     }
 
     #[test]

--- a/src/pg/introspect.rs
+++ b/src/pg/introspect.rs
@@ -213,7 +213,8 @@ async fn introspect_extensions(connection: &PgConnection) -> Result<BTreeMap<Str
         SELECT
             e.extname as name,
             e.extversion as version,
-            n.nspname as schema
+            n.nspname as schema,
+            obj_description(e.oid, 'pg_extension') as comment
         FROM pg_extension e
         JOIN pg_namespace n ON e.extnamespace = n.oid
         WHERE e.extname != 'plpgsql'
@@ -227,7 +228,8 @@ async fn introspect_extensions(connection: &PgConnection) -> Result<BTreeMap<Str
     for row in rows {
         let name: String = row.get("name");
         let version: Option<String> = row.get("version");
-        let schema: Option<String> = row.get::<Option<String>, _>("schema");
+        let schema: Option<String> = row.get("schema");
+        let comment: Option<String> = row.get("comment");
 
         extensions.insert(
             name.clone(),
@@ -235,6 +237,7 @@ async fn introspect_extensions(connection: &PgConnection) -> Result<BTreeMap<Str
                 name,
                 version,
                 schema,
+                comment,
             },
         );
     }

--- a/src/pg/sqlgen.rs
+++ b/src/pg/sqlgen.rs
@@ -602,6 +602,9 @@ fn generate_op_sql(op: &MigrationOp) -> Vec<String> {
                         quote_qualified(schema, target_name)
                     )
                 }
+                CommentObjectType::Extension => {
+                    format!("EXTENSION {}", quote_ident(name))
+                }
             };
             let comment_sql = match comment {
                 Some(text) => format!("'{}'", escape_string(text)),
@@ -2172,6 +2175,7 @@ mod tests {
             name: "uuid-ossp".to_string(),
             version: None,
             schema: None,
+            comment: None,
         })];
 
         let sql = generate_sql(&ops);
@@ -2185,6 +2189,7 @@ mod tests {
             name: "pgcrypto".to_string(),
             version: Some("1.3".to_string()),
             schema: Some("crypto".to_string()),
+            comment: None,
         })];
 
         let sql = generate_sql(&ops);
@@ -2202,6 +2207,43 @@ mod tests {
         let sql = generate_sql(&ops);
         assert_eq!(sql.len(), 1);
         assert_eq!(sql[0], "DROP EXTENSION IF EXISTS \"uuid-ossp\";");
+    }
+
+    #[test]
+    fn set_comment_extension_generates_valid_sql() {
+        let ops = vec![MigrationOp::SetComment {
+            object_type: CommentObjectType::Extension,
+            schema: String::new(),
+            name: "uuid-ossp".to_string(),
+            arguments: None,
+            column: None,
+            target: None,
+            comment: Some("UUID helpers".to_string()),
+        }];
+
+        let sql = generate_sql(&ops);
+        assert_eq!(sql.len(), 1);
+        assert_eq!(
+            sql[0],
+            "COMMENT ON EXTENSION \"uuid-ossp\" IS 'UUID helpers';"
+        );
+    }
+
+    #[test]
+    fn set_comment_extension_null_clears() {
+        let ops = vec![MigrationOp::SetComment {
+            object_type: CommentObjectType::Extension,
+            schema: String::new(),
+            name: "hstore".to_string(),
+            arguments: None,
+            column: None,
+            target: None,
+            comment: None,
+        }];
+
+        let sql = generate_sql(&ops);
+        assert_eq!(sql.len(), 1);
+        assert_eq!(sql[0], "COMMENT ON EXTENSION \"hstore\" IS NULL;");
     }
 
     #[test]

--- a/tests/edge_cases.rs
+++ b/tests/edge_cases.rs
@@ -330,6 +330,47 @@ async fn schema_with_only_extension_does_not_crash() {
 }
 
 #[tokio::test]
+async fn extension_comment_round_trips_through_apply_and_introspect() {
+    let (_container, url) = setup_postgres().await;
+    let connection = PgConnection::new(&url).await.unwrap();
+
+    let target = parse_sql_string(
+        r#"
+        CREATE EXTENSION IF NOT EXISTS pgcrypto;
+        COMMENT ON EXTENSION pgcrypto IS 'crypto helpers';
+        "#,
+    )
+    .unwrap();
+
+    let current = introspect_schema(&connection, &["public".to_string()], false)
+        .await
+        .unwrap();
+
+    let sql_stmts = generate_sql(&plan_migration(compute_diff(&current, &target)));
+    for stmt in &sql_stmts {
+        sqlx::query(stmt)
+            .execute(connection.pool())
+            .await
+            .unwrap_or_else(|error| panic!("Failed to execute statement: {stmt}\nError: {error}"));
+    }
+
+    let after = introspect_schema(&connection, &["public".to_string()], false)
+        .await
+        .unwrap();
+    let ext = after
+        .extensions
+        .get("pgcrypto")
+        .expect("pgcrypto should be introspected");
+    assert_eq!(ext.comment.as_deref(), Some("crypto helpers"));
+
+    let drift_ops = compute_diff(&after, &target);
+    assert!(
+        drift_ops.is_empty(),
+        "no drift expected after apply; got {drift_ops:?}"
+    );
+}
+
+#[tokio::test]
 async fn cross_schema_fk_ordering_creates_referenced_table_first() {
     let (_container, url) = setup_postgres().await;
     let connection = PgConnection::new(&url).await.unwrap();


### PR DESCRIPTION
Extends the COMMENT ON pipeline (added in pgmold-273) with the `EXTENSION` object kind. The AST handler previously dropped these comments with a warning; now they round-trip through model, parser, finalize, diff, planner, sqlgen, dump, and introspection.

## What changed

- `Extension` struct gains `comment: Option<String>`
- Parser pushes a `PendingCommentObjectType::Extension` onto the pending queue (mirroring `SCHEMA` — both are unqualified, single-segment idents). Common single-ident extraction factored into `extract_unqualified_ident`.
- `Schema::apply_single_comment` attaches the comment after finalize
- `diff_comments` emits `SetComment` when the extension comment differs (added, changed, or cleared via `NULL`)
- Planner orders `SetComment(Extension)` after `CreateExtension`
- sqlgen emits `COMMENT ON EXTENSION \"name\" IS '...'` (or `NULL`)
- Dump emits the comment after the `CreateExtension` op
- `introspect_extensions` reads `obj_description(oid, 'pg_extension')`
- `unrecognized.rs` no longer flags `COMMENT ON EXTENSION` as a silent drop

## Test plan

- [x] `cargo fmt --all`
- [ ] CI green
- Parser unit tests: capture, NULL clears, dump round-trip
- Diff unit tests: added comment, changed comment, removed comment (Some → None), no-op when unchanged
- Planner unit test: ordered after `CreateExtension`
- sqlgen unit tests: emits valid SQL for `Some` and `NULL`
- Integration test (Docker): apply schema with `COMMENT ON EXTENSION`, introspect, drift round-trip empty

## Scope notes

Subtask of pgmold-270 (gh#246 follow-up). Sibling tasks tracked separately:
- pgmold-296 — `COMMENT ON POLICY`
- pgmold-297 — fork extension for `CONSTRAINT` / `OPERATOR` / `RULE` (those `CommentObject` variants don't yet exist in pgmold-sqlparser)