### PR TITLE
chore: bump version to 0.34.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1587,7 +1587,7 @@ dependencies = [
 
 [[package]]
 name = "pgmold"
-version = "0.34.8"
+version = "0.34.9"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "pgmold"
-version = "0.34.8"
+version = "0.34.9"
 edition = "2021"
 exclude = [".auto-claude/", ".auto-claude-security.json", ".claude_settings.json"]
 description = "PostgreSQL schema-as-code management tool"


### PR DESCRIPTION
Release bundle for #276 (PostGIS geometry/geography typmod preservation). Tag will be created on merge.