### PR TITLE
pgmold-288: parse ALTER SCHEMA ... OWNER TO

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -32,14 +32,14 @@ use crate::pg::sqlgen::strip_ident_quotes;
 use crate::util::{normalize_sql_whitespace, Result, SchemaError};
 use sqlparser::ast::{
     Action, AlterDefaultPrivileges, AlterDefaultPrivilegesAction, AlterDefaultPrivilegesObjectType,
-    AlterFunction, AlterFunctionKind, AlterFunctionOperation, AlterIndexOperation, AlterTable,
-    AlterTableOperation, AlterType, AlterTypeAddValue, AlterTypeAddValuePosition,
-    AlterTypeOperation, CreateAggregate, CreateAggregateOption, CreateDomain, CreateExtension,
-    CreateFunction, CreateServerStatement, CreateTrigger, CreateView, DeferrableInitial,
-    DropDomain, DropExtension, DropFunction, DropTrigger, FunctionParallel, Grantee, GranteeName,
-    GranteesType, ObjectType, Owner, Privileges, RenameTableNameKind, SchemaName, Statement,
-    TableConstraint, TriggerEvent as SqlTriggerEvent, TriggerPeriod, TriggerReferencingType,
-    UserDefinedTypeRepresentation,
+    AlterFunction, AlterFunctionKind, AlterFunctionOperation, AlterIndexOperation, AlterSchema,
+    AlterSchemaOperation, AlterTable, AlterTableOperation, AlterType, AlterTypeAddValue,
+    AlterTypeAddValuePosition, AlterTypeOperation, CreateAggregate, CreateAggregateOption,
+    CreateDomain, CreateExtension, CreateFunction, CreateServerStatement, CreateTrigger,
+    CreateView, DeferrableInitial, DropDomain, DropExtension, DropFunction, DropTrigger,
+    FunctionParallel, Grantee, GranteeName, GranteesType, ObjectType, Owner, Privileges,
+    RenameTableNameKind, SchemaName, Statement, TableConstraint, TriggerEvent as SqlTriggerEvent,
+    TriggerPeriod, TriggerReferencingType, UserDefinedTypeRepresentation,
 };
 use sqlparser::dialect::PostgreSqlDialect;
 use sqlparser::parser::Parser;
@@ -655,6 +655,22 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
                     | AlterTypeOperation::RenameAttribute { .. } => {}
                 }
             }
+            Statement::AlterSchema(AlterSchema { operations, .. }) => {
+                // `PgSchema` does not yet carry an `owner` field, so OWNER TO
+                // accepts-and-ignores like ALTER TYPE SET SCHEMA. Other
+                // operations (Rename, SetDefaultCollate, replica/options ops)
+                // are BigQuery-flavoured or storage-only and not modelled.
+                for op in operations {
+                    match op {
+                        AlterSchemaOperation::OwnerTo { .. }
+                        | AlterSchemaOperation::Rename { .. }
+                        | AlterSchemaOperation::SetDefaultCollate { .. }
+                        | AlterSchemaOperation::AddReplica { .. }
+                        | AlterSchemaOperation::DropReplica { .. }
+                        | AlterSchemaOperation::SetOptionsParens { .. } => {}
+                    }
+                }
+            }
             Statement::AlterDefaultPrivileges(adp) => {
                 apply_alter_default_privileges(adp, &mut schema);
             }
@@ -1260,7 +1276,6 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
             // pgmold consumes `AlterTable` (above) but not these sibling
             // ALTER variants yet.
             Statement::AlterView { .. }
-            | Statement::AlterSchema(_)
             | Statement::AlterPolicy { .. }
             | Statement::RenameTable(_)
             // Maintenance ops (VACUUM / ANALYZE / LOCK TABLE, etc.).

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -3732,6 +3732,26 @@ fn parses_alter_type_attribute_ops_no_model_effect() {
 }
 
 #[test]
+fn parses_alter_schema_owner_to_no_model_effect() {
+    let sql = r#"
+        CREATE SCHEMA foo;
+        ALTER SCHEMA "foo" OWNER TO "bar";
+    "#;
+    let schema = parse_sql_string(sql).expect("ALTER SCHEMA OWNER TO must parse without error");
+    assert!(schema.schemas.contains_key("foo"));
+}
+
+#[test]
+fn alter_schema_owner_to_does_not_warn() {
+    let sql = "ALTER SCHEMA \"foo\" OWNER TO \"bar\";";
+    let findings = find_unrecognized_statements(sql);
+    assert!(
+        findings.is_empty(),
+        "expected no unrecognized findings for ALTER SCHEMA OWNER TO, got: {findings:?}"
+    );
+}
+
+#[test]
 fn parses_alter_default_privileges_multi_grantee() {
     let sql = r#"
         ALTER DEFAULT PRIVILEGES FOR ROLE admin IN SCHEMA public

--- a/src/parser/unrecognized.rs
+++ b/src/parser/unrecognized.rs
@@ -56,11 +56,9 @@ static REVOKE_BROAD: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"(?is)\bREVOKE\s+[^;]+;").unwrap());
 
 // Restricted to the object kinds whose OWNER TO is routed through the
-// preprocess strip + ownership.rs regex pass. ALTER AGGREGATE ... OWNER
-// TO is parsed through the sqlparser AST path instead and must not appear
-// here. SCHEMA is included: preprocess leaves it alone and sqlparser's
-// AlterSchema is ignored in parser/mod.rs, so owner changes there are
-// silently dropped — exactly the shape this detector exists to surface.
+// preprocess strip + ownership.rs regex pass, plus the AST-handled kinds
+// (TYPE, SCHEMA). ALTER AGGREGATE ... OWNER TO is parsed through the
+// sqlparser AST path instead and must not appear here.
 static ALTER_OWNER_BROAD: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
         r"(?is)\bALTER\s+(?:TABLE|FUNCTION|TYPE|DOMAIN|MATERIALIZED\s+VIEW|VIEW|SEQUENCE|SCHEMA)\s+[^;]+?\s+OWNER\s+TO\s+[^;]+;",
@@ -130,6 +128,8 @@ static ALTER_VIEW_OWNER_CLAIM: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"(?is)\bALTER\s+VIEW\s+.+?\s+OWNER\s+TO\s+").unwrap());
 static ALTER_SEQUENCE_OWNER_CLAIM: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"(?is)\bALTER\s+SEQUENCE\s+.+?\s+OWNER\s+TO\s+").unwrap());
+static ALTER_SCHEMA_OWNER_CLAIM: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?is)\bALTER\s+SCHEMA\s+.+?\s+OWNER\s+TO\s+").unwrap());
 
 // AST-handled since pgmold-289: any well-formed statement is processed by
 // `apply_alter_default_privileges` regardless of role/schema/grantee count
@@ -186,6 +186,7 @@ static RECOGNIZERS: &[BroadRecognizer] = &[
             &ALTER_MATERIALIZED_VIEW_OWNER_CLAIM,
             &ALTER_VIEW_OWNER_CLAIM,
             &ALTER_SEQUENCE_OWNER_CLAIM,
+            &ALTER_SCHEMA_OWNER_CLAIM,
         ],
     },
     BroadRecognizer {
@@ -370,11 +371,15 @@ COMMENT ON TABLE public.users IS 'a table';
     }
 
     #[test]
-    fn alter_schema_owner_flagged() {
+    fn alter_schema_owner_not_flagged() {
         let sql = "ALTER SCHEMA foo OWNER TO bar;";
-        let findings = find_unrecognized_statements(sql);
-        assert_eq!(findings.len(), 1);
-        assert_eq!(findings[0].kind, "ALTER ... OWNER TO");
+        assert!(find_unrecognized_statements(sql).is_empty());
+    }
+
+    #[test]
+    fn alter_schema_owner_quoted_not_flagged() {
+        let sql = "ALTER SCHEMA \"foo\" OWNER TO \"bar\";";
+        assert!(find_unrecognized_statements(sql).is_empty());
     }
 
     #[test]
@@ -440,14 +445,13 @@ END $$;
     fn multiple_unrecognized_statements_reported() {
         let sql = "\
 COMMENT ON INDEX public.idx_foo IS 'a';
-ALTER SCHEMA foo OWNER TO bar;
+ALTER COLLATION foo OWNER TO bar;
 GRANT role1 TO alice;
 ";
         let findings = find_unrecognized_statements(sql);
-        assert_eq!(findings.len(), 3);
+        assert_eq!(findings.len(), 2);
         let kinds: Vec<&str> = findings.iter().map(|f| f.kind).collect();
         assert!(kinds.contains(&"COMMENT ON"));
-        assert!(kinds.contains(&"ALTER ... OWNER TO"));
         assert!(kinds.contains(&"GRANT"));
     }
 }

--- a/tests/corpus/upstream_pg/privileges.silent_drops.txt
+++ b/tests/corpus/upstream_pg/privileges.silent_drops.txt
@@ -5,7 +5,6 @@
 #
 # Regenerate via:  PGMOLD_UPDATE_SILENT_DROPS=1 cargo test --test corpus_upstream_pg
 
-ALTER SCHEMA OWNER TO
 GRANT ... ON <implicit>
 GRANT <role> TO ...
 REVOKE <role> FROM ...


### PR DESCRIPTION
Closes #288.

`ALTER SCHEMA <name> OWNER TO <role>` was the last `ALTER ... OWNER TO`
target still surfaced as a silent-drop warning. ALTER TABLE / FUNCTION /
TYPE / DOMAIN / VIEW / MATERIALIZED VIEW / SEQUENCE were already routed
through either the regex pass or the AST handler from PR #270 (pgmold-289).

## Summary

- `src/parser/mod.rs`: handle `Statement::AlterSchema` explicitly. `PgSchema` does not yet model an owner field, so `OwnerTo` accepts-and-ignores (same pattern PR #270 used for `AlterTypeOperation::SetSchema`). Other operations (`Rename`, `SetDefaultCollate`, replica/options ops) are BigQuery-flavoured or storage-only and not modelled. Removed the no-op `Statement::AlterSchema(_)` arm so the AST variant is not double-claimed.
- `src/parser/unrecognized.rs`: add `ALTER_SCHEMA_OWNER_CLAIM` so the broad `ALTER ... OWNER TO` recognizer treats well-formed ALTER SCHEMA OWNER TO as claimed.
- `tests/corpus/upstream_pg/privileges.silent_drops.txt`: drop the `ALTER SCHEMA OWNER TO` shape from the upstream-pg silent-drops snapshot — the corpus fixture (`privileges.sql:1681 ALTER SCHEMA testns OWNER TO regress_schemauser2`) no longer surfaces.

## Test plan

- [ ] CI: `cargo test --test corpus_upstream_pg upstream_pg_silent_drops_match_snapshot` passes against the trimmed snapshot.
- [ ] CI: `parses_alter_schema_owner_to_no_model_effect` parses `ALTER SCHEMA "foo" OWNER TO "bar"` cleanly.
- [ ] CI: `alter_schema_owner_to_does_not_warn` confirms `find_unrecognized_statements` returns empty.
- [ ] CI: `alter_schema_owner_not_flagged` and `alter_schema_owner_quoted_not_flagged` cover the recognizer claim path.
- [ ] Manual: re-run the sagri/mrv apply that originally surfaced the warning; the `pgmold did not recognize ALTER ... OWNER TO statement ... ALTER SCHEMA` line should no longer appear.