### PR TITLE
pgmold-301: COMMENT ON CONSTRAINT end-to-end

### DIFF
--- a/src/diff/dependencies.rs
+++ b/src/diff/dependencies.rs
@@ -175,6 +175,7 @@ fn push_policy_recreate_comment(ops: &mut Vec<MigrationOp>, policy: &Policy) {
         arguments: None,
         column: None,
         target: Some(policy.table.clone()),
+        on_domain: false,
         comment: Some(comment_text.clone()),
     });
 }

--- a/src/diff/mod.rs
+++ b/src/diff/mod.rs
@@ -180,6 +180,7 @@ fn diff_comments(from: &Schema, to: &Schema) -> Vec<MigrationOp> {
                 arguments: None,
                 column: None,
                 target: None,
+                on_domain: false,
                 comment: to_table.comment.clone(),
             });
         }
@@ -198,6 +199,7 @@ fn diff_comments(from: &Schema, to: &Schema) -> Vec<MigrationOp> {
                     arguments: None,
                     column: Some(col_name.clone()),
                     target: None,
+                    on_domain: false,
                     comment: to_col.comment.clone(),
                 });
             }
@@ -215,6 +217,7 @@ fn diff_comments(from: &Schema, to: &Schema) -> Vec<MigrationOp> {
                 arguments: Some(to_func.args_string()),
                 column: None,
                 target: None,
+                on_domain: false,
                 comment: to_func.comment.clone(),
             });
         }
@@ -235,6 +238,7 @@ fn diff_comments(from: &Schema, to: &Schema) -> Vec<MigrationOp> {
                 arguments: None,
                 column: None,
                 target: None,
+                on_domain: false,
                 comment: to_view.comment.clone(),
             });
         }
@@ -250,6 +254,7 @@ fn diff_comments(from: &Schema, to: &Schema) -> Vec<MigrationOp> {
                 arguments: None,
                 column: None,
                 target: None,
+                on_domain: false,
                 comment: to_enum.comment.clone(),
             });
         }
@@ -265,6 +270,7 @@ fn diff_comments(from: &Schema, to: &Schema) -> Vec<MigrationOp> {
                 arguments: None,
                 column: None,
                 target: None,
+                on_domain: false,
                 comment: to_domain.comment.clone(),
             });
         }
@@ -280,6 +286,7 @@ fn diff_comments(from: &Schema, to: &Schema) -> Vec<MigrationOp> {
                 arguments: None,
                 column: None,
                 target: None,
+                on_domain: false,
                 comment: to_schema.comment.clone(),
             });
         }
@@ -295,6 +302,7 @@ fn diff_comments(from: &Schema, to: &Schema) -> Vec<MigrationOp> {
                 arguments: None,
                 column: None,
                 target: None,
+                on_domain: false,
                 comment: to_seq.comment.clone(),
             });
         }
@@ -310,6 +318,7 @@ fn diff_comments(from: &Schema, to: &Schema) -> Vec<MigrationOp> {
                 arguments: None,
                 column: None,
                 target: Some(to_trigger.target_name.clone()),
+                on_domain: false,
                 comment: to_trigger.comment.clone(),
             });
         }
@@ -336,6 +345,7 @@ fn diff_comments(from: &Schema, to: &Schema) -> Vec<MigrationOp> {
                     arguments: None,
                     column: None,
                     target: Some(to_table.name.clone()),
+                    on_domain: false,
                     comment: to_policy.comment.clone(),
                 });
             }
@@ -361,12 +371,67 @@ fn diff_comments(from: &Schema, to: &Schema) -> Vec<MigrationOp> {
                 arguments: None,
                 column: None,
                 target: None,
+                on_domain: false,
                 comment: Some(target_comment.clone()),
             });
         }
     }
 
+    diff_constraint_comments(
+        &from.table_constraint_comments,
+        &to.table_constraint_comments,
+        false,
+        &mut ops,
+    );
+    diff_constraint_comments(
+        &from.domain_constraint_comments,
+        &to.domain_constraint_comments,
+        true,
+        &mut ops,
+    );
+
     ops
+}
+
+/// Emits `SetComment(Constraint)` ops for every entry whose text differs
+/// between source and target. Mirrors policy comments: the constraint is
+/// fully user-managed (no PostgreSQL-shipped defaults), so a normal exact
+/// diff applies, including clears via `IS NULL` when the source drops a
+/// previously-set comment.
+///
+/// Keys are `"schema.parent.constraint_name"` where `parent` is a table or
+/// domain. The parent name is split off here and passed through `target`,
+/// while `name` carries the constraint identifier.
+fn diff_constraint_comments(
+    from: &std::collections::BTreeMap<String, String>,
+    to: &std::collections::BTreeMap<String, String>,
+    on_domain: bool,
+    ops: &mut Vec<MigrationOp>,
+) {
+    let mut keys: std::collections::BTreeSet<&String> = from.keys().collect();
+    keys.extend(to.keys());
+
+    for key in keys {
+        let from_text = from.get(key);
+        let to_text = to.get(key);
+        if from_text == to_text {
+            continue;
+        }
+        let (parent_key, constraint_name) = key.rsplit_once('.').unwrap_or_else(|| {
+            panic!("constraint comment key {key:?} must encode schema.parent.constraint_name")
+        });
+        let (parent_schema, parent_name) = crate::model::parse_qualified_name(parent_key);
+        ops.push(MigrationOp::SetComment {
+            object_type: CommentObjectType::Constraint,
+            schema: parent_schema,
+            name: constraint_name.to_string(),
+            arguments: None,
+            column: None,
+            target: Some(parent_name),
+            on_domain,
+            comment: to_text.cloned(),
+        });
+    }
 }
 
 #[cfg(test)]
@@ -1845,6 +1910,146 @@ mod tests {
 
         let ops = compute_diff(&from, &to);
         assert!(ops.is_empty(), "no migration ops expected, got {ops:?}");
+    }
+
+    fn schema_with_table_constraint_comment(comment: Option<&str>) -> crate::model::Schema {
+        let mut schema = empty_schema();
+        schema
+            .tables
+            .insert("public.users".to_string(), simple_table("users"));
+        if let Some(text) = comment {
+            schema
+                .table_constraint_comments
+                .insert("public.users.users_pkey".to_string(), text.to_string());
+        }
+        schema
+    }
+
+    #[test]
+    fn detects_added_table_constraint_comment() {
+        let from = schema_with_table_constraint_comment(None);
+        let to = schema_with_table_constraint_comment(Some("primary key"));
+
+        let ops = compute_diff(&from, &to);
+        assert_eq!(ops.len(), 1);
+        match &ops[0] {
+            MigrationOp::SetComment {
+                object_type,
+                schema,
+                name,
+                target,
+                on_domain,
+                comment,
+                ..
+            } => {
+                assert_eq!(*object_type, CommentObjectType::Constraint);
+                assert_eq!(schema, "public");
+                assert_eq!(name, "users_pkey");
+                assert_eq!(target.as_deref(), Some("users"));
+                assert!(!*on_domain);
+                assert_eq!(comment.as_deref(), Some("primary key"));
+            }
+            other => panic!("expected SetComment, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn detects_changed_table_constraint_comment() {
+        let from = schema_with_table_constraint_comment(Some("old"));
+        let to = schema_with_table_constraint_comment(Some("new"));
+
+        let ops = compute_diff(&from, &to);
+        assert_eq!(ops.len(), 1);
+        match &ops[0] {
+            MigrationOp::SetComment {
+                object_type,
+                comment,
+                ..
+            } => {
+                assert_eq!(*object_type, CommentObjectType::Constraint);
+                assert_eq!(comment.as_deref(), Some("new"));
+            }
+            other => panic!("expected SetComment, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn detects_cleared_table_constraint_comment() {
+        let from = schema_with_table_constraint_comment(Some("old"));
+        let to = schema_with_table_constraint_comment(None);
+
+        let ops = compute_diff(&from, &to);
+        assert_eq!(ops.len(), 1);
+        match &ops[0] {
+            MigrationOp::SetComment {
+                object_type,
+                comment,
+                ..
+            } => {
+                assert_eq!(*object_type, CommentObjectType::Constraint);
+                assert!(comment.is_none(), "clear must emit None");
+            }
+            other => panic!("expected SetComment, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn no_op_when_table_constraint_comment_unchanged() {
+        let from = schema_with_table_constraint_comment(Some("primary key"));
+        let to = from.clone();
+
+        let ops = compute_diff(&from, &to);
+        assert!(ops.is_empty(), "no migration ops expected, got {ops:?}");
+    }
+
+    #[test]
+    fn detects_added_domain_constraint_comment_with_on_domain_flag() {
+        let mut from = empty_schema();
+        let mut to = empty_schema();
+        let domain = crate::model::Domain {
+            schema: "public".to_string(),
+            name: "amount".to_string(),
+            data_type: crate::model::PgType::Integer,
+            default: None,
+            not_null: false,
+            collation: None,
+            check_constraints: vec![crate::model::DomainConstraint {
+                name: Some("amount_positive".to_string()),
+                expression: "VALUE > 0".to_string(),
+            }],
+            owner: None,
+            grants: Vec::new(),
+            comment: None,
+        };
+        from.domains
+            .insert("public.amount".to_string(), domain.clone());
+        to.domains.insert("public.amount".to_string(), domain);
+        to.domain_constraint_comments.insert(
+            "public.amount.amount_positive".to_string(),
+            "must be positive".to_string(),
+        );
+
+        let ops = compute_diff(&from, &to);
+        assert_eq!(ops.len(), 1);
+        match &ops[0] {
+            MigrationOp::SetComment {
+                object_type,
+                schema,
+                name,
+                target,
+                on_domain,
+                comment,
+                ..
+            } => {
+                assert_eq!(*object_type, CommentObjectType::Constraint);
+                assert_eq!(schema, "public");
+                assert_eq!(name, "amount_positive");
+                assert_eq!(target.as_deref(), Some("amount"));
+                assert!(*on_domain, "domain form must set on_domain=true");
+                assert_eq!(comment.as_deref(), Some("must be positive"));
+            }
+            other => panic!("expected SetComment, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/diff/op_key.rs
+++ b/src/diff/op_key.rs
@@ -222,6 +222,11 @@ pub(crate) enum OpKey {
         arguments: Option<String>,
         column: Option<String>,
         target: Option<String>,
+        /// Required for `CommentObjectType::Constraint` so a constraint
+        /// with the same name appearing on both a table and a domain
+        /// produces two distinct keys. Always `false` for every other
+        /// variant.
+        on_domain: bool,
     },
 }
 
@@ -490,6 +495,7 @@ impl OpKey {
                 arguments,
                 column,
                 target,
+                on_domain,
                 ..
             } => OpKey::SetComment {
                 object_type: *object_type,
@@ -498,6 +504,7 @@ impl OpKey {
                 arguments: arguments.clone(),
                 column: column.clone(),
                 target: target.clone(),
+                on_domain: *on_domain,
             },
         }
     }

--- a/src/diff/planner.rs
+++ b/src/diff/planner.rs
@@ -1028,6 +1028,7 @@ impl MigrationGraph {
                     arguments,
                     column,
                     target,
+                    on_domain,
                 } => {
                     use crate::diff::CommentObjectType;
                     let require = |opt: &Option<String>, kind: &str, field: &str| -> String {
@@ -1120,6 +1121,49 @@ impl MigrationGraph {
                                 },
                                 key.clone(),
                             ));
+                        }
+                        CommentObjectType::Constraint => {
+                            // Each `COMMENT ON CONSTRAINT name ON [DOMAIN] tgt`
+                            // depends on the constraint existing. The
+                            // constraint kind is unknown at this point —
+                            // pgmold only retains "name + on which relation",
+                            // not "PK / FK / CHECK / UNIQUE / EXCLUDE".
+                            // `add_edge` silently skips unknown source keys,
+                            // so emit an edge for every plausible producer
+                            // and let the actual one bind. Inline forms are
+                            // subsumed under `CreateTable` / `CreateDomain`;
+                            // ALTER ADD forms get their own edges.
+                            let target_name = require(target, "Constraint", "target");
+                            let parent = QualifiedName::new(schema, &target_name);
+                            let candidates: Vec<OpKey> = if *on_domain {
+                                vec![OpKey::CreateDomain(qualified_name(schema, &target_name))]
+                            } else {
+                                vec![
+                                    OpKey::CreateTable(qualified_name(schema, &target_name)),
+                                    OpKey::AddPrimaryKey {
+                                        table: parent.clone(),
+                                    },
+                                    OpKey::AddIndex {
+                                        table: parent.clone(),
+                                        name: name.clone(),
+                                    },
+                                    OpKey::AddForeignKey {
+                                        table: parent.clone(),
+                                        name: name.clone(),
+                                    },
+                                    OpKey::AddCheckConstraint {
+                                        table: parent.clone(),
+                                        name: name.clone(),
+                                    },
+                                    OpKey::AddExclusionConstraint {
+                                        table: parent,
+                                        name: name.clone(),
+                                    },
+                                ]
+                            };
+                            for candidate in candidates {
+                                edges_to_add.push((candidate, key.clone()));
+                            }
                         }
                     }
                 }
@@ -6325,6 +6369,7 @@ mod tests {
             arguments: None,
             column: Some(column.to_string()),
             target: None,
+            on_domain: false,
             comment: Some("@omit create,update".to_string()),
         }
     }
@@ -6350,6 +6395,7 @@ mod tests {
                 arguments: None,
                 column: None,
                 target: None,
+                on_domain: false,
                 comment: Some("widget table".to_string()),
             },
             column_comment("public", "widgets", "id"),
@@ -6365,6 +6411,7 @@ mod tests {
             arguments: Some(args.to_string()),
             column: None,
             target: None,
+            on_domain: false,
             comment: Some(body.to_string()),
         };
         assert_comments_all_distinct(vec![
@@ -6384,6 +6431,7 @@ mod tests {
             arguments: None,
             column: None,
             target: Some(target.to_string()),
+            on_domain: false,
             comment: Some(format!("audit trigger on {target}")),
         };
         assert_comments_all_distinct(vec![trigger_comment("users"), trigger_comment("orders")]);
@@ -6435,6 +6483,7 @@ mod tests {
                 arguments: None,
                 column: None,
                 target: None,
+                on_domain: false,
                 comment: Some("managed reporting & verification".to_string()),
             },
             MigrationOp::CreateSchema(make_schema("mrv")),
@@ -6466,6 +6515,7 @@ mod tests {
                 arguments: Some(args_string.clone()),
                 column: None,
                 target: None,
+                on_domain: false,
                 comment: Some("@deprecated".to_string()),
             },
             MigrationOp::CreateSchema(make_schema("mrv")),
@@ -6498,6 +6548,7 @@ mod tests {
                 arguments: None,
                 column: None,
                 target: None,
+                on_domain: false,
                 comment: Some("widget table".to_string()),
             },
             MigrationOp::CreateTable(simple_table_with_fks("widgets", vec![])),
@@ -6537,6 +6588,7 @@ mod tests {
                 arguments: None,
                 column: None,
                 target: Some("users".to_string()),
+                on_domain: false,
                 comment: Some("self-access only".to_string()),
             },
             MigrationOp::CreateTable(simple_table_with_fks("users", vec![])),
@@ -6560,6 +6612,7 @@ mod tests {
                 arguments: None,
                 column: None,
                 target: None,
+                on_domain: false,
                 comment: Some("UUID helpers".to_string()),
             },
             MigrationOp::CreateExtension(make_extension("uuid-ossp")),
@@ -6582,6 +6635,7 @@ mod tests {
                 arguments: None,
                 column: None,
                 target: Some("users".to_string()),
+                on_domain: false,
                 comment: Some("audit trigger".to_string()),
             },
             MigrationOp::CreateTable(simple_table_with_fks("users", vec![])),
@@ -6606,6 +6660,7 @@ mod tests {
                 arguments: None,
                 column: None,
                 target: None,
+                on_domain: false,
                 comment: Some("active users view".to_string()),
             },
             MigrationOp::CreateView(make_view(

--- a/src/diff/types.rs
+++ b/src/diff/types.rs
@@ -28,6 +28,12 @@ pub enum CommentObjectType {
     Trigger,
     Extension,
     Policy,
+    /// Comment on a named PK/FK/CHECK/UNIQUE/EXCLUDE constraint. The
+    /// `target` field on `SetComment` carries the parent relation name and
+    /// `on_domain` distinguishes the `ON DOMAIN <name>` form from the
+    /// `ON <table>` form. The constraint kind itself is not recorded —
+    /// PostgreSQL resolves it from `pg_constraint` at apply time.
+    Constraint,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -256,6 +262,11 @@ pub enum MigrationOp {
         arguments: Option<String>,
         column: Option<String>,
         target: Option<String>,
+        /// Only meaningful for `CommentObjectType::Constraint`. `true`
+        /// emits `COMMENT ON CONSTRAINT name ON DOMAIN target IS …`,
+        /// `false` emits `COMMENT ON CONSTRAINT name ON target IS …`.
+        /// Always `false` for every other variant.
+        on_domain: bool,
         comment: Option<String>,
     },
 

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -66,6 +66,7 @@ fn push_comment_op(
             arguments: None,
             column: None,
             target: None,
+            on_domain: false,
             comment: Some(text.clone()),
         });
     }
@@ -86,6 +87,7 @@ fn push_column_comment_op(
             arguments: None,
             column: Some(column_name.to_string()),
             target: None,
+            on_domain: false,
             comment: Some(text.clone()),
         });
     }
@@ -106,6 +108,7 @@ fn push_function_comment_op(
             arguments: Some(arguments.to_string()),
             column: None,
             target: None,
+            on_domain: false,
             comment: Some(text.clone()),
         });
     }
@@ -126,8 +129,51 @@ fn push_trigger_comment_op(
             arguments: None,
             column: None,
             target: Some(target_name.to_string()),
+            on_domain: false,
             comment: Some(text.clone()),
         });
+    }
+}
+
+fn push_constraint_comment_op(
+    ops: &mut Vec<MigrationOp>,
+    parent_schema: &str,
+    parent_name: &str,
+    constraint_name: &str,
+    comment: &str,
+    on_domain: bool,
+) {
+    ops.push(MigrationOp::SetComment {
+        object_type: CommentObjectType::Constraint,
+        schema: parent_schema.to_string(),
+        name: constraint_name.to_string(),
+        arguments: None,
+        column: None,
+        target: Some(parent_name.to_string()),
+        on_domain,
+        comment: Some(comment.to_string()),
+    });
+}
+
+fn push_constraint_comment_ops(
+    ops: &mut Vec<MigrationOp>,
+    sidecar: &std::collections::BTreeMap<String, String>,
+    parent_schema: &str,
+    parent_name: &str,
+    on_domain: bool,
+) {
+    let parent_prefix = format!("{parent_schema}.{parent_name}.");
+    for (key, comment) in sidecar.iter() {
+        if let Some(constraint_name) = key.strip_prefix(&parent_prefix) {
+            push_constraint_comment_op(
+                ops,
+                parent_schema,
+                parent_name,
+                constraint_name,
+                comment,
+                on_domain,
+            );
+        }
     }
 }
 
@@ -146,6 +192,7 @@ fn push_policy_comment_op(
             arguments: None,
             column: None,
             target: Some(table_name.to_string()),
+            on_domain: false,
             comment: Some(text.clone()),
         });
     }
@@ -253,6 +300,13 @@ pub fn schema_to_create_ops(schema: &Schema) -> Vec<MigrationOp> {
             &domain.name,
             &domain.comment,
         );
+        push_constraint_comment_ops(
+            &mut ops,
+            &schema.domain_constraint_comments,
+            &domain.schema,
+            &domain.name,
+            true,
+        );
     }
 
     for sequence in schema.sequences.values() {
@@ -330,6 +384,13 @@ pub fn schema_to_create_ops(schema: &Schema) -> Vec<MigrationOp> {
         for (col_name, col) in &table.columns {
             push_column_comment_op(&mut ops, &table.schema, &table.name, col_name, &col.comment);
         }
+        push_constraint_comment_ops(
+            &mut ops,
+            &schema.table_constraint_comments,
+            &table.schema,
+            &table.name,
+            false,
+        );
     }
 
     for partition in schema.partitions.values() {
@@ -388,6 +449,7 @@ pub fn schema_to_create_ops(schema: &Schema) -> Vec<MigrationOp> {
                 arguments: Some(agg_args.clone()),
                 column: None,
                 target: None,
+                on_domain: false,
                 comment: Some(text.clone()),
             });
         }

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -342,7 +342,7 @@ pub fn filter_by_target_schemas(schema: &Schema, target_schemas: &[String]) -> S
             .collect()
     }
 
-    Schema {
+    let mut result = Schema {
         schemas: retain_by_schema(&schema.schemas, &allowed, |s| &s.name),
         extensions: schema.extensions.clone(),
         servers: schema.servers.clone(),
@@ -387,7 +387,13 @@ pub fn filter_by_target_schemas(schema: &Schema, target_schemas: &[String]) -> S
             })
             .map(|(k, v)| (k.clone(), v.clone()))
             .collect(),
-    }
+    };
+    // Mirror the filter_schema path: drop orphan sidecar entries even
+    // though the schema-prefix filter above already covers the only orphan
+    // shape currently possible. Defense-in-depth so future changes to
+    // table / domain filtering cannot leak stale comments.
+    result.drop_orphan_constraint_comments();
+    result
 }
 
 fn filter_map<T>(map: &BTreeMap<String, T>, filter: &Filter) -> BTreeMap<String, T>

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -342,6 +342,19 @@ pub fn filter_by_target_schemas(schema: &Schema, target_schemas: &[String]) -> S
             .collect()
     }
 
+    fn retain_by_key_schema(
+        map: &BTreeMap<String, String>,
+        allowed: &HashSet<&str>,
+    ) -> BTreeMap<String, String> {
+        map.iter()
+            .filter(|(key, _)| {
+                key.split_once('.')
+                    .is_some_and(|(s, _)| allowed.contains(s))
+            })
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect()
+    }
+
     let mut result = Schema {
         schemas: retain_by_schema(&schema.schemas, &allowed, |s| &s.name),
         extensions: schema.extensions.clone(),
@@ -369,24 +382,14 @@ pub fn filter_by_target_schemas(schema: &Schema, target_schemas: &[String]) -> S
         pending_grants: Vec::new(),
         pending_revokes: Vec::new(),
         pending_comments: Vec::new(),
-        table_constraint_comments: schema
-            .table_constraint_comments
-            .iter()
-            .filter(|(key, _)| {
-                key.split_once('.')
-                    .is_some_and(|(s, _)| allowed.contains(s))
-            })
-            .map(|(k, v)| (k.clone(), v.clone()))
-            .collect(),
-        domain_constraint_comments: schema
-            .domain_constraint_comments
-            .iter()
-            .filter(|(key, _)| {
-                key.split_once('.')
-                    .is_some_and(|(s, _)| allowed.contains(s))
-            })
-            .map(|(k, v)| (k.clone(), v.clone()))
-            .collect(),
+        table_constraint_comments: retain_by_key_schema(
+            &schema.table_constraint_comments,
+            &allowed,
+        ),
+        domain_constraint_comments: retain_by_key_schema(
+            &schema.domain_constraint_comments,
+            &allowed,
+        ),
     };
     // Mirror the filter_schema path: drop orphan sidecar entries even
     // though the schema-prefix filter above already covers the only orphan

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -253,7 +253,7 @@ pub fn filter_schema(schema: &Schema, filter: &Filter) -> Schema {
         strip_grants_from_values(&mut schemas);
     }
 
-    Schema {
+    let mut filtered = Schema {
         schemas,
         extensions: filter_field(&schema.extensions, filter, ObjectType::Extensions),
         servers: schema.servers.clone(),
@@ -285,7 +285,13 @@ pub fn filter_schema(schema: &Schema, filter: &Filter) -> Schema {
         } else {
             Vec::new()
         },
-    }
+        table_constraint_comments: schema.table_constraint_comments.clone(),
+        domain_constraint_comments: schema.domain_constraint_comments.clone(),
+    };
+    // Drop sidecar entries whose parent (table or domain) was filtered out
+    // so the diff loop cannot emit a `COMMENT ON CONSTRAINT ... ON missing`.
+    filtered.drop_orphan_constraint_comments();
+    filtered
 }
 
 pub fn exclude_unmanaged_partitions(current: &Schema, target: &Schema) -> Schema {

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -369,6 +369,24 @@ pub fn filter_by_target_schemas(schema: &Schema, target_schemas: &[String]) -> S
         pending_grants: Vec::new(),
         pending_revokes: Vec::new(),
         pending_comments: Vec::new(),
+        table_constraint_comments: schema
+            .table_constraint_comments
+            .iter()
+            .filter(|(key, _)| {
+                key.split_once('.')
+                    .is_some_and(|(s, _)| allowed.contains(s))
+            })
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect(),
+        domain_constraint_comments: schema
+            .domain_constraint_comments
+            .iter()
+            .filter(|(key, _)| {
+                key.split_once('.')
+                    .is_some_and(|(s, _)| allowed.contains(s))
+            })
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect(),
     }
 }
 

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -92,6 +92,7 @@ pub enum PendingCommentObjectType {
     Trigger,
     Extension,
     Policy,
+    Constraint,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -99,6 +100,11 @@ pub struct PendingComment {
     pub object_type: PendingCommentObjectType,
     pub object_key: String,
     pub comment: Option<String>,
+    /// Only meaningful for `PendingCommentObjectType::Constraint`. `true`
+    /// when the source statement used the `ON DOMAIN <domain>` tail rather
+    /// than `ON <table>`. Routes resolution through `Schema::domains`
+    /// instead of `Schema::tables`. Always `false` for every other variant.
+    pub on_domain: bool,
 }
 
 /// Represents a pending GRANT parsed from a GRANT statement.
@@ -171,6 +177,21 @@ pub struct Schema {
     #[serde(skip)]
     pub pending_comments: Vec<PendingComment>,
     pub default_privileges: Vec<DefaultPrivilege>,
+    /// Comments on named table constraints (PK, FK, CHECK, UNIQUE, EXCLUDE)
+    /// keyed as `"schema.table.constraint_name"`. Stored as a Schema-level
+    /// sidecar so adding the field does not require changing every
+    /// `Table` / `ForeignKey` / `CheckConstraint` / `Index` constructor in
+    /// the codebase. The constraint kind is irrelevant for emitting
+    /// `COMMENT ON CONSTRAINT name ON tbl IS '...'` because PostgreSQL
+    /// resolves the kind from `pg_constraint`.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub table_constraint_comments: BTreeMap<String, String>,
+    /// Comments on named CHECK constraints attached to domains, keyed as
+    /// `"schema.domain.constraint_name"`. Mirrors
+    /// `table_constraint_comments` but resolved against `domains` and
+    /// emitted via the `ON DOMAIN` form.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub domain_constraint_comments: BTreeMap<String, String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -984,6 +1005,8 @@ impl Schema {
             pending_revokes: Vec::new(),
             pending_comments: Vec::new(),
             default_privileges: Vec::new(),
+            table_constraint_comments: BTreeMap::new(),
+            domain_constraint_comments: BTreeMap::new(),
         }
     }
 
@@ -1353,7 +1376,56 @@ impl Schema {
                 }
                 false
             }
+            PendingCommentObjectType::Constraint => {
+                // Key encodes schema.parent.constraint_name where parent is
+                // either a table (default) or a domain (when on_domain).
+                // Routed through the matching Schema-level sidecar map so we
+                // do not have to mutate every constraint variant struct.
+                let Some((parent_key, _)) = pc.object_key.rsplit_once('.') else {
+                    return false;
+                };
+                if pc.on_domain {
+                    if !self.domains.contains_key(parent_key) {
+                        return false;
+                    }
+                    update_constraint_comment(
+                        &mut self.domain_constraint_comments,
+                        &pc.object_key,
+                        pc.comment.as_ref(),
+                    );
+                } else {
+                    if !self.tables.contains_key(parent_key) {
+                        return false;
+                    }
+                    update_constraint_comment(
+                        &mut self.table_constraint_comments,
+                        &pc.object_key,
+                        pc.comment.as_ref(),
+                    );
+                }
+                true
+            }
         }
+    }
+
+    /// Drops sidecar constraint comment entries whose parent table or
+    /// domain has been pruned from the schema. Called by the filter and
+    /// drift-baseline pipelines so that orphan entries cannot leak into
+    /// downstream emit. The constraint name itself is not validated against
+    /// the parent's per-kind constraint vectors — pgmold accepts the comment
+    /// even if the underlying constraint is filtered out at a finer
+    /// granularity, and PostgreSQL will surface the mismatch at apply time.
+    pub fn drop_orphan_constraint_comments(&mut self) {
+        let tables = &self.tables;
+        self.table_constraint_comments.retain(|key, _| {
+            key.rsplit_once('.')
+                .is_some_and(|(parent, _)| tables.contains_key(parent))
+        });
+        let domains = &self.domains;
+        self.domain_constraint_comments.retain(|key, _| {
+            key.rsplit_once('.')
+                .is_some_and(|(parent, _)| domains.contains_key(parent))
+        });
     }
 
     fn merge_all_grants(&mut self) {
@@ -1406,6 +1478,21 @@ pub fn revoke_from_grants(
             true
         }
     });
+}
+
+fn update_constraint_comment(
+    sidecar: &mut BTreeMap<String, String>,
+    key: &str,
+    comment: Option<&String>,
+) {
+    match comment {
+        Some(text) => {
+            sidecar.insert(key.to_string(), text.clone());
+        }
+        None => {
+            sidecar.remove(key);
+        }
+    }
 }
 
 fn merge_grants_by_grantee(grants: &mut Vec<Grant>) {

--- a/src/parser/comments.rs
+++ b/src/parser/comments.rs
@@ -32,6 +32,9 @@ pub(super) struct CommentStatement<'a> {
     pub object_name: &'a ObjectName,
     pub arguments: Option<&'a [DataType]>,
     pub table_name: Option<&'a ObjectName>,
+    /// `true` when the AST's relation tail used `ON DOMAIN <domain>` rather
+    /// than `ON <table>`. Only meaningful for `CommentObject::Constraint`.
+    pub on_domain: bool,
     pub comment: Option<String>,
 }
 
@@ -48,6 +51,7 @@ pub(super) fn apply_comment_statement(
         object_name,
         arguments,
         table_name: partner_table,
+        on_domain,
         comment,
     } = stmt;
 
@@ -159,16 +163,26 @@ pub(super) fn apply_comment_statement(
         // these via its preprocess-stage scan and turn them into errors
         // under `--strict`. Per-kind modeling lands in subtasks of pgmold-270.
         CommentObject::Constraint => {
-            let target = match partner_table {
-                Some(rel) => {
-                    let (rs, rn) = extract_qualified_name(rel);
-                    format!("{object_name} ON {rs}.{rn}")
-                }
-                None => object_name.to_string(),
+            let constraint_parts = object_name_parts(object_name);
+            if constraint_parts.len() != 1 {
+                return Err(SchemaError::ParseError(format!(
+                    "COMMENT ON CONSTRAINT expects an unqualified constraint name, got {object_name}"
+                )));
+            }
+            let constraint_name = constraint_parts.into_iter().next().unwrap();
+            let Some(partner_relation) = partner_table else {
+                return Err(SchemaError::ParseError(
+                    "COMMENT ON CONSTRAINT missing ON [DOMAIN] <relation> tail".into(),
+                ));
             };
-            eprintln!(
-                "warning: pgmold does not model COMMENT ON CONSTRAINT; dropping comment on {target}"
-            );
+            let (parent_schema, parent_name) = extract_qualified_name(partner_relation);
+            let key = format!("{parent_schema}.{parent_name}.{constraint_name}");
+            schema.pending_comments.push(PendingComment {
+                object_type: PendingCommentObjectType::Constraint,
+                object_key: key,
+                comment,
+                on_domain,
+            });
         }
         CommentObject::Operator => {
             eprintln!(
@@ -252,6 +266,7 @@ fn push(
         object_type,
         object_key,
         comment,
+        on_domain: false,
     });
 }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1332,7 +1332,7 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
                 arguments,
                 operator_args: _,
                 table_name,
-                on_domain: _,
+                on_domain,
                 comment,
                 if_exists: _,
             } => {
@@ -1342,6 +1342,7 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
                         object_name: &object_name,
                         arguments: arguments.as_deref(),
                         table_name: table_name.as_ref(),
+                        on_domain,
                         comment,
                     },
                     &mut schema,

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -2697,10 +2697,9 @@ fn comment_on_constraint_null_clears_comment() {
         COMMENT ON CONSTRAINT users_id_chk ON public.users IS NULL;
     "#;
     let schema = parse_sql_string(sql).unwrap();
-    assert!(schema
+    assert!(!schema
         .table_constraint_comments
-        .get("public.users.users_id_chk")
-        .is_none());
+        .contains_key("public.users.users_id_chk"));
 }
 
 #[test]

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -2666,6 +2666,111 @@ fn comment_on_policy_roundtrips_through_dump() {
 }
 
 #[test]
+fn comment_on_constraint_on_table_captures_text() {
+    let sql = r#"
+        CREATE TABLE public.users (
+            id serial,
+            CONSTRAINT users_pkey PRIMARY KEY (id),
+            CONSTRAINT users_email_chk CHECK (id > 0)
+        );
+        COMMENT ON CONSTRAINT users_email_chk ON public.users IS 'positive id';
+    "#;
+    let schema = parse_sql_string(sql).unwrap();
+    assert_eq!(
+        schema
+            .table_constraint_comments
+            .get("public.users.users_email_chk")
+            .map(String::as_str),
+        Some("positive id"),
+    );
+    assert!(schema.domain_constraint_comments.is_empty());
+}
+
+#[test]
+fn comment_on_constraint_null_clears_comment() {
+    let sql = r#"
+        CREATE TABLE public.users (
+            id serial,
+            CONSTRAINT users_id_chk CHECK (id > 0)
+        );
+        COMMENT ON CONSTRAINT users_id_chk ON public.users IS 'positive id';
+        COMMENT ON CONSTRAINT users_id_chk ON public.users IS NULL;
+    "#;
+    let schema = parse_sql_string(sql).unwrap();
+    assert!(schema
+        .table_constraint_comments
+        .get("public.users.users_id_chk")
+        .is_none());
+}
+
+#[test]
+fn comment_on_constraint_on_domain_captures_text() {
+    let sql = r#"
+        CREATE DOMAIN public.amount AS INTEGER CONSTRAINT amount_positive CHECK (VALUE > 0);
+        COMMENT ON CONSTRAINT amount_positive ON DOMAIN public.amount IS 'must be positive';
+    "#;
+    let schema = parse_sql_string(sql).unwrap();
+    assert_eq!(
+        schema
+            .domain_constraint_comments
+            .get("public.amount.amount_positive")
+            .map(String::as_str),
+        Some("must be positive"),
+    );
+    assert!(schema.table_constraint_comments.is_empty());
+}
+
+#[test]
+fn comment_on_constraint_roundtrips_through_dump() {
+    use crate::dump::generate_dump;
+    let sql = r#"
+        CREATE TABLE public.users (
+            id serial,
+            CONSTRAINT users_id_chk CHECK (id > 0)
+        );
+        COMMENT ON CONSTRAINT users_id_chk ON public.users IS 'positive id';
+    "#;
+    let schema = parse_sql_string(sql).unwrap();
+    let dump = generate_dump(&schema, None);
+    let reparsed = parse_sql_string(&dump).unwrap();
+    assert_eq!(
+        reparsed
+            .table_constraint_comments
+            .get("public.users.users_id_chk")
+            .map(String::as_str),
+        Some("positive id"),
+    );
+}
+
+#[test]
+fn comment_on_constraint_on_domain_roundtrips_through_dump() {
+    use crate::dump::generate_dump;
+    let sql = r#"
+        CREATE DOMAIN public.amount AS INTEGER CONSTRAINT amount_positive CHECK (VALUE > 0);
+        COMMENT ON CONSTRAINT amount_positive ON DOMAIN public.amount IS 'must be positive';
+    "#;
+    let schema = parse_sql_string(sql).unwrap();
+    let dump = generate_dump(&schema, None);
+    let reparsed = parse_sql_string(&dump).unwrap();
+    assert_eq!(
+        reparsed
+            .domain_constraint_comments
+            .get("public.amount.amount_positive")
+            .map(String::as_str),
+        Some("must be positive"),
+    );
+}
+
+#[test]
+fn comment_on_constraint_dropped_when_parent_table_missing() {
+    let sql = r#"
+        COMMENT ON CONSTRAINT orphan_chk ON public.missing IS 'orphaned';
+    "#;
+    let schema = parse_sql_string(sql).unwrap();
+    assert!(schema.table_constraint_comments.is_empty());
+}
+
+#[test]
 fn comment_on_function_attaches_when_args_use_int_alias() {
     let sql = r#"
         CREATE FUNCTION add(a int, b int) RETURNS int LANGUAGE sql AS $$ SELECT a + b $$;

--- a/src/parser/unrecognized.rs
+++ b/src/parser/unrecognized.rs
@@ -101,6 +101,8 @@ static COMMENT_ON_EXTENSION_CLAIM: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"(?is)\bCOMMENT\s+ON\s+EXTENSION\s+").unwrap());
 static COMMENT_ON_POLICY_CLAIM: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"(?is)\bCOMMENT\s+ON\s+POLICY\s+").unwrap());
+static COMMENT_ON_CONSTRAINT_CLAIM: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?is)\bCOMMENT\s+ON\s+CONSTRAINT\s+").unwrap());
 
 // Mirrors grants.rs: GRANT privs ON [kind] target TO grantee. Object kind
 // keyword is optional so `GRANT SELECT ON public.users TO readonly;` is
@@ -160,6 +162,7 @@ static RECOGNIZERS: &[BroadRecognizer] = &[
             &COMMENT_ON_TRIGGER_CLAIM,
             &COMMENT_ON_EXTENSION_CLAIM,
             &COMMENT_ON_POLICY_CLAIM,
+            &COMMENT_ON_CONSTRAINT_CLAIM,
         ],
     },
     BroadRecognizer {
@@ -307,10 +310,15 @@ COMMENT ON TABLE public.users IS 'a table';
     }
 
     #[test]
-    fn comment_on_constraint_flagged() {
+    fn comment_on_constraint_on_table_not_flagged() {
         let sql = "COMMENT ON CONSTRAINT foo ON public.users IS 'check it';";
-        let findings = find_unrecognized_statements(sql);
-        assert_eq!(findings.len(), 1);
+        assert!(find_unrecognized_statements(sql).is_empty());
+    }
+
+    #[test]
+    fn comment_on_constraint_on_domain_not_flagged() {
+        let sql = "COMMENT ON CONSTRAINT positive ON DOMAIN public.amount IS 'amount > 0';";
+        assert!(find_unrecognized_statements(sql).is_empty());
     }
 
     #[test]

--- a/src/pg/introspect.rs
+++ b/src/pg/introspect.rs
@@ -42,6 +42,8 @@ pub async fn introspect_schema(
         mut all_force_rls,
         mut all_policies,
         default_privileges,
+        table_constraint_comments,
+        domain_constraint_comments,
     ) = tokio::try_join!(
         introspect_schemas(connection, target_schemas),
         introspect_extensions(connection),
@@ -71,6 +73,8 @@ pub async fn introspect_schema(
         introspect_all_force_rls(connection, target_schemas),
         introspect_all_policies(connection, target_schemas),
         introspect_default_privileges(connection, target_schemas),
+        introspect_table_constraint_comments(connection, target_schemas),
+        introspect_domain_constraint_comments(connection, target_schemas),
     )?;
 
     let mut schema = Schema::new();
@@ -87,6 +91,8 @@ pub async fn introspect_schema(
     schema.sequences = sequences;
     schema.partitions = partitions;
     schema.default_privileges = default_privileges;
+    schema.table_constraint_comments = table_constraint_comments;
+    schema.domain_constraint_comments = domain_constraint_comments;
 
     for (qualified_name, grants) in table_view_grants {
         if let Some(table) = schema.tables.get_mut(&qualified_name) {
@@ -1568,6 +1574,96 @@ async fn introspect_all_policies(
             });
     }
 
+    Ok(result)
+}
+
+/// Reads `obj_description(con.oid, 'pg_constraint')` for every named
+/// constraint attached to a relation (PK / FK / CHECK / UNIQUE / EXCLUDE)
+/// in the target schemas. Returns a map keyed by
+/// `"schema.table.constraint_name"` so the diff path can iterate it
+/// alongside the source-side sidecar without needing per-kind lookups.
+async fn introspect_table_constraint_comments(
+    connection: &PgConnection,
+    target_schemas: &[String],
+) -> Result<BTreeMap<String, String>> {
+    let rows = sqlx::query(
+        r#"
+        SELECT
+            n.nspname AS table_schema,
+            c.relname AS table_name,
+            con.conname AS constraint_name,
+            obj_description(con.oid, 'pg_constraint') AS comment
+        FROM pg_constraint con
+        JOIN pg_class c ON con.conrelid = c.oid
+        JOIN pg_namespace n ON c.relnamespace = n.oid
+        WHERE n.nspname = ANY($1::text[])
+          AND c.relkind IN ('r', 'p')
+          AND c.relispartition = false
+          AND obj_description(con.oid, 'pg_constraint') IS NOT NULL
+        "#,
+    )
+    .bind(target_schemas)
+    .fetch_all(connection.pool())
+    .await
+    .map_err(|e| {
+        SchemaError::DatabaseError(format!("Failed to fetch table constraint comments: {e}"))
+    })?;
+
+    let mut result = BTreeMap::new();
+    for row in rows {
+        let table_schema: String = row.get("table_schema");
+        let table_name: String = row.get("table_name");
+        let constraint_name: String = row.get("constraint_name");
+        let comment: String = row.get("comment");
+        result.insert(
+            format!("{table_schema}.{table_name}.{constraint_name}"),
+            comment,
+        );
+    }
+    Ok(result)
+}
+
+/// Mirrors `introspect_table_constraint_comments` for CHECK constraints
+/// attached to domains. The relation tail uses `ON DOMAIN <name>` at
+/// emit time, distinguished from the table form via `on_domain` in the
+/// `SetComment` op.
+async fn introspect_domain_constraint_comments(
+    connection: &PgConnection,
+    target_schemas: &[String],
+) -> Result<BTreeMap<String, String>> {
+    let rows = sqlx::query(
+        r#"
+        SELECT
+            n.nspname AS domain_schema,
+            t.typname AS domain_name,
+            con.conname AS constraint_name,
+            obj_description(con.oid, 'pg_constraint') AS comment
+        FROM pg_constraint con
+        JOIN pg_type t ON con.contypid = t.oid
+        JOIN pg_namespace n ON t.typnamespace = n.oid
+        WHERE n.nspname = ANY($1::text[])
+          AND con.contype = 'c'
+          AND obj_description(con.oid, 'pg_constraint') IS NOT NULL
+        "#,
+    )
+    .bind(target_schemas)
+    .fetch_all(connection.pool())
+    .await
+    .map_err(|e| {
+        SchemaError::DatabaseError(format!("Failed to fetch domain constraint comments: {e}"))
+    })?;
+
+    let mut result = BTreeMap::new();
+    for row in rows {
+        let domain_schema: String = row.get("domain_schema");
+        let domain_name: String = row.get("domain_name");
+        let constraint_name: String = row.get("constraint_name");
+        let comment: String = row.get("comment");
+        result.insert(
+            format!("{domain_schema}.{domain_name}.{constraint_name}"),
+            comment,
+        );
+    }
     Ok(result)
 }
 

--- a/src/pg/sqlgen.rs
+++ b/src/pg/sqlgen.rs
@@ -554,6 +554,7 @@ fn generate_op_sql(op: &MigrationOp) -> Vec<String> {
             arguments,
             column,
             target,
+            on_domain,
             comment,
         } => {
             let object_sql = match object_type {
@@ -610,6 +611,20 @@ fn generate_op_sql(op: &MigrationOp) -> Vec<String> {
                     format!(
                         "POLICY {} ON {}",
                         quote_ident(name),
+                        quote_qualified(schema, target_name)
+                    )
+                }
+                CommentObjectType::Constraint => {
+                    let target_name = target.as_deref().unwrap_or_else(|| {
+                        panic!(
+                            "SetComment(Constraint) requires `target` (parent table or domain), got None for {schema}.{name}"
+                        )
+                    });
+                    let relation_kind = if *on_domain { "DOMAIN " } else { "" };
+                    format!(
+                        "CONSTRAINT {} ON {}{}",
+                        quote_ident(name),
+                        relation_kind,
                         quote_qualified(schema, target_name)
                     )
                 }
@@ -2258,6 +2273,7 @@ mod tests {
             arguments: None,
             column: None,
             target: Some("users".to_string()),
+            on_domain: false,
             comment: Some("self-access only".to_string()),
         }];
 
@@ -2278,6 +2294,7 @@ mod tests {
             arguments: None,
             column: None,
             target: Some("users".to_string()),
+            on_domain: false,
             comment: None,
         }];
 
@@ -2298,6 +2315,7 @@ mod tests {
             arguments: None,
             column: None,
             target: None,
+            on_domain: false,
             comment: Some("UUID helpers".to_string()),
         }];
 
@@ -2318,12 +2336,76 @@ mod tests {
             arguments: None,
             column: None,
             target: None,
+            on_domain: false,
             comment: None,
         }];
 
         let sql = generate_sql(&ops);
         assert_eq!(sql.len(), 1);
         assert_eq!(sql[0], "COMMENT ON EXTENSION \"hstore\" IS NULL;");
+    }
+
+    #[test]
+    fn set_comment_constraint_on_table_generates_valid_sql() {
+        let ops = vec![MigrationOp::SetComment {
+            object_type: CommentObjectType::Constraint,
+            schema: "public".to_string(),
+            name: "users_pkey".to_string(),
+            arguments: None,
+            column: None,
+            target: Some("users".to_string()),
+            on_domain: false,
+            comment: Some("primary key".to_string()),
+        }];
+
+        let sql = generate_sql(&ops);
+        assert_eq!(sql.len(), 1);
+        assert_eq!(
+            sql[0],
+            "COMMENT ON CONSTRAINT \"users_pkey\" ON \"public\".\"users\" IS 'primary key';"
+        );
+    }
+
+    #[test]
+    fn set_comment_constraint_on_domain_generates_valid_sql() {
+        let ops = vec![MigrationOp::SetComment {
+            object_type: CommentObjectType::Constraint,
+            schema: "public".to_string(),
+            name: "positive".to_string(),
+            arguments: None,
+            column: None,
+            target: Some("amount".to_string()),
+            on_domain: true,
+            comment: Some("amount > 0".to_string()),
+        }];
+
+        let sql = generate_sql(&ops);
+        assert_eq!(sql.len(), 1);
+        assert_eq!(
+            sql[0],
+            "COMMENT ON CONSTRAINT \"positive\" ON DOMAIN \"public\".\"amount\" IS 'amount > 0';"
+        );
+    }
+
+    #[test]
+    fn set_comment_constraint_null_clears() {
+        let ops = vec![MigrationOp::SetComment {
+            object_type: CommentObjectType::Constraint,
+            schema: "public".to_string(),
+            name: "users_pkey".to_string(),
+            arguments: None,
+            column: None,
+            target: Some("users".to_string()),
+            on_domain: false,
+            comment: None,
+        }];
+
+        let sql = generate_sql(&ops);
+        assert_eq!(sql.len(), 1);
+        assert_eq!(
+            sql[0],
+            "COMMENT ON CONSTRAINT \"users_pkey\" ON \"public\".\"users\" IS NULL;"
+        );
     }
 
     #[test]

--- a/tests/corpus/upstream_pg/alter_table.silent_drops.txt
+++ b/tests/corpus/upstream_pg/alter_table.silent_drops.txt
@@ -5,5 +5,4 @@
 #
 # Regenerate via:  PGMOLD_UPDATE_SILENT_DROPS=1 cargo test --test corpus_upstream_pg
 
-COMMENT ON CONSTRAINT
 COMMENT ON INDEX

--- a/tests/edge_cases.rs
+++ b/tests/edge_cases.rs
@@ -371,6 +371,96 @@ async fn extension_comment_round_trips_through_apply_and_introspect() {
 }
 
 #[tokio::test]
+async fn table_constraint_comment_round_trips_through_apply_and_introspect() {
+    let (_container, url) = setup_postgres().await;
+    let connection = PgConnection::new(&url).await.unwrap();
+
+    let target = parse_sql_string(
+        r#"
+        CREATE TABLE public.users (
+            id BIGINT NOT NULL,
+            CONSTRAINT users_pkey PRIMARY KEY (id),
+            CONSTRAINT users_id_positive CHECK (id > 0)
+        );
+        COMMENT ON CONSTRAINT users_id_positive ON public.users IS 'must be positive';
+        "#,
+    )
+    .unwrap();
+
+    let current = introspect_schema(&connection, &["public".to_string()], false)
+        .await
+        .unwrap();
+
+    let sql_stmts = generate_sql(&plan_migration(compute_diff(&current, &target)));
+    for stmt in &sql_stmts {
+        sqlx::query(stmt)
+            .execute(connection.pool())
+            .await
+            .unwrap_or_else(|error| panic!("Failed to execute statement: {stmt}\nError: {error}"));
+    }
+
+    let after = introspect_schema(&connection, &["public".to_string()], false)
+        .await
+        .unwrap();
+    assert_eq!(
+        after
+            .table_constraint_comments
+            .get("public.users.users_id_positive")
+            .map(String::as_str),
+        Some("must be positive"),
+    );
+
+    let drift_ops = compute_diff(&after, &target);
+    assert!(
+        drift_ops.is_empty(),
+        "no drift expected after apply; got {drift_ops:?}"
+    );
+}
+
+#[tokio::test]
+async fn domain_constraint_comment_round_trips_through_apply_and_introspect() {
+    let (_container, url) = setup_postgres().await;
+    let connection = PgConnection::new(&url).await.unwrap();
+
+    let target = parse_sql_string(
+        r#"
+        CREATE DOMAIN public.amount AS INTEGER CONSTRAINT amount_positive CHECK (VALUE > 0);
+        COMMENT ON CONSTRAINT amount_positive ON DOMAIN public.amount IS 'must be positive';
+        "#,
+    )
+    .unwrap();
+
+    let current = introspect_schema(&connection, &["public".to_string()], false)
+        .await
+        .unwrap();
+
+    let sql_stmts = generate_sql(&plan_migration(compute_diff(&current, &target)));
+    for stmt in &sql_stmts {
+        sqlx::query(stmt)
+            .execute(connection.pool())
+            .await
+            .unwrap_or_else(|error| panic!("Failed to execute statement: {stmt}\nError: {error}"));
+    }
+
+    let after = introspect_schema(&connection, &["public".to_string()], false)
+        .await
+        .unwrap();
+    assert_eq!(
+        after
+            .domain_constraint_comments
+            .get("public.amount.amount_positive")
+            .map(String::as_str),
+        Some("must be positive"),
+    );
+
+    let drift_ops = compute_diff(&after, &target);
+    assert!(
+        drift_ops.is_empty(),
+        "no drift expected after apply; got {drift_ops:?}"
+    );
+}
+
+#[tokio::test]
 async fn policy_comment_round_trips_through_apply_and_introspect() {
     let (_container, url) = setup_postgres().await;
     let connection = PgConnection::new(&url).await.unwrap();


### PR DESCRIPTION
## Summary

Wires `COMMENT ON CONSTRAINT name ON [DOMAIN] target IS '...'` end-to-end so constraint comments survive round-trip and converge. Mirrors pgmold-296 (POLICY) and pgmold-295 (EXTENSION). Previously the AST handler dropped these with a warning.

## Design

Constraint comments are stored as Schema-level sidecar `BTreeMap<String, String>` (`table_constraint_comments`, `domain_constraint_comments`) keyed `"schema.parent.constraint_name"`, rather than as fields on the per-kind constraint structs (`ForeignKey` / `CheckConstraint` / `Index` / `ExclusionConstraint` / `DomainConstraint`). The sidecar form keeps the blast radius confined to `Schema` and avoids touching ~290 constructor sites across the codebase. The constraint kind is irrelevant for emitting `COMMENT ON CONSTRAINT` because PostgreSQL resolves it from `pg_constraint` at apply time.

`SetComment` / `OpKey::SetComment` gain an `on_domain: bool` so the same constraint name on a table and on a domain produces two distinct ops; `PendingComment` carries the same flag.

## Pipeline

- `parser/comments.rs` pushes `PendingCommentObjectType::Constraint` onto the queue with `on_domain` from the AST
- `Schema::apply_single_comment` routes Constraint comments into the matching sidecar after `finalize()` validates the parent exists
- `diff_constraint_comments` emits `SetComment` on every text difference (added / changed / cleared via `IS NULL`)
- Planner orders `SetComment(Constraint)` after `CreateTable` / `CreateDomain` and every plausible `Add{PrimaryKey,Index,FK,Check,Exclusion}` producer
- `sqlgen` emits `COMMENT ON CONSTRAINT "name" ON [DOMAIN] "schema"."target" IS '...'`
- `dump` emits sidecar entries after each parent via `push_constraint_comment_ops`
- `introspect_table_constraint_comments` / `introspect_domain_constraint_comments` read `obj_description(con.oid, 'pg_constraint')`
- `filter` preserves sidecars then drops orphans via `Schema::drop_orphan_constraint_comments`
- `unrecognized.rs` no longer flags `COMMENT ON CONSTRAINT`; `alter_table.silent_drops.txt` loses its line

## Follow-up

pgmold-304 filed: introspection filters `relispartition = false`, so `COMMENT ON CONSTRAINT` placed directly on a partition child table is silently lost on round-trip. Matches how the rest of `introspect.rs` treats partition children; tracked separately.

## Test plan

- [x] Parser unit tests in `src/parser/tests.rs` cover capture, NULL clear, dump round-trip for both `ON <table>` and `ON DOMAIN`, and orphan drop
- [x] `parser/unrecognized.rs` test flipped from `comment_on_constraint_flagged` to `comment_on_constraint_on_table_not_flagged` + `_on_domain_not_flagged`
- [x] `diff/mod.rs` unit tests cover added / changed / cleared / unchanged for the table sidecar plus the `on_domain=true` case
- [x] `sqlgen` unit tests cover both forms and the `IS NULL` clear
- [x] End-to-end tests in `tests/edge_cases.rs` apply against a real PostgreSQL container, introspect, and assert no drift on second diff
- [x] `cargo fmt --all`

Closes pgmold-301.