### PR TITLE
pgmold-304: COMMENT ON CONSTRAINT on partition children round-trips

### DIFF
--- a/src/diff/planner.rs
+++ b/src/diff/planner.rs
@@ -1135,11 +1135,13 @@ impl MigrationGraph {
                             // ALTER ADD forms get their own edges.
                             let target_name = require(target, "Constraint", "target");
                             let parent = QualifiedName::new(schema, &target_name);
+                            let parent_qualified = qualified_name(schema, &target_name);
                             let candidates: Vec<OpKey> = if *on_domain {
-                                vec![OpKey::CreateDomain(qualified_name(schema, &target_name))]
+                                vec![OpKey::CreateDomain(parent_qualified)]
                             } else {
                                 vec![
-                                    OpKey::CreateTable(qualified_name(schema, &target_name)),
+                                    OpKey::CreateTable(parent_qualified.clone()),
+                                    OpKey::CreatePartition(parent_qualified),
                                     OpKey::AddPrimaryKey {
                                         table: parent.clone(),
                                     },

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -395,6 +395,13 @@ pub fn schema_to_create_ops(schema: &Schema) -> Vec<MigrationOp> {
 
     for partition in schema.partitions.values() {
         ops.push(MigrationOp::CreatePartition(partition.clone()));
+        push_constraint_comment_ops(
+            &mut ops,
+            &schema.table_constraint_comments,
+            &partition.schema,
+            &partition.name,
+            false,
+        );
     }
 
     for function in schema.functions.values() {

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1378,9 +1378,12 @@ impl Schema {
             }
             PendingCommentObjectType::Constraint => {
                 // Key encodes schema.parent.constraint_name where parent is
-                // either a table (default) or a domain (when on_domain).
-                // Routed through the matching Schema-level sidecar map so we
-                // do not have to mutate every constraint variant struct.
+                // either a table, a partition child, or a domain (when
+                // on_domain). Routed through the matching Schema-level
+                // sidecar map so we do not have to mutate every constraint
+                // variant struct. Partition children share the table sidecar
+                // because PostgreSQL stores constraint comments on the child
+                // relation, and the diff/emit path is parent-kind agnostic.
                 let Some((parent_key, _)) = pc.object_key.rsplit_once('.') else {
                     return false;
                 };
@@ -1394,7 +1397,9 @@ impl Schema {
                         pc.comment.as_ref(),
                     );
                 } else {
-                    if !self.tables.contains_key(parent_key) {
+                    if !self.tables.contains_key(parent_key)
+                        && !self.partitions.contains_key(parent_key)
+                    {
                         return false;
                     }
                     update_constraint_comment(
@@ -1417,9 +1422,11 @@ impl Schema {
     /// granularity, and PostgreSQL will surface the mismatch at apply time.
     pub fn drop_orphan_constraint_comments(&mut self) {
         let tables = &self.tables;
+        let partitions = &self.partitions;
         self.table_constraint_comments.retain(|key, _| {
-            key.rsplit_once('.')
-                .is_some_and(|(parent, _)| tables.contains_key(parent))
+            key.rsplit_once('.').is_some_and(|(parent, _)| {
+                tables.contains_key(parent) || partitions.contains_key(parent)
+            })
         });
         let domains = &self.domains;
         self.domain_constraint_comments.retain(|key, _| {

--- a/src/pg/introspect.rs
+++ b/src/pg/introspect.rs
@@ -1582,6 +1582,11 @@ async fn introspect_all_policies(
 /// in the target schemas. Returns a map keyed by
 /// `"schema.table.constraint_name"` so the diff path can iterate it
 /// alongside the source-side sidecar without needing per-kind lookups.
+///
+/// Partition children (`relispartition = true`) are included: PostgreSQL
+/// stores their constraint comments on the child relation, not the parent,
+/// and `COMMENT ON CONSTRAINT name ON child_table` is the syntactic form
+/// pgmold must round-trip.
 async fn introspect_table_constraint_comments(
     connection: &PgConnection,
     target_schemas: &[String],
@@ -1598,7 +1603,6 @@ async fn introspect_table_constraint_comments(
         JOIN pg_namespace n ON c.relnamespace = n.oid
         WHERE n.nspname = ANY($1::text[])
           AND c.relkind IN ('r', 'p')
-          AND c.relispartition = false
           AND obj_description(con.oid, 'pg_constraint') IS NOT NULL
         "#,
     )

--- a/tests/edge_cases.rs
+++ b/tests/edge_cases.rs
@@ -461,6 +461,76 @@ async fn domain_constraint_comment_round_trips_through_apply_and_introspect() {
 }
 
 #[tokio::test]
+async fn partition_child_constraint_comment_round_trips_through_apply_and_introspect() {
+    let (_container, url) = setup_postgres().await;
+    let connection = PgConnection::new(&url).await.unwrap();
+
+    sqlx::query(
+        r#"
+        CREATE TABLE public.measurement (
+            city_id INT NOT NULL,
+            logdate DATE NOT NULL,
+            peaktemp INT
+        ) PARTITION BY RANGE (logdate);
+        CREATE TABLE public.measurement_2024 PARTITION OF public.measurement
+            FOR VALUES FROM ('2024-01-01') TO ('2025-01-01');
+        ALTER TABLE public.measurement_2024
+            ADD CONSTRAINT measurement_2024_peak_positive CHECK (peaktemp > 0);
+        "#,
+    )
+    .execute(connection.pool())
+    .await
+    .unwrap();
+
+    let target = parse_sql_string(
+        r#"
+        CREATE TABLE public.measurement (
+            city_id INT NOT NULL,
+            logdate DATE NOT NULL,
+            peaktemp INT
+        ) PARTITION BY RANGE (logdate);
+        CREATE TABLE public.measurement_2024 PARTITION OF public.measurement
+            FOR VALUES FROM ('2024-01-01') TO ('2025-01-01');
+        ALTER TABLE public.measurement_2024
+            ADD CONSTRAINT measurement_2024_peak_positive CHECK (peaktemp > 0);
+        COMMENT ON CONSTRAINT measurement_2024_peak_positive ON public.measurement_2024
+            IS 'partition-local sanity check';
+        "#,
+    )
+    .unwrap();
+
+    let current = introspect_schema(&connection, &["public".to_string()], false)
+        .await
+        .unwrap();
+
+    let sql_stmts = generate_sql(&plan_migration(compute_diff(&current, &target)));
+    for stmt in &sql_stmts {
+        sqlx::query(stmt)
+            .execute(connection.pool())
+            .await
+            .unwrap_or_else(|error| panic!("Failed to execute statement: {stmt}\nError: {error}"));
+    }
+
+    let after = introspect_schema(&connection, &["public".to_string()], false)
+        .await
+        .unwrap();
+    assert_eq!(
+        after
+            .table_constraint_comments
+            .get("public.measurement_2024.measurement_2024_peak_positive")
+            .map(String::as_str),
+        Some("partition-local sanity check"),
+        "introspect must capture COMMENT ON CONSTRAINT on partition child"
+    );
+
+    let drift_ops = compute_diff(&after, &target);
+    assert!(
+        drift_ops.is_empty(),
+        "no drift expected after apply; got {drift_ops:?}"
+    );
+}
+
+#[tokio::test]
 async fn policy_comment_round_trips_through_apply_and_introspect() {
     let (_container, url) = setup_postgres().await;
     let connection = PgConnection::new(&url).await.unwrap();

--- a/tests/edge_cases.rs
+++ b/tests/edge_cases.rs
@@ -465,22 +465,25 @@ async fn partition_child_constraint_comment_round_trips_through_apply_and_intros
     let (_container, url) = setup_postgres().await;
     let connection = PgConnection::new(&url).await.unwrap();
 
-    sqlx::query(
+    for stmt in [
         r#"
         CREATE TABLE public.measurement (
             city_id INT NOT NULL,
             logdate DATE NOT NULL,
             peaktemp INT
-        ) PARTITION BY RANGE (logdate);
-        CREATE TABLE public.measurement_2024 PARTITION OF public.measurement
-            FOR VALUES FROM ('2024-01-01') TO ('2025-01-01');
-        ALTER TABLE public.measurement_2024
-            ADD CONSTRAINT measurement_2024_peak_positive CHECK (peaktemp > 0);
+        ) PARTITION BY RANGE (logdate)
         "#,
-    )
-    .execute(connection.pool())
-    .await
-    .unwrap();
+        r#"
+        CREATE TABLE public.measurement_2024 PARTITION OF public.measurement
+            FOR VALUES FROM ('2024-01-01') TO ('2025-01-01')
+        "#,
+        r#"
+        ALTER TABLE public.measurement_2024
+            ADD CONSTRAINT measurement_2024_peak_positive CHECK (peaktemp > 0)
+        "#,
+    ] {
+        sqlx::query(stmt).execute(connection.pool()).await.unwrap();
+    }
 
     let target = parse_sql_string(
         r#"


### PR DESCRIPTION
## Summary

Fixes pgmold-304. Introspection filtered partition children with `relispartition = false`, so any `COMMENT ON CONSTRAINT name ON child_partition IS '...'` was silently dropped on round-trip.

## Approach

The diff / emit / sqlgen path is already parent-kind agnostic — `SetComment(Constraint)` only carries the parent's relation name and emits `COMMENT ON CONSTRAINT name ON schema.target IS '...'` whatever the target is. Reuse the existing `Schema.table_constraint_comments` sidecar instead of introducing a new model field.

## Changes

- `src/pg/introspect.rs` — drop the `relispartition = false` filter from `introspect_table_constraint_comments`.
- `src/model/mod.rs` — `apply_pending_comment` (Constraint, non-domain) and `drop_orphan_constraint_comments` accept a parent in `tables` OR `partitions`.
- `src/dump.rs` — iterate `schema.partitions` and push their constraint comment ops alongside the existing per-table loop.
- `src/diff/planner.rs` — add `OpKey::CreatePartition` to the Constraint SetComment producer candidate list so the comment depends on the partition that owns it (existing `add_edge` silently skips unmatched candidates).
- `tests/edge_cases.rs` — new integration test that seeds a partition + child + constraint via raw SQL, parses a target SQL adding the comment, plans + applies, re-introspects, and asserts both the comment is captured and `compute_diff(after, target)` is empty.

## Test plan

- [x] `cargo fmt --all`
- [x] New integration `partition_child_constraint_comment_round_trips_through_apply_and_introspect` exercises the failure mode (would fail under old `relispartition = false` filter — `after.table_constraint_comments` empty, drift non-empty)
- [ ] CI: `cargo test`

## Follow-up

pgmold-305 (P3, discovered-from): pin behavior of constraints inherited from a partitioned parent — explicit test for `coninhparent = true` rows on children to confirm no spurious drift in either placement.