### PR TITLE
pgmold-297: bump pgmold-sqlparser to 0.63.0 + absorb new COMMENT ON kinds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["command-line-utilities", "database"]
 clap = { version = "4.5", features = ["derive", "env"] }
 tokio = { version = "1.35", features = ["full"] }
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres"] }
-sqlparser = { package = "pgmold-sqlparser", version = "0.62.0", features = ["visitor"] }
+sqlparser = { package = "pgmold-sqlparser", version = "0.63.0", features = ["visitor"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 anyhow = "1.0"
@@ -37,11 +37,11 @@ sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres"] }
 tokio = { version = "1.35", features = ["full"] }
 assert_cmd = "2"
 criterion = { version = "0.5", features = ["html_reports"] }
-sqlparser = { package = "pgmold-sqlparser", version = "0.62.0", features = ["visitor"] }
+sqlparser = { package = "pgmold-sqlparser", version = "0.63.0", features = ["visitor"] }
 
 [[bench]]
 name = "performance"
 harness = false
 
 [build-dependencies]
-sqlparser = { package = "pgmold-sqlparser", version = "0.62.0", features = ["visitor"] }
+sqlparser = { package = "pgmold-sqlparser", version = "0.63.0", features = ["visitor"] }

--- a/src/parser/comments.rs
+++ b/src/parser/comments.rs
@@ -157,7 +157,36 @@ pub(super) fn apply_comment_statement(
         // Object kinds pgmold does not model. Surface a warning so the
         // statement is not silently lost; `unrecognized.rs` will also flag
         // these via its preprocess-stage scan and turn them into errors
-        // under `--strict`.
+        // under `--strict`. Per-kind modeling lands in subtasks of pgmold-270.
+        CommentObject::Constraint => {
+            let target = match partner_table {
+                Some(rel) => {
+                    let (rs, rn) = extract_qualified_name(rel);
+                    format!("{object_name} ON {rs}.{rn}")
+                }
+                None => object_name.to_string(),
+            };
+            eprintln!(
+                "warning: pgmold does not model COMMENT ON CONSTRAINT; dropping comment on {target}"
+            );
+        }
+        CommentObject::Operator => {
+            eprintln!(
+                "warning: pgmold does not model COMMENT ON OPERATOR; dropping comment on {object_name}"
+            );
+        }
+        CommentObject::Rule => {
+            let target = match partner_table {
+                Some(rel) => {
+                    let (rs, rn) = extract_qualified_name(rel);
+                    format!("{object_name} ON {rs}.{rn}")
+                }
+                None => object_name.to_string(),
+            };
+            eprintln!(
+                "warning: pgmold does not model COMMENT ON RULE; dropping comment on {target}"
+            );
+        }
         CommentObject::Policy => {
             let policy_parts = object_name_parts(object_name);
             if policy_parts.len() != 1 {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1330,7 +1330,9 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
                 object_type,
                 object_name,
                 arguments,
+                operator_args: _,
                 table_name,
+                on_domain: _,
                 comment,
                 if_exists: _,
             } => {

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -4970,6 +4970,45 @@ COMMENT ON POLICY p ON public.users IS 'x';
 }
 
 #[test]
+fn comment_on_constraint_parses_without_error_table_form() {
+    let sql = "\
+CREATE TABLE public.orders (id serial, total numeric CHECK (total > 0));
+COMMENT ON CONSTRAINT orders_total_check ON public.orders IS 'must be positive';
+";
+    parse_sql_string(sql).expect("COMMENT ON CONSTRAINT should parse");
+}
+
+#[test]
+fn comment_on_constraint_parses_without_error_domain_form() {
+    let sql = "\
+CREATE DOMAIN public.email AS text CHECK (VALUE LIKE '%@%');
+COMMENT ON CONSTRAINT email_check ON DOMAIN public.email IS 'rough shape';
+";
+    parse_sql_string(sql).expect("COMMENT ON CONSTRAINT ON DOMAIN should parse");
+}
+
+#[test]
+fn comment_on_operator_parses_without_error() {
+    let sql = "COMMENT ON OPERATOR public.+(integer, integer) IS 'integer addition';";
+    parse_sql_string(sql).expect("COMMENT ON OPERATOR should parse");
+}
+
+#[test]
+fn comment_on_operator_unary_none_parses_without_error() {
+    let sql = "COMMENT ON OPERATOR -(NONE, integer) IS 'unary minus';";
+    parse_sql_string(sql).expect("COMMENT ON OPERATOR with NONE slot should parse");
+}
+
+#[test]
+fn comment_on_rule_parses_without_error() {
+    let sql = "\
+CREATE TABLE public.orders (id serial);
+COMMENT ON RULE notify_me ON public.orders IS 'rewrite rule';
+";
+    parse_sql_string(sql).expect("COMMENT ON RULE should parse");
+}
+
+#[test]
 fn alter_aggregate_owner_records_pending_owner() {
     let sql = r#"
 CREATE AGGREGATE public.group_concat(text) (


### PR DESCRIPTION
## Summary

Bumps `pgmold-sqlparser` to `0.63.0` (just published) which adds parser coverage for three previously-rejected `COMMENT ON …` shapes:

- `COMMENT ON CONSTRAINT name ON [DOMAIN] target IS '…'`
- `COMMENT ON OPERATOR name (left, right) IS '…'` — each side may be `NONE` for unary ops
- `COMMENT ON RULE name ON target IS '…'`

The 0.63.0 release also adds two new fields to `Statement::Comment`:
- `operator_args: Option<CommentOperatorArgs>` (operand types for `OPERATOR`)
- `on_domain: bool` (set when `CONSTRAINT … ON DOMAIN` was parsed)

## Changes

- `Cargo.toml` — bump dep to `0.63.0` across `[dependencies]`, `[dev-dependencies]`, `[build-dependencies]`.
- `src/parser/mod.rs` — extend the `Statement::Comment` destructure with `operator_args: _` and `on_domain: _` so the file compiles.
- `src/parser/comments.rs` — add `Constraint` / `Operator` / `Rule` arms in `apply_comment_statement`, emitting the existing warn-and-drop pattern (matches `Index`/`Procedure`/`Role`/`Database`/`User`/`Collation`). The `Constraint` and `Rule` warnings include the partner relation so users can locate the source.
- `src/parser/tests.rs` — 5 smoke tests confirming `parse_sql_string` does not error on the new shapes.

## Behavior change

Previously these three forms produced a hard parser error from sqlparser. They now parse-succeed, emit a stderr warning, and are dropped. `unrecognized.rs` still flags them via its preprocess scan, so `--strict` users continue to get a hard error until the per-kind modeling subtasks land.

## Follow-ups (filed in beads, not in scope here)

- `pgmold-298` — pending-comment keys assume no dots in schema/table/object names (parent-task scope check)
- `pgmold-299` — fork: harden `parse_operator_name` against EOF / missing operator name
- `pgmold-300` — fork: model COMMENT-ON-CONSTRAINT target as enum instead of `(table_name, on_domain: bool)`
- per-kind modeling subtasks of `pgmold-270` will translate the warnings into real schema state

## Test plan

- [ ] CI: `cargo test --all` (relies on 0.63.0 from crates.io)
- [x] `comment_on_constraint_parses_without_error_table_form`
- [x] `comment_on_constraint_parses_without_error_domain_form`
- [x] `comment_on_operator_parses_without_error`
- [x] `comment_on_operator_unary_none_parses_without_error`
- [x] `comment_on_rule_parses_without_error`

Closes pgmold-297.