### PR TITLE
chore: bump version to 0.34.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1587,7 +1587,7 @@ dependencies = [
 
 [[package]]
 name = "pgmold"
-version = "0.34.9"
+version = "0.34.10"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "pgmold"
-version = "0.34.9"
+version = "0.34.10"
 edition = "2021"
 exclude = [".auto-claude/", ".auto-claude-security.json", ".claude_settings.json"]
 description = "PostgreSQL schema-as-code management tool"


### PR DESCRIPTION
Release v0.34.10 — fixes #281 (planner emits DROP POLICY + ALTER POLICY for the same policy in one plan).

Includes the same DROP+ALTER conflict fix for views (column-type-change path), a plan-level invariant `debug_assert` over policies and views, and tightened policy-expression normalization for 3-part qualified identifiers.

Merged: #282.