### PR TITLE
pgmold-289: dedup auto-generated CHECK constraint names

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -56,7 +56,8 @@ use ownership::parse_owner_statements;
 use preprocess::preprocess_sql;
 use sequences::parse_create_sequence;
 use tables::{
-    apply_primary_key, parse_column_with_serial, parse_create_table, parse_referential_action,
+    apply_primary_key, dedup_check_constraint_name, parse_column_with_serial, parse_create_table,
+    parse_referential_action,
 };
 use util::{
     extract_qualified_name, normalize_expr, parse_data_type, parse_for_values,
@@ -324,11 +325,13 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
                                         });
                                     }
                                     TableConstraint::Check(chk) => {
-                                        let constraint_name = chk
-                                            .name
-                                            .as_ref()
-                                            .map(|n| unquote_ident(&n.to_string()).to_string())
-                                            .unwrap_or_else(|| format!("{tbl_name}_check"));
+                                        let constraint_name = match &chk.name {
+                                            Some(name) => unquote_ident(&name.to_string()).to_string(),
+                                            None => dedup_check_constraint_name(
+                                                &format!("{tbl_name}_check"),
+                                                table,
+                                            ),
+                                        };
 
                                         table.check_constraints.push(CheckConstraint {
                                             name: constraint_name,

--- a/src/parser/tables.rs
+++ b/src/parser/tables.rs
@@ -16,6 +16,7 @@ use std::collections::BTreeMap;
 
 use super::util::{
     extract_qualified_name, normalize_expr, parse_data_type, truncate_identifier, unquote_ident,
+    PG_MAX_IDENTIFIER_LENGTH,
 };
 
 pub(super) struct ParsedTable {
@@ -120,22 +121,21 @@ pub(super) fn parse_create_table(
                     });
                 }
                 ColumnOption::Check(chk) => {
-                    let constraint_name = explicit_name.clone().unwrap_or_else(|| {
-                        // Postgres names unnamed CHECKs after the columns the expression
-                        // *references*, not the column they are attached to. Walk the
-                        // expression and apply the same single-vs-multi logic as the
-                        // out-of-line path so inline and table-level CHECKs converge.
-                        let table_cols: Vec<&str> =
-                            table.columns.keys().map(|s| s.as_str()).collect();
-                        let referenced = collect_referenced_columns(&chk.expr, &table_cols);
-                        if referenced.len() == 1 {
-                            format!("{}_{}_check", table.name, referenced[0])
-                        } else {
-                            format!("{}_check", table.name)
+                    let constraint_name = match &explicit_name {
+                        Some(name) => truncate_identifier(name),
+                        None => {
+                            let table_cols: Vec<&str> =
+                                table.columns.keys().map(|s| s.as_str()).collect();
+                            let base = default_check_constraint_base_name(
+                                &table.name,
+                                &chk.expr,
+                                &table_cols,
+                            );
+                            dedup_check_constraint_name(&base, &table)
                         }
-                    });
+                    };
                     table.check_constraints.push(CheckConstraint {
-                        name: truncate_identifier(&constraint_name),
+                        name: constraint_name,
                         expression: normalize_expr(&chk.expr.to_string()),
                     });
                 }
@@ -194,26 +194,19 @@ pub(super) fn parse_create_table(
                 });
             }
             TableConstraint::Check(chk) => {
-                let constraint_name = chk
-                    .name
-                    .as_ref()
-                    .map(|n| unquote_ident(&n.to_string()).to_string())
-                    .unwrap_or_else(|| {
-                        // Postgres names unnamed CHECKs `{table}_{column}_check` when the
-                        // expression references exactly one known column, and `{table}_check`
-                        // otherwise.
+                let constraint_name = match &chk.name {
+                    Some(name) => truncate_identifier(unquote_ident(&name.to_string())),
+                    None => {
                         let table_cols: Vec<&str> =
                             table.columns.keys().map(|s| s.as_str()).collect();
-                        let referenced = collect_referenced_columns(&chk.expr, &table_cols);
-                        if referenced.len() == 1 {
-                            format!("{}_{}_check", table.name, referenced[0])
-                        } else {
-                            format!("{}_check", table.name)
-                        }
-                    });
+                        let base =
+                            default_check_constraint_base_name(&table.name, &chk.expr, &table_cols);
+                        dedup_check_constraint_name(&base, &table)
+                    }
+                };
 
                 table.check_constraints.push(CheckConstraint {
-                    name: truncate_identifier(&constraint_name),
+                    name: constraint_name,
                     expression: normalize_expr(&chk.expr.to_string()),
                 });
             }
@@ -493,6 +486,54 @@ pub(super) fn parse_referential_action(action: &Option<SqlReferentialAction>) ->
         Some(SqlReferentialAction::SetDefault) => ReferentialAction::SetDefault,
         None => ReferentialAction::NoAction,
     }
+}
+
+/// Pick the Postgres-compatible default name for an unnamed CHECK constraint, given the
+/// expression and the table's columns. Postgres' `ChooseConstraintName` builds the base
+/// name as `{table}_{column}_check` when the expression references exactly one known
+/// column, and `{table}_check` otherwise.
+pub(super) fn default_check_constraint_base_name(
+    table_name: &str,
+    expr: &Expr,
+    table_columns: &[&str],
+) -> String {
+    let referenced = collect_referenced_columns(expr, table_columns);
+    if referenced.len() == 1 {
+        format!("{}_{}_check", table_name, referenced[0])
+    } else {
+        format!("{}_check", table_name)
+    }
+}
+
+/// Disambiguate a candidate constraint name against the names already taken by CHECK
+/// constraints on the same table. Mirrors Postgres' `ChooseConstraintName` numeric-suffix
+/// scheme: if `base` is free, use it as-is; otherwise try `{base}1`, `{base}2`, ... until
+/// a free slot is found. When the base is at the 63-byte cap, the base is truncated
+/// further so the numeric suffix fits without falling off — Postgres does the same.
+pub(super) fn dedup_check_constraint_name(base: &str, table: &Table) -> String {
+    let candidate = truncate_identifier(base);
+    if !check_name_taken(&candidate, table) {
+        return candidate;
+    }
+    let mut counter: u32 = 1;
+    loop {
+        let suffix = counter.to_string();
+        let max_base = PG_MAX_IDENTIFIER_LENGTH.saturating_sub(suffix.len());
+        let truncated_base = if base.len() > max_base {
+            &base[..max_base]
+        } else {
+            base
+        };
+        let candidate = format!("{truncated_base}{suffix}");
+        if !check_name_taken(&candidate, table) {
+            return candidate;
+        }
+        counter += 1;
+    }
+}
+
+fn check_name_taken(name: &str, table: &Table) -> bool {
+    table.check_constraints.iter().any(|c| c.name == name)
 }
 
 /// Collect the set of known table columns referenced by a CHECK expression, in the order

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -4711,6 +4711,112 @@ fn inline_check_constraint_name_is_truncated_to_63_bytes() {
 }
 
 #[test]
+fn multiple_unnamed_inline_checks_with_no_column_refs_get_unique_names() {
+    // Two inline CHECK constraints whose expressions reference no table column would both
+    // collapse to the bare `{table}_check` default. Postgres resolves the collision by
+    // appending a numeric suffix (`_check`, `_check1`, ...). Without dedup, sqlgen emits
+    // two `ALTER TABLE ADD CONSTRAINT "t_check" CHECK (...)` statements and the second
+    // fails at apply with `constraint "t_check" already exists`.
+    let sql = r#"
+        CREATE TABLE t (
+            a NUMERIC NOT NULL CHECK (1 = 1),
+            b INTEGER NOT NULL CHECK (2 = 2)
+        );
+    "#;
+    let schema = parse_sql_string(sql).unwrap();
+    let table = schema.tables.get("public.t").unwrap();
+    assert_eq!(table.check_constraints.len(), 2);
+    let names: Vec<&str> = table
+        .check_constraints
+        .iter()
+        .map(|c| c.name.as_str())
+        .collect();
+    let unique: std::collections::BTreeSet<&str> = names.iter().copied().collect();
+    assert_eq!(
+        unique.len(),
+        names.len(),
+        "every CHECK constraint within a table must have a unique name; got: {names:?}"
+    );
+    assert!(
+        unique.contains("t_check"),
+        "first unnamed CHECK should keep the bare `{{table}}_check` name; got: {names:?}"
+    );
+    assert!(
+        unique.contains("t_check1"),
+        "second collision should append `1` (Postgres scheme); got: {names:?}"
+    );
+}
+
+#[test]
+fn multiple_unnamed_inline_checks_referencing_same_column_get_unique_names() {
+    // Two inline CHECKs both referencing column `a` produce the same base name `t_a_check`
+    // under the column-aware default. Postgres assigns `t_a_check` and `t_a_check1`.
+    let sql = r#"
+        CREATE TABLE t (
+            a INTEGER NOT NULL CHECK (a > 0),
+            b INTEGER NOT NULL CHECK (a < 100)
+        );
+    "#;
+    let schema = parse_sql_string(sql).unwrap();
+    let table = schema.tables.get("public.t").unwrap();
+    assert_eq!(table.check_constraints.len(), 2);
+    let names: std::collections::BTreeSet<&str> = table
+        .check_constraints
+        .iter()
+        .map(|c| c.name.as_str())
+        .collect();
+    assert!(names.contains("t_a_check"), "got: {names:?}");
+    assert!(names.contains("t_a_check1"), "got: {names:?}");
+}
+
+#[test]
+fn multiple_unnamed_table_level_checks_get_unique_names() {
+    // Out-of-line table-level CHECKs that don't share a single referenced column collapse
+    // to `{table}_check`. Two such constraints must resolve via Postgres' suffix scheme.
+    let sql = r#"
+        CREATE TABLE t (
+            a INTEGER,
+            b INTEGER,
+            CHECK (1 = 1),
+            CHECK (2 = 2)
+        );
+    "#;
+    let schema = parse_sql_string(sql).unwrap();
+    let table = schema.tables.get("public.t").unwrap();
+    assert_eq!(table.check_constraints.len(), 2);
+    let names: std::collections::BTreeSet<&str> = table
+        .check_constraints
+        .iter()
+        .map(|c| c.name.as_str())
+        .collect();
+    assert!(names.contains("t_check"), "got: {names:?}");
+    assert!(names.contains("t_check1"), "got: {names:?}");
+}
+
+#[test]
+fn unnamed_check_does_not_collide_with_explicit_user_name() {
+    // If the user explicitly named their CHECK `t_check`, an unnamed CHECK that would
+    // otherwise default to `t_check` must dedup to `t_check1` rather than colliding.
+    let sql = r#"
+        CREATE TABLE t (
+            a INTEGER,
+            CONSTRAINT t_check CHECK (a > 0),
+            CHECK (1 = 1)
+        );
+    "#;
+    let schema = parse_sql_string(sql).unwrap();
+    let table = schema.tables.get("public.t").unwrap();
+    assert_eq!(table.check_constraints.len(), 2);
+    let names: std::collections::BTreeSet<&str> = table
+        .check_constraints
+        .iter()
+        .map(|c| c.name.as_str())
+        .collect();
+    assert!(names.contains("t_check"), "got: {names:?}");
+    assert!(names.contains("t_check1"), "got: {names:?}");
+}
+
+#[test]
 fn alter_type_add_value_appends() {
     let sql = "CREATE TYPE color AS ENUM ('red', 'blue'); ALTER TYPE color ADD VALUE 'green';";
     let schema = parse_sql_string(sql).expect("Should parse");

--- a/src/parser/util.rs
+++ b/src/parser/util.rs
@@ -11,7 +11,7 @@ use sqlparser::ast::{
 };
 
 /// PostgreSQL's NAMEDATALEN is 64, so identifiers are truncated to 63 bytes.
-const PG_MAX_IDENTIFIER_LENGTH: usize = 63;
+pub(super) const PG_MAX_IDENTIFIER_LENGTH: usize = 63;
 
 pub(super) fn truncate_identifier(s: &str) -> String {
     if s.len() <= PG_MAX_IDENTIFIER_LENGTH {

--- a/tests/constraints.rs
+++ b/tests/constraints.rs
@@ -257,3 +257,64 @@ async fn check_constraint_double_precision_cast_round_trip() {
         "Should have no CHECK constraint diff after apply (double precision case). Got: {check_ops:?}"
     );
 }
+
+#[tokio::test]
+async fn multiple_unnamed_inline_check_constraints_apply_without_collision() {
+    // Regression for pgmold-289: multiple unnamed inline CHECK constraints on the same
+    // table both auto-named to `<table>_check`, producing duplicate
+    // `ALTER TABLE ADD CONSTRAINT "<table>_check"` statements that fail on apply with
+    // `constraint "<table>_check" already exists`.
+    let (_container, url) = setup_postgres().await;
+    let connection = PgConnection::new(&url).await.unwrap();
+
+    let schema_sql = r#"
+        CREATE TABLE "public"."t" (
+            "a" NUMERIC NOT NULL CHECK (1 = 1),
+            "b" INTEGER NOT NULL DEFAULT 1 CHECK (2 = 2)
+        );
+    "#;
+
+    let parsed_schema = parse_sql_string(schema_sql).unwrap();
+    let empty_schema = Schema::new();
+    let diff_ops = compute_diff(&empty_schema, &parsed_schema);
+    let planned = plan_migration(diff_ops);
+    let sql = generate_sql(&planned);
+
+    for stmt in &sql {
+        sqlx::query(stmt)
+            .execute(connection.pool())
+            .await
+            .unwrap_or_else(|e| panic!("apply failed on statement {stmt:?}: {e}"));
+    }
+
+    let db_schema = introspect_schema(&connection, &["public".to_string()], false)
+        .await
+        .unwrap();
+    let table = db_schema.tables.get("public.t").unwrap();
+    assert_eq!(table.check_constraints.len(), 2);
+    let names: std::collections::BTreeSet<&str> = table
+        .check_constraints
+        .iter()
+        .map(|c| c.name.as_str())
+        .collect();
+    assert_eq!(
+        names.len(),
+        2,
+        "every CHECK constraint must have a unique name post-apply; got: {names:?}"
+    );
+
+    let second_diff = compute_diff(&db_schema, &parsed_schema);
+    let check_ops: Vec<_> = second_diff
+        .iter()
+        .filter(|op| {
+            matches!(
+                op,
+                MigrationOp::AddCheckConstraint { .. } | MigrationOp::DropCheckConstraint { .. }
+            )
+        })
+        .collect();
+    assert!(
+        check_ops.is_empty(),
+        "second plan must converge: parser-assigned names must match what Postgres stores. Got: {check_ops:?}"
+    );
+}


### PR DESCRIPTION
Closes #289.

## Problem

Multiple unnamed inline `CHECK` constraints on the same table can collapse to the same auto-generated name when their expressions either share their referenced column or reference no column at all. The pgmold-parser-assigned name was used verbatim by sqlgen, so two CHECKs both named `<table>_check` (or `<table>_<col>_check`) produced two `ALTER TABLE ... ADD CONSTRAINT \"<name>\"` statements and the second failed at apply:

```
constraint \"<name>\" for relation \"<table>\" already exists
```

The sagri/mrv corpus tripped this on `mrv.t_0015` after the snapshot scrubber rewrote multiple inline CHECK bodies; it's not specific to the scrubber.

## Naming strategy

Match Postgres' `ChooseConstraintName` scheme exactly: the first CHECK keeps its base name (`<table>_<col>_check` if the expression references exactly one known column, else `<table>_check`), and subsequent collisions append a numeric suffix (`_check1`, `_check2`, ...). When the base is already at the 63-byte `NAMEDATALEN` cap, the base is truncated further so the suffix fits — same as Postgres.

This was preferred over a pgmold-only suffix scheme because:

- Introspection observes whatever Postgres has stored, so converging on `_check1` / `_check2` minimizes spurious DROP+ADD churn after apply.
- It maps 1:1 onto the existing collision behavior visible to anyone reading `pg_constraint.conname`.

Verified against `psql` for the four shapes of unnamed CHECK collision (two column-level same-col, two column-level no-col-ref, two table-level no-col-ref, explicit-named + unnamed colliding on default). Postgres assigns identical names in every case.

Dedup applies only to auto-generated names — an explicitly-named `CONSTRAINT foo CHECK (...)` is preserved verbatim, so user-side duplicate-name errors still surface at apply rather than being silently suppressed.

## Wiring

Three CHECK paths now share the same dedup helper:

- `src/parser/tables.rs` — inline column-level `CHECK` in `CREATE TABLE`
- `src/parser/tables.rs` — out-of-line table-level `CHECK` in `CREATE TABLE`
- `src/parser/mod.rs` — `ALTER TABLE ... ADD CONSTRAINT ... CHECK`

The default-name computation (column-aware vs. bare) is extracted into `default_check_constraint_base_name`. Dedup lives in `dedup_check_constraint_name(base, &table)`, which checks against the in-progress `Table.check_constraints` and walks `1, 2, 3, ...` until it finds a free slot. Source-order iteration matches Postgres'.

## Scrubber-workaround revert

The issue notes that the workaround in commit 40661f6 (the unnamed-CHECK `CONSTRAINT \"chk_<n>\"` injection in `scripts/sanitize_schema.py`) can be reverted once this lands. That file lives on the long-running `pgmold-sagri-snapshot` branch (PR #288) and is not present on `main`, so the revert needs to happen on that branch — out of scope for this PR. Filing a follow-up to land the revert there once this is merged.

## Test plan

- [x] `src/parser/tests.rs::multiple_unnamed_inline_checks_with_no_column_refs_get_unique_names` — the issue's reproduction (two no-column-ref inline CHECKs), assert names `t_check` and `t_check1`.
- [x] `src/parser/tests.rs::multiple_unnamed_inline_checks_referencing_same_column_get_unique_names` — two CHECKs both ref'ing `a` get `t_a_check` and `t_a_check1`.
- [x] `src/parser/tests.rs::multiple_unnamed_table_level_checks_get_unique_names` — out-of-line variant.
- [x] `src/parser/tests.rs::unnamed_check_does_not_collide_with_explicit_user_name` — explicit `CONSTRAINT t_check` followed by unnamed CHECK dedups to `t_check1`.
- [x] `tests/constraints.rs::multiple_unnamed_inline_check_constraints_apply_without_collision` — full pipeline (parse → diff → plan → sqlgen → apply against testcontainer Postgres → re-introspect → re-diff). Asserts apply succeeds, post-introspection names are unique, and a second plan is empty (convergence).
- [x] All four naming shapes verified empirically against `psql` — the parser-assigned name matches what `pg_constraint.conname` contains for the same SQL.
- [x] Existing `inline_check_*` parser tests still hold (single-CHECK paths take the no-collision branch and behave identically).
- [x] `cargo fmt --all -- --check` passes.