### PR TITLE
pgmold-296: COMMENT ON POLICY end-to-end

### DIFF
--- a/src/diff/dependencies.rs
+++ b/src/diff/dependencies.rs
@@ -147,14 +147,36 @@ pub(super) fn generate_policy_ops_for_affected_tables(
                     table: QualifiedName::new(&from_table.schema, &from_table.name),
                     name: policy.name.clone(),
                 });
-                additional_ops.push(MigrationOp::CreatePolicy(
-                    target_policy.unwrap_or(policy).clone(),
-                ));
+                let effective_policy = target_policy.unwrap_or(policy).clone();
+                additional_ops.push(MigrationOp::CreatePolicy(effective_policy.clone()));
+                push_policy_recreate_comment(&mut additional_ops, &effective_policy);
             }
         }
     }
 
     (additional_ops, policies_to_filter)
+}
+
+/// When a policy is dropped+recreated due to a column or function dependency,
+/// PostgreSQL drops the row in `pg_description` along with the policy. The
+/// outer `diff_comments` pass can't notice — it compares source-side comment
+/// text to source-side comment text, both still equal — so the post-apply DB
+/// silently loses the comment until the next plan run. Re-emit `SetComment`
+/// alongside the recreate so the comment survives in lockstep with the
+/// policy.
+fn push_policy_recreate_comment(ops: &mut Vec<MigrationOp>, policy: &Policy) {
+    let Some(comment_text) = policy.comment.as_ref() else {
+        return;
+    };
+    ops.push(MigrationOp::SetComment {
+        object_type: crate::diff::CommentObjectType::Policy,
+        schema: policy.table_schema.clone(),
+        name: policy.name.clone(),
+        arguments: None,
+        column: None,
+        target: Some(policy.table.clone()),
+        comment: Some(comment_text.clone()),
+    });
 }
 
 /// Generate trigger drop/create ops for tables with affected columns (type changes or drops).
@@ -343,9 +365,9 @@ pub(super) fn generate_policy_ops_for_function_changes(
                     table: QualifiedName::new(&table.schema, &table.name),
                     name: policy.name.clone(),
                 });
-                additional_ops.push(MigrationOp::CreatePolicy(
-                    target_policy.unwrap_or(policy).clone(),
-                ));
+                let effective_policy = target_policy.unwrap_or(policy).clone();
+                additional_ops.push(MigrationOp::CreatePolicy(effective_policy.clone()));
+                push_policy_recreate_comment(&mut additional_ops, &effective_policy);
             }
         }
     }
@@ -669,6 +691,7 @@ mod tests {
             roles: vec!["authenticated".to_string()],
             using_expr: Some("id = current_user_id()".to_string()),
             check_expr: None,
+            comment: None,
         });
         from.tables.insert("public.users".to_string(), users_table);
 
@@ -693,6 +716,7 @@ mod tests {
             roles: vec!["authenticated".to_string()],
             using_expr: Some("id = current_user_id()".to_string()),
             check_expr: None,
+            comment: None,
         });
         to.tables
             .insert("public.users".to_string(), users_table_uuid);
@@ -729,6 +753,93 @@ mod tests {
         }
         if let MigrationOp::CreatePolicy(policy) = &create_policy_ops[0] {
             assert_eq!(policy.name, "users_select");
+        }
+    }
+
+    #[test]
+    fn policy_recreate_preserves_source_comment() {
+        // Regression: a column-type change forces DropPolicy+CreatePolicy. The
+        // outer `diff_comments` pass compares source-side comment text on each
+        // side and finds them equal, so it emits nothing. Without an explicit
+        // SetComment alongside the recreate, PostgreSQL silently loses the
+        // policy comment because it's tied to the dropped pg_policy row.
+        let mut from = empty_schema();
+        let mut users_table = simple_table("users");
+        users_table.columns.insert(
+            "id".to_string(),
+            Column {
+                name: "id".to_string(),
+                data_type: PgType::Integer,
+                nullable: false,
+                default: None,
+                comment: None,
+                generated: None,
+            },
+        );
+        users_table.policies.push(Policy {
+            name: "users_select".to_string(),
+            table_schema: "public".to_string(),
+            table: "users".to_string(),
+            command: PolicyCommand::Select,
+            roles: vec!["authenticated".to_string()],
+            using_expr: Some("id = current_user_id()".to_string()),
+            check_expr: None,
+            comment: Some("self-access only".to_string()),
+        });
+        from.tables.insert("public.users".to_string(), users_table);
+
+        let mut to = empty_schema();
+        let mut users_table_uuid = simple_table("users");
+        users_table_uuid.columns.insert(
+            "id".to_string(),
+            Column {
+                name: "id".to_string(),
+                data_type: PgType::Uuid,
+                nullable: false,
+                default: None,
+                comment: None,
+                generated: None,
+            },
+        );
+        users_table_uuid.policies.push(Policy {
+            name: "users_select".to_string(),
+            table_schema: "public".to_string(),
+            table: "users".to_string(),
+            command: PolicyCommand::Select,
+            roles: vec!["authenticated".to_string()],
+            using_expr: Some("id = current_user_id()".to_string()),
+            check_expr: None,
+            comment: Some("self-access only".to_string()),
+        });
+        to.tables
+            .insert("public.users".to_string(), users_table_uuid);
+
+        let ops = compute_diff(&from, &to);
+
+        let create_pos = ops
+            .iter()
+            .position(|op| matches!(op, MigrationOp::CreatePolicy(_)))
+            .expect("CreatePolicy should be emitted on column type change");
+        let comment_pos = ops
+            .iter()
+            .position(|op| {
+                matches!(
+                    op,
+                    MigrationOp::SetComment {
+                        object_type: crate::diff::CommentObjectType::Policy,
+                        ..
+                    }
+                )
+            })
+            .expect("SetComment for the recreated policy must be emitted alongside the recreate");
+        assert!(
+            create_pos < comment_pos,
+            "CreatePolicy must precede SetComment(Policy). create_pos={create_pos}, comment_pos={comment_pos}"
+        );
+
+        if let MigrationOp::SetComment { comment, name, .. } = &ops[comment_pos] {
+            assert_eq!(name, "users_select");
+            assert_eq!(comment.as_deref(), Some("self-access only"));
         }
     }
 
@@ -994,6 +1105,7 @@ mod tests {
             roles: vec!["authenticated".to_string()],
             using_expr: Some("enterprise_id = current_enterprise_id()".to_string()),
             check_expr: None,
+            comment: None,
         });
         from.tables.insert("public.users".to_string(), users_table);
 
@@ -1018,6 +1130,7 @@ mod tests {
             roles: vec!["authenticated".to_string()],
             using_expr: Some("id = current_user_id()".to_string()),
             check_expr: None,
+            comment: None,
         });
         to.tables.insert("public.users".to_string(), users_table_to);
 
@@ -1105,6 +1218,7 @@ mod tests {
             roles: vec!["public".to_string()],
             using_expr: Some("public.check_access()".to_string()),
             check_expr: None,
+            comment: None,
         });
         table.row_level_security = true;
 

--- a/src/diff/mod.rs
+++ b/src/diff/mod.rs
@@ -315,6 +315,33 @@ fn diff_comments(from: &Schema, to: &Schema) -> Vec<MigrationOp> {
         }
     }
 
+    // Policy comments live nested under tables; iterate every (table,
+    // policy) pair on the target side and look up the matching policy on
+    // the source side by name. Policies are entirely user-managed (no
+    // PostgreSQL-shipped defaults), so unlike extensions a normal exact
+    // diff is correct: emit SetComment whenever the target text differs
+    // from the source, including clears.
+    for (key, to_table) in &to.tables {
+        for to_policy in &to_table.policies {
+            let from_comment = from
+                .tables
+                .get(key)
+                .and_then(|t| t.policies.iter().find(|p| p.name == to_policy.name))
+                .and_then(|p| p.comment.as_ref());
+            if to_policy.comment.as_ref() != from_comment {
+                ops.push(MigrationOp::SetComment {
+                    object_type: CommentObjectType::Policy,
+                    schema: to_table.schema.clone(),
+                    name: to_policy.name.clone(),
+                    arguments: None,
+                    column: None,
+                    target: Some(to_table.name.clone()),
+                    comment: to_policy.comment.clone(),
+                });
+            }
+        }
+    }
+
     // Extension comments are source-managed only: PostgreSQL ships some
     // extensions with default `obj_description` text (e.g. btree_gist),
     // which would otherwise produce a spurious `COMMENT ON EXTENSION ...
@@ -1711,6 +1738,115 @@ mod tests {
         assert!(ops.is_empty(), "no migration ops expected, got {ops:?}");
     }
 
+    fn table_with_policy(comment: Option<&str>) -> crate::model::Table {
+        let mut t = simple_table("users");
+        t.row_level_security = true;
+        t.policies.push(crate::model::Policy {
+            name: "p_self".to_string(),
+            table_schema: "public".to_string(),
+            table: "users".to_string(),
+            command: crate::model::PolicyCommand::All,
+            roles: vec!["public".to_string()],
+            using_expr: Some("true".to_string()),
+            check_expr: None,
+            comment: comment.map(|s| s.to_string()),
+        });
+        t
+    }
+
+    #[test]
+    fn detects_added_policy_comment() {
+        let mut from = empty_schema();
+        from.tables
+            .insert("public.users".to_string(), table_with_policy(None));
+        let mut to = empty_schema();
+        to.tables.insert(
+            "public.users".to_string(),
+            table_with_policy(Some("self-access only")),
+        );
+
+        let ops = compute_diff(&from, &to);
+        assert_eq!(ops.len(), 1);
+        match &ops[0] {
+            MigrationOp::SetComment {
+                object_type,
+                schema,
+                name,
+                target,
+                comment,
+                ..
+            } => {
+                assert_eq!(*object_type, CommentObjectType::Policy);
+                assert_eq!(schema, "public");
+                assert_eq!(name, "p_self");
+                assert_eq!(target.as_deref(), Some("users"));
+                assert_eq!(comment.as_deref(), Some("self-access only"));
+            }
+            other => panic!("expected SetComment, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn detects_changed_policy_comment() {
+        let mut from = empty_schema();
+        from.tables
+            .insert("public.users".to_string(), table_with_policy(Some("old")));
+        let mut to = empty_schema();
+        to.tables
+            .insert("public.users".to_string(), table_with_policy(Some("new")));
+
+        let ops = compute_diff(&from, &to);
+        assert_eq!(ops.len(), 1);
+        match &ops[0] {
+            MigrationOp::SetComment {
+                object_type,
+                comment,
+                ..
+            } => {
+                assert_eq!(*object_type, CommentObjectType::Policy);
+                assert_eq!(comment.as_deref(), Some("new"));
+            }
+            other => panic!("expected SetComment, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn detects_cleared_policy_comment() {
+        let mut from = empty_schema();
+        from.tables.insert(
+            "public.users".to_string(),
+            table_with_policy(Some("old comment")),
+        );
+        let mut to = empty_schema();
+        to.tables
+            .insert("public.users".to_string(), table_with_policy(None));
+
+        let ops = compute_diff(&from, &to);
+        assert_eq!(ops.len(), 1);
+        match &ops[0] {
+            MigrationOp::SetComment {
+                object_type,
+                comment,
+                ..
+            } => {
+                assert_eq!(*object_type, CommentObjectType::Policy);
+                assert!(comment.is_none(), "clear should emit None comment");
+            }
+            other => panic!("expected SetComment, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn no_op_when_policy_comment_unchanged() {
+        let mut from = empty_schema();
+        from.tables
+            .insert("public.users".to_string(), table_with_policy(Some("k/v")));
+        let to = from.clone();
+
+        let ops = compute_diff(&from, &to);
+        assert!(ops.is_empty(), "no migration ops expected, got {ops:?}");
+    }
+
     #[test]
     fn detects_added_schema() {
         let from = empty_schema();
@@ -2261,6 +2397,7 @@ mod tests {
             roles: vec!["authenticated".to_string()],
             using_expr: Some("role = 'admin'::TEXT".to_string()),
             check_expr: None,
+            comment: None,
         });
         from.tables.insert("public.users".to_string(), table);
 
@@ -2275,6 +2412,7 @@ mod tests {
             roles: vec!["authenticated".to_string()],
             using_expr: Some("role = 'admin'::text".to_string()),
             check_expr: None,
+            comment: None,
         });
         to.tables.insert("public.users".to_string(), table);
 
@@ -2308,6 +2446,7 @@ mod tests {
                     .to_string(),
             ),
             check_expr: None,
+            comment: None,
         });
         from.tables.insert("public.entities".to_string(), table);
 
@@ -2329,6 +2468,7 @@ mod tests {
                     .to_string(),
             ),
             check_expr: None,
+            comment: None,
         });
         to.tables.insert("public.entities".to_string(), table);
 
@@ -2357,6 +2497,7 @@ mod tests {
                 "(EXISTS ( SELECT 1 FROM user_roles ur WHERE ur.user_id = auth.uid()))".to_string(),
             ),
             check_expr: None,
+            comment: None,
         });
         from.tables.insert("public.users".to_string(), table);
 
@@ -2373,6 +2514,7 @@ mod tests {
                 "(EXISTS (SELECT 1 FROM user_roles ur WHERE ur.user_id = auth.uid()))".to_string(),
             ),
             check_expr: None,
+            comment: None,
         });
         to.tables.insert("public.users".to_string(), table);
 
@@ -2397,6 +2539,7 @@ mod tests {
             roles: vec!["authenticated".to_string()],
             using_expr: Some("(id = 1 )".to_string()),
             check_expr: None,
+            comment: None,
         });
         from.tables.insert("public.users".to_string(), table);
 
@@ -2411,6 +2554,7 @@ mod tests {
             roles: vec!["authenticated".to_string()],
             using_expr: Some("(id = 1)".to_string()),
             check_expr: None,
+            comment: None,
         });
         to.tables.insert("public.users".to_string(), table);
 
@@ -2434,6 +2578,7 @@ mod tests {
             roles: vec!["authenticated".to_string()],
             using_expr: Some("( SELECT auth.is_admin() AS is_admin)".to_string()),
             check_expr: Some("( SELECT auth.is_admin() AS is_admin)".to_string()),
+            comment: None,
         });
         from.tables
             .insert("public.feature_flags".to_string(), table);
@@ -2449,6 +2594,7 @@ mod tests {
             roles: vec!["authenticated".to_string()],
             using_expr: Some("auth.is_admin()".to_string()),
             check_expr: Some("auth.is_admin()".to_string()),
+            comment: None,
         });
         to.tables.insert("public.feature_flags".to_string(), table);
 
@@ -2893,6 +3039,7 @@ CREATE TRIGGER "on_user_role_change" AFTER INSERT OR UPDATE OR DELETE ON "public
             roles: vec!["authenticated".to_string()],
             using_expr: Some("true".to_string()),
             check_expr: None,
+            comment: None,
         }];
         to.tables.insert("public.users".to_string(), table);
 
@@ -3783,6 +3930,7 @@ CREATE TRIGGER "on_user_role_change" AFTER INSERT OR UPDATE OR DELETE ON "public
             roles: vec!["authenticated".to_string()],
             using_expr: Some("old_col IS NOT NULL".to_string()),
             check_expr: None,
+            comment: None,
         });
         from.tables.insert("public.users".to_string(), table);
 
@@ -3800,6 +3948,7 @@ CREATE TRIGGER "on_user_role_change" AFTER INSERT OR UPDATE OR DELETE ON "public
             roles: vec!["authenticated".to_string()],
             using_expr: Some("id IS NOT NULL".to_string()),
             check_expr: None,
+            comment: None,
         });
         to.tables.insert("public.users".to_string(), table_to);
 
@@ -3853,6 +4002,7 @@ CREATE TRIGGER "on_user_role_change" AFTER INSERT OR UPDATE OR DELETE ON "public
             roles: vec!["authenticated".to_string()],
             using_expr: Some("enterprise_id = current_enterprise_id()".to_string()),
             check_expr: None,
+            comment: None,
         });
         from.tables
             .insert("public.suppliers".to_string(), suppliers);
@@ -3882,6 +4032,7 @@ CREATE TRIGGER "on_user_role_change" AFTER INSERT OR UPDATE OR DELETE ON "public
             roles: vec!["authenticated".to_string()],
             using_expr: Some("id IS NOT NULL".to_string()),
             check_expr: None,
+            comment: None,
         });
         to.tables
             .insert("public.suppliers".to_string(), suppliers_to);

--- a/src/diff/planner.rs
+++ b/src/diff/planner.rs
@@ -1111,6 +1111,16 @@ impl MigrationGraph {
                         CommentObjectType::Extension => {
                             edges_to_add.push((OpKey::CreateExtension(name.clone()), key.clone()));
                         }
+                        CommentObjectType::Policy => {
+                            let target_name = require(target, "Policy", "target");
+                            edges_to_add.push((
+                                OpKey::CreatePolicy {
+                                    table: QualifiedName::new(schema, &target_name),
+                                    name: name.clone(),
+                                },
+                                key.clone(),
+                            ));
+                        }
                     }
                 }
 
@@ -1952,6 +1962,7 @@ mod tests {
             roles: vec!["authenticated".to_string()],
             using_expr: Some("id = current_user_id()".to_string()),
             check_expr: None,
+            comment: None,
         };
 
         let ops = vec![
@@ -2132,6 +2143,7 @@ mod tests {
             roles: vec!["authenticated".to_string()],
             using_expr: Some("enterprise_id = current_enterprise_id()".to_string()),
             check_expr: None,
+            comment: None,
         };
 
         let ops = vec![
@@ -3540,6 +3552,7 @@ mod tests {
             roles: vec!["authenticated".to_string()],
             using_expr: Some("true".to_string()),
             check_expr: None,
+            comment: None,
         }
     }
 
@@ -6510,6 +6523,30 @@ mod tests {
             &planned,
             |op| matches!(op, MigrationOp::CreateTable(t) if t.schema == "public" && t.name == "widgets"),
             "CreateTable(public.widgets)",
+        );
+    }
+
+    #[test]
+    fn policy_comment_ordered_after_create_policy() {
+        let policy = make_policy("p_self", "public", "users");
+        let ops = vec![
+            MigrationOp::SetComment {
+                object_type: crate::diff::CommentObjectType::Policy,
+                schema: "public".to_string(),
+                name: "p_self".to_string(),
+                arguments: None,
+                column: None,
+                target: Some("users".to_string()),
+                comment: Some("self-access only".to_string()),
+            },
+            MigrationOp::CreateTable(simple_table_with_fks("users", vec![])),
+            MigrationOp::CreatePolicy(policy),
+        ];
+        let planned = plan_migration(ops);
+        assert_creator_precedes_comment(
+            &planned,
+            |op| matches!(op, MigrationOp::CreatePolicy(p) if p.name == "p_self"),
+            "CreatePolicy(p_self)",
         );
     }
 

--- a/src/diff/types.rs
+++ b/src/diff/types.rs
@@ -27,6 +27,7 @@ pub enum CommentObjectType {
     Sequence,
     Trigger,
     Extension,
+    Policy,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -131,6 +131,26 @@ fn push_trigger_comment_op(
     }
 }
 
+fn push_policy_comment_op(
+    ops: &mut Vec<MigrationOp>,
+    table_schema: &str,
+    policy_name: &str,
+    table_name: &str,
+    comment: &Option<String>,
+) {
+    if let Some(text) = comment {
+        ops.push(MigrationOp::SetComment {
+            object_type: CommentObjectType::Policy,
+            schema: table_schema.to_string(),
+            name: policy_name.to_string(),
+            arguments: None,
+            column: None,
+            target: Some(table_name.to_string()),
+            comment: Some(text.clone()),
+        });
+    }
+}
+
 fn push_owner_and_grant_ops(ops: &mut Vec<MigrationOp>, info: DumpObjectInfo<'_>) {
     if let Some(ref owner) = info.owner {
         push_owner_op(
@@ -282,6 +302,13 @@ pub fn schema_to_create_ops(schema: &Schema) -> Vec<MigrationOp> {
 
         for policy in &table.policies {
             ops.push(MigrationOp::CreatePolicy(policy.clone()));
+            push_policy_comment_op(
+                &mut ops,
+                &table.schema,
+                &policy.name,
+                &table.name,
+                &policy.comment,
+            );
         }
 
         push_grant_ops(

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -1417,6 +1417,7 @@ mod tests {
                 roles: vec!["authenticated".to_string()],
                 using_expr: Some("user_id = current_user_id()".to_string()),
                 check_expr: None,
+                comment: None,
             }],
             partition_by: None,
 
@@ -1531,6 +1532,7 @@ mod tests {
                 roles: vec!["authenticated".to_string()],
                 using_expr: Some("user_id = current_user_id()".to_string()),
                 check_expr: None,
+                comment: None,
             }],
             partition_by: None,
 
@@ -1586,6 +1588,7 @@ mod tests {
                 roles: vec!["authenticated".to_string()],
                 using_expr: Some("user_id = current_user_id()".to_string()),
                 check_expr: None,
+                comment: None,
             }],
             partition_by: None,
 
@@ -1655,6 +1658,7 @@ mod tests {
                 roles: vec!["authenticated".to_string()],
                 using_expr: Some("user_id = current_user_id()".to_string()),
                 check_expr: None,
+                comment: None,
             }],
             partition_by: None,
 

--- a/src/lint/locks.rs
+++ b/src/lint/locks.rs
@@ -621,6 +621,7 @@ mod tests {
             roles: vec!["authenticated".to_string()],
             using_expr: Some("user_id = current_user_id()".to_string()),
             check_expr: None,
+            comment: None,
         })];
         let warnings = detect_lock_hazards(&ops);
 

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -91,6 +91,7 @@ pub enum PendingCommentObjectType {
     Sequence,
     Trigger,
     Extension,
+    Policy,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -500,6 +501,8 @@ pub struct Policy {
     pub roles: Vec<String>,
     pub using_expr: Option<String>,
     pub check_expr: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
@@ -1329,6 +1332,21 @@ impl Schema {
                     false
                 }
             }
+            PendingCommentObjectType::Policy => {
+                // Key encodes schema.table.policy_name. Split off the policy
+                // name (last segment) and resolve the table from the prefix.
+                if let Some((table_key, policy_name)) = pc.object_key.rsplit_once('.') {
+                    if let Some(table) = self.tables.get_mut(table_key) {
+                        if let Some(policy) =
+                            table.policies.iter_mut().find(|p| p.name == policy_name)
+                        {
+                            policy.comment = pc.comment.clone();
+                            return true;
+                        }
+                    }
+                }
+                false
+            }
         }
     }
 
@@ -1747,6 +1765,7 @@ mod tests {
             roles: vec!["authenticated".to_string()],
             using_expr: Some("true".to_string()),
             check_expr: None,
+            comment: None,
         });
         schema
     }
@@ -1834,6 +1853,7 @@ mod tests {
             roles: vec!["authenticated".to_string()],
             using_expr: Some("user_id = current_user_id()".to_string()),
             check_expr: None,
+            comment: None,
         };
         assert_eq!(policy.table_schema, "auth");
     }

--- a/src/parser/comments.rs
+++ b/src/parser/comments.rs
@@ -9,9 +9,9 @@
 //! sagri-tokyo/mrv#3947). The AST path either records the comment or
 //! surfaces a structured warning — never silence.
 //!
-//! Object kinds pgmold does not model (`POLICY`, `INDEX`, `PROCEDURE`,
-//! `ROLE`, `DATABASE`, `USER`, `COLLATION`) emit a warning through
-//! `eprintln!` and are skipped. Their existence is also surfaced by
+//! Object kinds pgmold does not model (`INDEX`, `PROCEDURE`, `ROLE`,
+//! `DATABASE`, `USER`, `COLLATION`) emit a warning through `eprintln!` and
+//! are skipped. Their existence is also surfaced by
 //! `unrecognized::find_unrecognized_statements`, which under `--strict`
 //! converts the warning into an error.
 
@@ -159,16 +159,21 @@ pub(super) fn apply_comment_statement(
         // these via its preprocess-stage scan and turn them into errors
         // under `--strict`.
         CommentObject::Policy => {
-            let target = match partner_table {
-                Some(rel) => {
-                    let (rs, rn) = extract_qualified_name(rel);
-                    format!("{object_name} ON {rs}.{rn}")
-                }
-                None => object_name.to_string(),
+            let policy_parts = object_name_parts(object_name);
+            if policy_parts.len() != 1 {
+                return Err(SchemaError::ParseError(format!(
+                    "COMMENT ON POLICY expects an unqualified policy name, got {object_name}"
+                )));
+            }
+            let policy_name = policy_parts.into_iter().next().unwrap();
+            let Some(partner_table) = partner_table else {
+                return Err(SchemaError::ParseError(
+                    "COMMENT ON POLICY missing ON <table> tail".into(),
+                ));
             };
-            eprintln!(
-                "warning: pgmold does not model COMMENT ON POLICY; dropping comment on {target}"
-            );
+            let (table_schema, table_name) = extract_qualified_name(partner_table);
+            let key = format!("{table_schema}.{table_name}.{policy_name}");
+            push(schema, PendingCommentObjectType::Policy, key, comment);
         }
         CommentObject::Index => {
             eprintln!(

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -230,6 +230,7 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
                     },
                     using_expr: using.as_ref().map(|e: &sqlparser::ast::Expr| normalize_expr(&e.to_string())),
                     check_expr: with_check.as_ref().map(|e: &sqlparser::ast::Expr| normalize_expr(&e.to_string())),
+                    comment: None,
                 };
                 schema.pending_policies.push(policy);
             }

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -2559,6 +2559,71 @@ fn comment_on_extension_roundtrips_through_dump() {
 }
 
 #[test]
+fn comment_on_policy_captures_text() {
+    let sql = r#"
+        CREATE TABLE public.users (id serial);
+        ALTER TABLE public.users ENABLE ROW LEVEL SECURITY;
+        CREATE POLICY p_self ON public.users USING (true);
+        COMMENT ON POLICY p_self ON public.users IS 'self-access only';
+    "#;
+    let schema = parse_sql_string(sql).unwrap();
+    schema
+        .tables
+        .get("public.users")
+        .expect("users should exist")
+        .policies
+        .iter()
+        .find(|p| p.name == "p_self")
+        .map(|p| {
+            assert_eq!(p.comment.as_deref(), Some("self-access only"));
+        })
+        .expect("policy p_self should be parsed");
+}
+
+#[test]
+fn comment_on_policy_null_clears_comment() {
+    let sql = r#"
+        CREATE TABLE public.users (id serial);
+        ALTER TABLE public.users ENABLE ROW LEVEL SECURITY;
+        CREATE POLICY p_self ON public.users USING (true);
+        COMMENT ON POLICY p_self ON public.users IS NULL;
+    "#;
+    let schema = parse_sql_string(sql).unwrap();
+    let policy = schema
+        .tables
+        .get("public.users")
+        .unwrap()
+        .policies
+        .iter()
+        .find(|p| p.name == "p_self")
+        .unwrap();
+    assert!(policy.comment.is_none());
+}
+
+#[test]
+fn comment_on_policy_roundtrips_through_dump() {
+    use crate::dump::generate_dump;
+    let sql = r#"
+        CREATE TABLE public.users (id serial);
+        ALTER TABLE public.users ENABLE ROW LEVEL SECURITY;
+        CREATE POLICY p_self ON public.users USING (true);
+        COMMENT ON POLICY p_self ON public.users IS 'self-access only';
+    "#;
+    let schema = parse_sql_string(sql).unwrap();
+    let dump = generate_dump(&schema, None);
+    let reparsed = parse_sql_string(&dump).unwrap();
+    let policy = reparsed
+        .tables
+        .get("public.users")
+        .expect("users should survive roundtrip")
+        .policies
+        .iter()
+        .find(|p| p.name == "p_self")
+        .expect("policy should survive roundtrip");
+    assert_eq!(policy.comment.as_deref(), Some("self-access only"));
+}
+
+#[test]
 fn comment_on_function_attaches_when_args_use_int_alias() {
     let sql = r#"
         CREATE FUNCTION add(a int, b int) RETURNS int LANGUAGE sql AS $$ SELECT a + b $$;

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -4937,14 +4937,13 @@ CREATE AGGREGATE public.group_concat(text) (
 fn parse_sql_string_with_strict_errors_on_unrecognized() {
     let sql = "\
 CREATE TABLE public.users (id serial);
-CREATE POLICY p ON public.users USING (true);
-COMMENT ON POLICY p ON public.users IS 'policy comment';
+COMMENT ON INDEX public.users_idx IS 'index comment';
 ";
     let result = parse_sql_string_with_strict(sql, true);
     let err = result.expect_err("strict mode should reject unrecognized statements");
     let message = err.to_string();
     assert!(
-        message.contains("COMMENT ON POLICY"),
+        message.contains("COMMENT ON INDEX"),
         "error should mention the offending statement: {message}"
     );
     assert!(

--- a/src/parser/unrecognized.rs
+++ b/src/parser/unrecognized.rs
@@ -418,12 +418,12 @@ END $$;
 
     #[test]
     fn warning_message_includes_line_and_snippet() {
-        let sql = "\n\nCOMMENT ON POLICY p ON public.t IS 'x';";
+        let sql = "\n\nCOMMENT ON INDEX public.idx_foo IS 'x';";
         let finding = find_unrecognized_statements(sql).remove(0);
         let message = finding.warning_message();
         assert!(message.contains("line 3"), "missing line number: {message}");
         assert!(
-            message.contains("COMMENT ON POLICY"),
+            message.contains("COMMENT ON INDEX"),
             "missing snippet: {message}"
         );
     }
@@ -431,7 +431,7 @@ END $$;
     #[test]
     fn multiple_unrecognized_statements_reported() {
         let sql = "\
-COMMENT ON POLICY p ON public.t IS 'a';
+COMMENT ON INDEX public.idx_foo IS 'a';
 ALTER SCHEMA foo OWNER TO bar;
 GRANT role1 TO alice;
 ";

--- a/src/parser/unrecognized.rs
+++ b/src/parser/unrecognized.rs
@@ -99,6 +99,8 @@ static COMMENT_ON_TRIGGER_CLAIM: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"(?is)\bCOMMENT\s+ON\s+TRIGGER\s+").unwrap());
 static COMMENT_ON_EXTENSION_CLAIM: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"(?is)\bCOMMENT\s+ON\s+EXTENSION\s+").unwrap());
+static COMMENT_ON_POLICY_CLAIM: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?is)\bCOMMENT\s+ON\s+POLICY\s+").unwrap());
 
 // Mirrors grants.rs: GRANT privs ON [kind] target TO grantee. Object kind
 // keyword is optional so `GRANT SELECT ON public.users TO readonly;` is
@@ -157,6 +159,7 @@ static RECOGNIZERS: &[BroadRecognizer] = &[
             &COMMENT_ON_SEQUENCE_CLAIM,
             &COMMENT_ON_TRIGGER_CLAIM,
             &COMMENT_ON_EXTENSION_CLAIM,
+            &COMMENT_ON_POLICY_CLAIM,
         ],
     },
     BroadRecognizer {
@@ -251,21 +254,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn comment_on_policy_flagged() {
-        let sql = "\
-CREATE TABLE public.users (id serial);
-CREATE POLICY p ON public.users USING (true);
-COMMENT ON POLICY p ON public.users IS 'policy comment';
-";
-        let findings = find_unrecognized_statements(sql);
-        assert_eq!(findings.len(), 1, "expected one finding: {findings:?}");
-        let finding = &findings[0];
-        assert_eq!(finding.kind, "COMMENT ON");
-        assert_eq!(finding.line, 3);
-        assert!(
-            finding.snippet.contains("COMMENT ON POLICY"),
-            "snippet missing COMMENT ON POLICY: {finding:?}"
-        );
+    fn comment_on_policy_not_flagged() {
+        let sql = "COMMENT ON POLICY p ON public.users IS 'policy comment';";
+        assert!(find_unrecognized_statements(sql).is_empty());
     }
 
     #[test]

--- a/src/pg/introspect.rs
+++ b/src/pg/introspect.rs
@@ -1479,7 +1479,8 @@ async fn introspect_all_policies(
                 ARRAY[]::text[]
             ) as roles,
             pg_get_expr(pol.polqual, pol.polrelid) as using_expr,
-            pg_get_expr(pol.polwithcheck, pol.polrelid) as check_expr
+            pg_get_expr(pol.polwithcheck, pol.polrelid) as check_expr,
+            obj_description(pol.oid, 'pg_policy') as comment
         FROM pg_policy pol
         JOIN pg_class c ON pol.polrelid = c.oid
         JOIN pg_namespace n ON c.relnamespace = n.oid
@@ -1502,6 +1503,7 @@ async fn introspect_all_policies(
         let roles: Vec<String> = row.get("roles");
         let using_expr: Option<String> = row.get("using_expr");
         let check_expr: Option<String> = row.get("check_expr");
+        let comment: Option<String> = row.get("comment");
 
         let roles = if roles.is_empty() {
             vec!["public".to_string()]
@@ -1520,6 +1522,7 @@ async fn introspect_all_policies(
                 roles,
                 using_expr,
                 check_expr,
+                comment,
             });
     }
 

--- a/src/pg/sqlgen.rs
+++ b/src/pg/sqlgen.rs
@@ -605,6 +605,14 @@ fn generate_op_sql(op: &MigrationOp) -> Vec<String> {
                 CommentObjectType::Extension => {
                     format!("EXTENSION {}", quote_ident(name))
                 }
+                CommentObjectType::Policy => {
+                    let target_name = target.as_deref().unwrap_or("");
+                    format!(
+                        "POLICY {} ON {}",
+                        quote_ident(name),
+                        quote_qualified(schema, target_name)
+                    )
+                }
             };
             let comment_sql = match comment {
                 Some(text) => format!("'{}'", escape_string(text)),
@@ -2207,6 +2215,46 @@ mod tests {
         let sql = generate_sql(&ops);
         assert_eq!(sql.len(), 1);
         assert_eq!(sql[0], "DROP EXTENSION IF EXISTS \"uuid-ossp\";");
+    }
+
+    #[test]
+    fn set_comment_policy_generates_valid_sql() {
+        let ops = vec![MigrationOp::SetComment {
+            object_type: CommentObjectType::Policy,
+            schema: "public".to_string(),
+            name: "p_self".to_string(),
+            arguments: None,
+            column: None,
+            target: Some("users".to_string()),
+            comment: Some("self-access only".to_string()),
+        }];
+
+        let sql = generate_sql(&ops);
+        assert_eq!(sql.len(), 1);
+        assert_eq!(
+            sql[0],
+            "COMMENT ON POLICY \"p_self\" ON \"public\".\"users\" IS 'self-access only';"
+        );
+    }
+
+    #[test]
+    fn set_comment_policy_null_clears() {
+        let ops = vec![MigrationOp::SetComment {
+            object_type: CommentObjectType::Policy,
+            schema: "public".to_string(),
+            name: "p_self".to_string(),
+            arguments: None,
+            column: None,
+            target: Some("users".to_string()),
+            comment: None,
+        }];
+
+        let sql = generate_sql(&ops);
+        assert_eq!(sql.len(), 1);
+        assert_eq!(
+            sql[0],
+            "COMMENT ON POLICY \"p_self\" ON \"public\".\"users\" IS NULL;"
+        );
     }
 
     #[test]
@@ -3954,6 +4002,7 @@ mod tests {
             roles: vec!["public".to_string()],
             using_expr: Some("true".to_string()),
             check_expr: None,
+            comment: None,
         })];
 
         let sql = generate_sql(&ops);
@@ -3983,6 +4032,7 @@ mod tests {
             roles: vec!["authenticated".to_string(), "service_role".to_string()],
             using_expr: Some("auth.uid() = user_id".to_string()),
             check_expr: None,
+            comment: None,
         })];
 
         let sql = generate_sql(&ops);

--- a/tests/edge_cases.rs
+++ b/tests/edge_cases.rs
@@ -371,6 +371,53 @@ async fn extension_comment_round_trips_through_apply_and_introspect() {
 }
 
 #[tokio::test]
+async fn policy_comment_round_trips_through_apply_and_introspect() {
+    let (_container, url) = setup_postgres().await;
+    let connection = PgConnection::new(&url).await.unwrap();
+
+    let target = parse_sql_string(
+        r#"
+        CREATE TABLE public.users (id SERIAL PRIMARY KEY);
+        ALTER TABLE public.users ENABLE ROW LEVEL SECURITY;
+        CREATE POLICY p_self ON public.users USING (true);
+        COMMENT ON POLICY p_self ON public.users IS 'self-access only';
+        "#,
+    )
+    .unwrap();
+
+    let current = introspect_schema(&connection, &["public".to_string()], false)
+        .await
+        .unwrap();
+
+    let sql_stmts = generate_sql(&plan_migration(compute_diff(&current, &target)));
+    for stmt in &sql_stmts {
+        sqlx::query(stmt)
+            .execute(connection.pool())
+            .await
+            .unwrap_or_else(|error| panic!("Failed to execute statement: {stmt}\nError: {error}"));
+    }
+
+    let after = introspect_schema(&connection, &["public".to_string()], false)
+        .await
+        .unwrap();
+    let policy = after
+        .tables
+        .get("public.users")
+        .expect("users should be introspected")
+        .policies
+        .iter()
+        .find(|p| p.name == "p_self")
+        .expect("policy p_self should be introspected");
+    assert_eq!(policy.comment.as_deref(), Some("self-access only"));
+
+    let drift_ops = compute_diff(&after, &target);
+    assert!(
+        drift_ops.is_empty(),
+        "no drift expected after apply; got {drift_ops:?}"
+    );
+}
+
+#[tokio::test]
 async fn cross_schema_fk_ordering_creates_referenced_table_first() {
     let (_container, url) = setup_postgres().await;
     let connection = PgConnection::new(&url).await.unwrap();


### PR DESCRIPTION
Closes pgmold-296.

Adds end-to-end support for `COMMENT ON POLICY` (parser, model, diff, planner, sqlgen, dump, introspect, unrecognized claim). Mirrors the structure of pgmold-295 (`COMMENT ON EXTENSION`, #274) for the POLICY object kind.

Subtask of pgmold-270 (gh#246, full COMMENT ON coverage).

## Why

The AST handler added in pgmold-273 routed `COMMENT ON POLICY` to an `eprintln!` drop with a warning. Schema files that include policy comments lost them silently on dump and looked like permanent drift on plan. This PR plugs the last in-tree gap so policies behave like every other commented object.

## What changed

- `model::Policy` gains `comment: Option<String>`.
- `PendingCommentObjectType::Policy` + `apply_single_comment` resolve the policy nested under its table after `finalize()` runs.
- `parser/comments.rs`: the `CommentObject::Policy` arm pushes a `PendingComment` with key `schema.table.policy_name` instead of dropping.
- `diff::CommentObjectType::Policy` and a new loop in `diff_comments` iterating tables × policies, comparing source-side comments. Unlike `Extension` there is no source-silent carve-out — policies are entirely user-managed.
- `planner.rs`: `SetComment(Policy)` orders after `CreatePolicy { table, name }`.
- `pg/sqlgen.rs`: emits `COMMENT ON POLICY "name" ON "schema"."table" IS '...'` (or `NULL`).
- `pg/introspect.rs`: reads `obj_description(pol.oid, 'pg_policy')` into the introspected `Policy`.
- `dump.rs`: a `push_policy_comment_op` helper writes the comment immediately after each `CreatePolicy` in the per-table loop.
- `parser/unrecognized.rs`: `COMMENT_ON_POLICY_CLAIM` is now a recognized claim under the broad `COMMENT ON` regex.

## Recreate-without-losing-comment fix

`diff/dependencies.rs` rebuilds `DropPolicy + CreatePolicy` when a column type changes or when a referenced function is dropped. Without intervention the new policy would have no comment in PostgreSQL because `pg_description` rows die with the dropped policy row, and the outer `diff_comments` pass cannot tell because source-side comment text is unchanged across the recreate. The recreate sites now re-emit `SetComment` alongside `CreatePolicy` when the target policy carries a comment. Pinned by a regression test.

## Test plan

- [x] `parser/tests.rs` — parse `COMMENT ON POLICY ... IS '...'`, parse `... IS NULL`, dump-and-reparse round-trip
- [x] `pg/sqlgen.rs` — `set_comment_policy_generates_valid_sql`, `set_comment_policy_null_clears`
- [x] `diff/mod.rs` — added / changed / cleared / no-op variants of policy-comment diffing
- [x] `diff/planner.rs` — `policy_comment_ordered_after_create_policy` (SetComment lands after CreatePolicy in the topological sort)
- [x] `diff/dependencies.rs` — `policy_recreate_preserves_source_comment` (DropPolicy + CreatePolicy + SetComment when a commented policy is forced to recreate)
- [x] `tests/edge_cases.rs` — `policy_comment_round_trips_through_apply_and_introspect` against a real Postgres container

## Follow-ups

- pgmold-297 — extend the sqlparser fork with `CommentObject::Constraint / Operator / Rule` so the remaining `COMMENT ON ...` kinds in pgmold-270 can be modeled.
- pgmold-298 — pre-existing dot-in-identifier ambiguity in `PendingComment.object_key`. The flat `schema.table.subname` key + `rsplit_once('.')` mis-routes if any segment contains a quoted dot. Affects Column and Trigger today; Policy inherits the same gap. Bulletproof fix is structured fields on `PendingComment`.