### PR TITLE
feat: preserve PostGIS geometry/geography typmod through parse → diff → emit

### DIFF
--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -256,6 +256,12 @@ pub enum PgType {
     Point,
     Xml,
     Vector(Option<u32>),
+    /// PostGIS `geometry` type with optional subtype (e.g. `Polygon`,
+    /// `MultiPolygon`, `Point`) and optional SRID. Both unset means a bare
+    /// `geometry` declaration with no typmod.
+    Geometry(Option<String>, Option<i32>),
+    /// PostGIS `geography` type, mirrors `Geometry`.
+    Geography(Option<String>, Option<i32>),
     Array(Box<PgType>),
     UserDefined(String),
     BuiltinNamed(String),

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -1927,6 +1927,45 @@ embedding_qualified public.vector(768)
 }
 
 #[test]
+fn parse_postgis_geometry_types() {
+    let sql = r#"
+CREATE TABLE shapes (
+id BIGINT NOT NULL PRIMARY KEY,
+g_bare geometry,
+g_polygon geometry(Polygon, 4326),
+g_qualified public.geometry(MultiPolygon, 4326),
+g_subtype_only geometry(Point),
+g_srid_only geometry(4326),
+geo_point geography(Point, 4326)
+);
+"#;
+
+    let schema = parse_sql_string(sql).expect("Should parse");
+    let shapes = &schema.tables["public.shapes"];
+    assert_eq!(shapes.columns["g_bare"].data_type, PgType::Geometry(None, None));
+    assert_eq!(
+        shapes.columns["g_polygon"].data_type,
+        PgType::Geometry(Some("Polygon".to_string()), Some(4326))
+    );
+    assert_eq!(
+        shapes.columns["g_qualified"].data_type,
+        PgType::Geometry(Some("MultiPolygon".to_string()), Some(4326))
+    );
+    assert_eq!(
+        shapes.columns["g_subtype_only"].data_type,
+        PgType::Geometry(Some("Point".to_string()), None)
+    );
+    assert_eq!(
+        shapes.columns["g_srid_only"].data_type,
+        PgType::Geometry(None, Some(4326))
+    );
+    assert_eq!(
+        shapes.columns["geo_point"].data_type,
+        PgType::Geography(Some("Point".to_string()), Some(4326))
+    );
+}
+
+#[test]
 fn real_parses_correctly() {
     let sql = r#"
 CREATE TABLE test (

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -1942,7 +1942,10 @@ geo_point geography(Point, 4326)
 
     let schema = parse_sql_string(sql).expect("Should parse");
     let shapes = &schema.tables["public.shapes"];
-    assert_eq!(shapes.columns["g_bare"].data_type, PgType::Geometry(None, None));
+    assert_eq!(
+        shapes.columns["g_bare"].data_type,
+        PgType::Geometry(None, None)
+    );
     assert_eq!(
         shapes.columns["g_polygon"].data_type,
         PgType::Geometry(Some("Polygon".to_string()), Some(4326))

--- a/src/parser/util.rs
+++ b/src/parser/util.rs
@@ -158,6 +158,14 @@ pub(super) fn parse_data_type(dt: &DataType) -> Result<PgType> {
                     let dimension = modifiers.first().and_then(|m| m.parse::<u32>().ok());
                     return Ok(PgType::Vector(dimension));
                 }
+                "geometry" | "geography" => {
+                    let (subtype, srid) = parse_postgis_modifiers(modifiers);
+                    return Ok(if type_name_lower == "geometry" {
+                        PgType::Geometry(subtype, srid)
+                    } else {
+                        PgType::Geography(subtype, srid)
+                    });
+                }
                 "inet" => return Ok(PgType::Inet),
                 "cidr" => return Ok(PgType::Cidr),
                 "macaddr" => return Ok(PgType::Macaddr),
@@ -195,5 +203,28 @@ pub(super) fn parse_data_type(dt: &DataType) -> Result<PgType> {
         other => Err(SchemaError::ParseError(format!(
             "unsupported column type: {other:?}"
         ))),
+    }
+}
+
+/// Parse PostGIS `geometry`/`geography` modifiers from sqlparser into
+/// `(subtype, srid)`. Accepts `()`, `(<srid>)`, `(<subtype>)`, or
+/// `(<subtype>, <srid>)`. Subtype casing is preserved as written for
+/// round-trip stability with Postgres' `format_type` output.
+fn parse_postgis_modifiers(modifiers: &[String]) -> (Option<String>, Option<i32>) {
+    let cleaned: Vec<String> = modifiers
+        .iter()
+        .map(|m| m.trim().trim_matches('\'').to_string())
+        .filter(|m| !m.is_empty())
+        .collect();
+    match cleaned.as_slice() {
+        [] => (None, None),
+        [single] => match single.parse::<i32>() {
+            Ok(srid) => (None, Some(srid)),
+            Err(_) => (Some(single.clone()), None),
+        },
+        [subtype, srid_text, ..] => {
+            let srid = srid_text.parse::<i32>().ok();
+            (Some(subtype.clone()), srid)
+        }
     }
 }

--- a/src/pg/introspect.rs
+++ b/src/pg/introspect.rs
@@ -794,6 +794,7 @@ async fn introspect_all_columns(
             c.domain_schema,
             c.domain_name,
             a.atttypmod,
+            pg_catalog.format_type(a.atttypid, a.atttypmod) AS pg_format_type,
             a.attgenerated,
             CASE WHEN a.attgenerated = 's'
                  THEN pg_catalog.pg_get_expr(ad.adbin, a.attrelid)
@@ -829,6 +830,7 @@ async fn introspect_all_columns(
         let domain_schema: Option<String> = row.get("domain_schema");
         let domain_name: Option<String> = row.get("domain_name");
         let atttypmod: i32 = row.get("atttypmod");
+        let pg_format_type: String = row.get("pg_format_type");
         let generation_expression: Option<String> = row.get("generation_expression");
 
         let pg_type = match (domain_schema, domain_name) {
@@ -839,6 +841,7 @@ async fn introspect_all_columns(
                 &udt_schema,
                 &udt_name,
                 atttypmod,
+                &pg_format_type,
             )?,
         };
 
@@ -909,6 +912,7 @@ fn map_pg_type(
     udt_schema: &str,
     udt_name: &str,
     atttypmod: i32,
+    pg_format_type: &str,
 ) -> Result<PgType> {
     if udt_schema != "pg_catalog"
         && udt_schema != "information_schema"
@@ -959,6 +963,13 @@ fn map_pg_type(
                     None
                 };
                 Ok(PgType::Vector(dimension))
+            } else if udt_name == "geometry" || udt_name == "geography" {
+                let (subtype, srid) = parse_postgis_format_type(pg_format_type);
+                Ok(if udt_name == "geometry" {
+                    PgType::Geometry(subtype, srid)
+                } else {
+                    PgType::Geography(subtype, srid)
+                })
             } else {
                 Ok(PgType::UserDefined(format!("{udt_schema}.{udt_name}")))
             }
@@ -981,6 +992,37 @@ fn map_pg_type(
 
 fn map_domain_element_type(base_udt: &str, domain_schema: &str) -> PgType {
     map_udt_name_to_pg_type(base_udt, domain_schema, None)
+}
+
+/// Parse Postgres' `format_type(atttypid, atttypmod)` output for PostGIS
+/// columns. Returns `(subtype, srid)` extracted from forms like
+/// `geometry`, `geometry(4326)`, `geometry(Polygon)`, `geometry(Polygon,4326)`.
+/// Subtype casing is preserved as Postgres reports it (e.g. `Polygon`).
+fn parse_postgis_format_type(format_type: &str) -> (Option<String>, Option<i32>) {
+    let open = match format_type.find('(') {
+        Some(idx) => idx,
+        None => return (None, None),
+    };
+    let close = match format_type.rfind(')') {
+        Some(idx) => idx,
+        None => return (None, None),
+    };
+    if close <= open + 1 {
+        return (None, None);
+    }
+    let inside = &format_type[open + 1..close];
+    let parts: Vec<&str> = inside.split(',').map(|s| s.trim()).collect();
+    match parts.as_slice() {
+        [single] => match single.parse::<i32>() {
+            Ok(srid) => (None, Some(srid)),
+            Err(_) => (Some((*single).to_string()), None),
+        },
+        [subtype, srid_text, ..] => {
+            let srid = srid_text.parse::<i32>().ok();
+            (Some((*subtype).to_string()), srid)
+        }
+        _ => (None, None),
+    }
 }
 
 async fn introspect_all_primary_keys(
@@ -2807,7 +2849,8 @@ mod tests {
 
     #[test]
     fn map_pg_type_domain_based_on_numeric_returns_user_defined() {
-        let result = map_pg_type("numeric", None, "public", "positive_money", -1).unwrap();
+        let result =
+            map_pg_type("numeric", None, "public", "positive_money", -1, "numeric").unwrap();
         assert_eq!(
             result,
             PgType::UserDefined("public.positive_money".to_string())
@@ -2816,7 +2859,7 @@ mod tests {
 
     #[test]
     fn map_pg_type_domain_based_on_text_returns_user_defined() {
-        let result = map_pg_type("text", None, "public", "email_address", -1).unwrap();
+        let result = map_pg_type("text", None, "public", "email_address", -1, "text").unwrap();
         assert_eq!(
             result,
             PgType::UserDefined("public.email_address".to_string())
@@ -2825,14 +2868,55 @@ mod tests {
 
     #[test]
     fn map_pg_type_builtin_numeric_stays_builtin() {
-        let result = map_pg_type("numeric", None, "pg_catalog", "numeric", -1).unwrap();
+        let result = map_pg_type("numeric", None, "pg_catalog", "numeric", -1, "numeric").unwrap();
         assert_eq!(result, PgType::BuiltinNamed("numeric".to_string()));
     }
 
     #[test]
     fn map_pg_type_builtin_text_stays_builtin() {
-        let result = map_pg_type("text", None, "pg_catalog", "text", -1).unwrap();
+        let result = map_pg_type("text", None, "pg_catalog", "text", -1, "text").unwrap();
         assert_eq!(result, PgType::Text);
+    }
+
+    #[test]
+    fn map_pg_type_postgis_geometry_with_subtype_and_srid() {
+        let result = map_pg_type(
+            "USER-DEFINED",
+            None,
+            "public",
+            "geometry",
+            0,
+            "geometry(Polygon,4326)",
+        )
+        .unwrap();
+        assert_eq!(
+            result,
+            PgType::Geometry(Some("Polygon".to_string()), Some(4326))
+        );
+    }
+
+    #[test]
+    fn map_pg_type_postgis_geometry_bare_returns_no_typmod() {
+        let result =
+            map_pg_type("USER-DEFINED", None, "public", "geometry", -1, "geometry").unwrap();
+        assert_eq!(result, PgType::Geometry(None, None));
+    }
+
+    #[test]
+    fn map_pg_type_postgis_geography_point_with_srid() {
+        let result = map_pg_type(
+            "USER-DEFINED",
+            None,
+            "public",
+            "geography",
+            0,
+            "geography(Point,4326)",
+        )
+        .unwrap();
+        assert_eq!(
+            result,
+            PgType::Geography(Some("Point".to_string()), Some(4326))
+        );
     }
 
     #[test]

--- a/src/pg/sqlgen.rs
+++ b/src/pg/sqlgen.rs
@@ -1010,6 +1010,8 @@ fn format_pg_type(pg_type: &PgType) -> String {
         PgType::Xml => "XML".to_string(),
         PgType::Vector(Some(dim)) => format!("vector({dim})"),
         PgType::Vector(None) => "vector".to_string(),
+        PgType::Geometry(subtype, srid) => format_postgis("geometry", subtype.as_deref(), *srid),
+        PgType::Geography(subtype, srid) => format_postgis("geography", subtype.as_deref(), *srid),
         PgType::Array(inner) => format!("{}[]", format_pg_type(inner)),
         PgType::UserDefined(name) => {
             let (schema, enum_name) = parse_qualified_name(name);
@@ -1023,6 +1025,15 @@ fn format_pg_type(pg_type: &PgType) -> String {
                 name.to_uppercase()
             }
         }
+    }
+}
+
+fn format_postgis(name: &str, subtype: Option<&str>, srid: Option<i32>) -> String {
+    match (subtype, srid) {
+        (None, None) => name.to_string(),
+        (Some(s), None) => format!("{name}({s})"),
+        (None, Some(srid)) => format!("{name}({srid})"),
+        (Some(s), Some(srid)) => format!("{name}({s}, {srid})"),
     }
 }
 
@@ -1744,6 +1755,27 @@ mod tests {
     use super::*;
     use crate::model::{EnumType, PrimaryKey, QualifiedName};
     use std::collections::BTreeMap;
+
+    #[test]
+    fn format_pg_type_postgis_geometry_emits_typmod() {
+        assert_eq!(
+            format_pg_type(&PgType::Geometry(Some("Polygon".into()), Some(4326))),
+            "geometry(Polygon, 4326)"
+        );
+        assert_eq!(format_pg_type(&PgType::Geometry(None, None)), "geometry");
+        assert_eq!(
+            format_pg_type(&PgType::Geometry(Some("Point".into()), None)),
+            "geometry(Point)"
+        );
+        assert_eq!(
+            format_pg_type(&PgType::Geometry(None, Some(4326))),
+            "geometry(4326)"
+        );
+        assert_eq!(
+            format_pg_type(&PgType::Geography(Some("Point".into()), Some(4326))),
+            "geography(Point, 4326)"
+        );
+    }
 
     #[test]
     fn create_enum_generates_valid_sql() {

--- a/tests/postgis.rs
+++ b/tests/postgis.rs
@@ -1,0 +1,137 @@
+//! Integration tests for PostGIS `geometry`/`geography` typmod handling.
+//!
+//! Uses the official `postgis/postgis` image instead of the default postgres
+//! image so the `geometry` type and `format_type()` output are real.
+
+mod common;
+use common::*;
+
+use testcontainers_modules::postgres::Postgres as PostgresImage;
+
+async fn setup_postgis() -> (
+    testcontainers::ContainerAsync<PostgresImage>,
+    String,
+) {
+    let container = PostgresImage::default()
+        .with_name("postgis/postgis")
+        .with_tag("16-3.4")
+        .start()
+        .await
+        .expect("postgis container should start");
+    let port = container.get_host_port_ipv4(5432).await.unwrap();
+    let url = format!("postgres://postgres:postgres@localhost:{port}/postgres");
+    (container, url)
+}
+
+#[tokio::test]
+async fn introspect_postgis_geometry_typmod_round_trips() {
+    let (_container, url) = setup_postgis().await;
+    let connection = PgConnection::new(&url).await.unwrap();
+
+    sqlx::query("CREATE EXTENSION IF NOT EXISTS postgis")
+        .execute(connection.pool())
+        .await
+        .unwrap();
+
+    sqlx::query(
+        r#"
+        CREATE TABLE shapes (
+            id BIGINT PRIMARY KEY,
+            g_polygon public.geometry(Polygon, 4326),
+            g_multipolygon public.geometry(MultiPolygon, 4326),
+            g_point public.geometry(Point, 4326),
+            g_bare public.geometry,
+            geo_point public.geography(Point, 4326)
+        )
+        "#,
+    )
+    .execute(connection.pool())
+    .await
+    .unwrap();
+
+    let schema = introspect_schema(&connection, &["public".to_string()], false)
+        .await
+        .unwrap();
+
+    let table = schema
+        .tables
+        .get("public.shapes")
+        .expect("shapes table should be introspected");
+
+    assert_eq!(
+        table.columns["g_polygon"].data_type,
+        pgmold::model::PgType::Geometry(Some("Polygon".to_string()), Some(4326))
+    );
+    assert_eq!(
+        table.columns["g_multipolygon"].data_type,
+        pgmold::model::PgType::Geometry(Some("MultiPolygon".to_string()), Some(4326))
+    );
+    assert_eq!(
+        table.columns["g_point"].data_type,
+        pgmold::model::PgType::Geometry(Some("Point".to_string()), Some(4326))
+    );
+    assert_eq!(
+        table.columns["g_bare"].data_type,
+        pgmold::model::PgType::Geometry(None, None)
+    );
+    assert_eq!(
+        table.columns["geo_point"].data_type,
+        pgmold::model::PgType::Geography(Some("Point".to_string()), Some(4326))
+    );
+}
+
+#[tokio::test]
+async fn create_table_with_geometry_typmod_introspects_back_to_source() {
+    use pgmold::parser::parse_sql_string;
+    use pgmold::pg::sqlgen::generate_sql;
+    use pgmold::diff::{compute_diff, planner::plan_migration};
+
+    let (_container, url) = setup_postgis().await;
+    let connection = PgConnection::new(&url).await.unwrap();
+
+    sqlx::query("CREATE EXTENSION IF NOT EXISTS postgis")
+        .execute(connection.pool())
+        .await
+        .unwrap();
+
+    let sql = r#"
+        CREATE TABLE mrv_polygon (
+            id BIGINT PRIMARY KEY,
+            geometry public.geometry(Polygon, 4326)
+        );
+    "#;
+
+    let source_schema = parse_sql_string(sql).expect("source SQL parses");
+    let empty = pgmold::model::Schema::default();
+    let diff = compute_diff(&empty, &source_schema);
+    let plan = plan_migration(diff);
+    let statements = generate_sql(&plan);
+
+    let create_table_stmt = statements
+        .iter()
+        .find(|s| s.contains("CREATE TABLE") && s.contains("mrv_polygon"))
+        .expect("plan should include a CREATE TABLE for mrv_polygon");
+    assert!(
+        create_table_stmt.contains("geometry(Polygon, 4326)"),
+        "CREATE TABLE must preserve PostGIS typmod, got: {create_table_stmt}"
+    );
+
+    sqlx::query(create_table_stmt)
+        .execute(connection.pool())
+        .await
+        .unwrap();
+
+    let after = introspect_schema(&connection, &["public".to_string()], false)
+        .await
+        .unwrap();
+    let table = after
+        .tables
+        .get("public.mrv_polygon")
+        .expect("table exists after apply");
+
+    assert_eq!(
+        table.columns["geometry"].data_type,
+        pgmold::model::PgType::Geometry(Some("Polygon".to_string()), Some(4326)),
+        "typmod must round-trip from source SQL through pgmold to the database"
+    );
+}

--- a/tests/postgis.rs
+++ b/tests/postgis.rs
@@ -8,10 +8,7 @@ use common::*;
 
 use testcontainers_modules::postgres::Postgres as PostgresImage;
 
-async fn setup_postgis() -> (
-    testcontainers::ContainerAsync<PostgresImage>,
-    String,
-) {
+async fn setup_postgis() -> (testcontainers::ContainerAsync<PostgresImage>, String) {
     let container = PostgresImage::default()
         .with_name("postgis/postgis")
         .with_tag("16-3.4")
@@ -82,9 +79,9 @@ async fn introspect_postgis_geometry_typmod_round_trips() {
 
 #[tokio::test]
 async fn create_table_with_geometry_typmod_introspects_back_to_source() {
+    use pgmold::diff::{compute_diff, planner::plan_migration};
     use pgmold::parser::parse_sql_string;
     use pgmold::pg::sqlgen::generate_sql;
-    use pgmold::diff::{compute_diff, planner::plan_migration};
 
     let (_container, url) = setup_postgis().await;
     let connection = PgConnection::new(&url).await.unwrap();


### PR DESCRIPTION
## Problem

PostGIS columns declared as `geometry(Polygon, 4326)` (or `geography(Point, 4326)`) lose their subtype and SRID modifiers when round-tripped through pgmold:

- The parser sweeps them into `PgType::UserDefined(\"public.geometry\")` (the catch-all branch in `parse_data_type`).
- The emitter regenerates bare `geometry`.
- Introspection has no way to recover the typmod from the live database.

As a result, `pgmold apply` against a fresh database creates the column as untyped `geometry`, and downstream tools that depend on the typmod silently regress. Concrete example: PostGraphile's `@graphile/postgis` plugin emits the abstract `GeometryInterface` for untyped columns and the concrete `GeometryPolygon` only when the column carries a typmod. With pgmold-managed schemas, the column is always untyped at apply time, so PostGraphile can never produce the concrete type.

## Change

Models PostGIS types as first-class variants in the canonical schema:

- New `PgType::Geometry(Option<String>, Option<i32>)` and `PgType::Geography(Option<String>, Option<i32>)` variants, parallel to `PgType::Vector`.
- Parser recognises `geometry`/`geography` (with optional `public.` prefix) in `DataType::Custom` and parses subtype + SRID from the modifiers. Accepts:
  - `geometry`
  - `geometry(<srid>)`
  - `geometry(<subtype>)`
  - `geometry(<subtype>, <srid>)`
- Sqlgen emits the typmod back in canonical form so plans round-trip.
- Introspection joins `pg_catalog.format_type(atttypid, atttypmod)` into the column query and parses its output for PostGIS columns. Subtype casing is preserved as Postgres reports it (`Polygon`, not `polygon`).

## Tests

- Parser: `parse_postgis_geometry_types` covers all four modifier shapes plus `geography`.
- Emitter: `format_pg_type_postgis_geometry_emits_typmod` pins canonical output.
- Introspection: three `map_pg_type_postgis_*` unit tests exercising the format_type parser.
- Integration (`tests/postgis.rs`): uses `postgis/postgis:16-3.4` to exercise the full round-trip — source SQL → plan → DDL execution → introspect → typed `PgType::Geometry`.

All 1247 lib tests pass; both new integration tests pass against a real PostGIS container.

## Behaviour for existing schemas

- Pre-existing schemas that used `public.geometry` (untyped) continue to round-trip as `PgType::Geometry(None, None)` and emit bare `geometry`.
- Schemas declaring `geometry(Polygon, 4326)` will now produce a non-empty diff against any database where pgmold previously stripped the typmod. The diff resolves with a single `ALTER COLUMN ... TYPE geometry(Polygon, 4326)` and is no-op once applied.

## Related

Discovered while debugging a PostGraphile resolveType failure in a downstream project — fresh CI databases produced untyped columns, but staging (where the column had previously been ALTERed to a typed form) worked. Root cause traced to the parser → emitter chain in this PR.