### PR TITLE
fix(model): normalise SQL-quoted SET values in function convergence

### DIFF
--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -2551,6 +2551,9 @@ mod tests {
         assert!(make("'_'").semantically_equals(&make("_")));
         assert!(make("'public'").semantically_equals(&make("public")));
         assert!(make("'pg_temp, public'").semantically_equals(&make("'pg_temp, public'")));
+        // Asymmetric multi-element: defends against future introspect changes
+        // that could return the bareword form for values containing commas.
+        assert!(make("'pg_temp, public'").semantically_equals(&make("pg_temp, public")));
         assert!(!make("foo").semantically_equals(&make("bar")));
     }
 

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -579,7 +579,7 @@ impl Function {
             && self.language == other.language
             && self.volatility == other.volatility
             && self.security == other.security
-            && self.config_params == other.config_params
+            && config_params_equal(&self.config_params, &other.config_params)
             && normalize_sql_body(&self.body) == normalize_sql_body(&other.body)
     }
 
@@ -637,6 +637,29 @@ fn split_top_level_commas(s: &str) -> Vec<&str> {
 fn normalize_sql_body(body: &str) -> String {
     let stripped = crate::util::strip_dollar_quotes(body);
     stripped.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// Canonicalises a `SET <param> = <value>` value for comparison.
+///
+/// `SET search_path = 'foo'` and `SET search_path = foo` are equivalent in
+/// PostgreSQL: pg_proc.proconfig stores both as the bareword `foo`. The SQL
+/// parser preserves the literal form (`'foo'` keeps its quotes); the
+/// introspector returns the bareword. Strip a single layer of surrounding
+/// single quotes so both sides match.
+fn normalize_config_value(value: &str) -> &str {
+    let bytes = value.as_bytes();
+    if bytes.len() >= 2 && bytes[0] == b'\'' && bytes[bytes.len() - 1] == b'\'' {
+        &value[1..value.len() - 1]
+    } else {
+        value
+    }
+}
+
+fn config_params_equal(left: &[(String, String)], right: &[(String, String)]) -> bool {
+    left.len() == right.len()
+        && left.iter().zip(right.iter()).all(|(l, r)| {
+            l.0 == r.0 && normalize_config_value(&l.1) == normalize_config_value(&r.1)
+        })
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -2505,6 +2528,43 @@ mod tests {
         };
         assert_eq!(func.config_params.len(), 1);
         assert_eq!(func.config_params[0].0, "search_path");
+    }
+
+    #[test]
+    fn function_semantically_equals_normalises_quoted_config_value() {
+        // Parser path keeps `SET search_path = '_'` as `'_'`; introspect path
+        // returns the bareword `_` from pg_proc.proconfig. Both must compare equal.
+        let make = |value: &str| Function {
+            name: "f".to_string(),
+            schema: "public".to_string(),
+            arguments: vec![],
+            return_type: "void".to_string(),
+            language: "sql".to_string(),
+            body: "SELECT 1".to_string(),
+            volatility: Volatility::Volatile,
+            security: SecurityType::Definer,
+            config_params: vec![("search_path".to_string(), value.to_string())],
+            owner: None,
+            grants: Vec::new(),
+            comment: None,
+        };
+        assert!(make("'_'").semantically_equals(&make("_")));
+        assert!(make("'public'").semantically_equals(&make("public")));
+        assert!(make("'pg_temp, public'").semantically_equals(&make("'pg_temp, public'")));
+        assert!(!make("foo").semantically_equals(&make("bar")));
+    }
+
+    #[test]
+    fn normalize_config_value_strips_outer_single_quotes() {
+        assert_eq!(normalize_config_value("'_'"), "_");
+        assert_eq!(
+            normalize_config_value("'pg_temp, public'"),
+            "pg_temp, public"
+        );
+        assert_eq!(normalize_config_value("public"), "public");
+        assert_eq!(normalize_config_value("''"), "");
+        assert_eq!(normalize_config_value("'"), "'");
+        assert_eq!(normalize_config_value(""), "");
     }
 
     #[test]

--- a/tests/corpus_sagri_mrv.rs
+++ b/tests/corpus_sagri_mrv.rs
@@ -91,12 +91,9 @@ async fn sagri_mrv_snapshot_converges() {
 
     // postgis/postgis ships with extra extensions (fuzzystrmatch,
     // postgis_tiger_geocoder, ...) the snapshot doesn't declare. Filter
-    // DropExtension — the snapshot is not converging cluster-level
-    // extensions, and this is genuine fixture/environment variance,
-    // not signal. (CreateExtension and AlterFunction are NOT filtered
-    // here because they would mask real pgmold regression signal; see
-    // the convergence-baseline assertion below for how those are
-    // tolerated without being silenced.)
+    // DropExtension — genuine fixture/environment variance, not signal.
+    // No other op classes are filtered: convergence is asserted at zero
+    // diff ops below.
     let diff_modulo_drop_ext = |from: &Schema, to: &Schema| -> Vec<MigrationOp> {
         compute_diff(from, to)
             .into_iter()
@@ -124,21 +121,14 @@ async fn sagri_mrv_snapshot_converges() {
         .expect("introspect after apply");
     let second_diff = diff_modulo_drop_ext(&after, &target);
 
-    // Convergence baseline: pgmold currently emits some no-op ops in the
-    // second diff against this snapshot. Tracked as gh#291 (functions
-    // re-emit AlterFunction after a no-op apply). The baseline is a
-    // ratchet — if it grows we've hit a NEW convergence bug and the
-    // test fails. When gh#291 is resolved drop the baseline to 0.
-    const CONVERGENCE_BASELINE: usize = 50;
-    if second_diff.len() > CONVERGENCE_BASELINE {
+    // Convergence: a no-op apply must produce a zero-op second diff.
+    if !second_diff.is_empty() {
         let remaining_sql = generate_sql(&plan_migration(second_diff.clone()));
         panic!(
-            "sagri_mrv convergence regressed: {} op(s) remain (baseline {}). \
-             A new convergence bug appeared — see gh#291 for context.\n\
+            "sagri_mrv convergence regressed: {} op(s) remain.\n\
              remaining ops: {:#?}\n\
              remaining SQL:\n{}",
             second_diff.len(),
-            CONVERGENCE_BASELINE,
             second_diff,
             remaining_sql.join("\n"),
         );

--- a/tests/corpus_sagri_mrv.rs
+++ b/tests/corpus_sagri_mrv.rs
@@ -124,8 +124,8 @@ async fn sagri_mrv_snapshot_converges() {
     // Convergence ratchet: pgmold currently emits some no-op ops in the
     // second diff for object kinds that pgmold doesn't fully model yet.
     // The 30-op baseline is fully attributed:
-    //   - 22 COMMENT ON   — introspect doesn't read pg_description (gh#298)
-    //   -  5 DROP+CREATE  — char(N)[] vs character[] in func sig key (gh#299)
+    //   - 23 COMMENT ON   — introspect doesn't read pg_description (gh#298)
+    //   -  4 DROP+CREATE  — char(N)[] vs character[] in func sig key (gh#299)
     //   -  2 CreateExt    — ALTER EXTENSION SET SCHEMA missing      (gh#300)
     //   -  1 ALTER TABLE  — scrubber rewrote default to pg_catalog  (gh#301)
     // Drop the baseline by the corresponding op count as each issue lands.

--- a/tests/corpus_sagri_mrv.rs
+++ b/tests/corpus_sagri_mrv.rs
@@ -121,14 +121,24 @@ async fn sagri_mrv_snapshot_converges() {
         .expect("introspect after apply");
     let second_diff = diff_modulo_drop_ext(&after, &target);
 
-    // Convergence: a no-op apply must produce a zero-op second diff.
-    if !second_diff.is_empty() {
+    // Convergence ratchet: pgmold currently emits some no-op ops in the
+    // second diff for object kinds that pgmold doesn't fully model yet.
+    // The 30-op baseline is fully attributed:
+    //   - 22 COMMENT ON   — introspect doesn't read pg_description (gh#298)
+    //   -  5 DROP+CREATE  — char(N)[] vs character[] in func sig key (gh#299)
+    //   -  2 CreateExt    — ALTER EXTENSION SET SCHEMA missing      (gh#300)
+    //   -  1 ALTER TABLE  — scrubber rewrote default to pg_catalog  (gh#301)
+    // Drop the baseline by the corresponding op count as each issue lands.
+    const CONVERGENCE_BASELINE: usize = 30;
+    if second_diff.len() > CONVERGENCE_BASELINE {
         let remaining_sql = generate_sql(&plan_migration(second_diff.clone()));
         panic!(
-            "sagri_mrv convergence regressed: {} op(s) remain.\n\
+            "sagri_mrv convergence regressed: {} op(s) remain (baseline {}). \
+             A new convergence bug appeared — see gh#298–301 for tracked classes.\n\
              remaining ops: {:#?}\n\
              remaining SQL:\n{}",
             second_diff.len(),
+            CONVERGENCE_BASELINE,
             second_diff,
             remaining_sql.join("\n"),
         );


### PR DESCRIPTION
Fixes #291 (the AlterFunction class). The 38 spurious `AlterFunction` ops on the sagri/mrv canary are gone. Four pre-existing convergence gaps that were hidden by the original 50-op ratchet are now visible and tracked separately (gh#298–301).

## Symptom (gh#291)

The sagri/mrv canary added in #284 ratcheted to a 50-op second-diff baseline because 38 of the snapshot's `SECURITY DEFINER` + `SET search_path` functions emit `AlterFunction` ops on a no-op apply. Same root cause across all 38; one normalisation gap.

## Root cause

`Function::semantically_equals` compared `config_params` with strict `==` (`src/model/mod.rs:582`). For the snapshot's scrubbed `SET search_path = '_'` clauses:

- **Parser** (`src/parser/functions.rs:92-96`) — `Expr::Value(SingleQuotedString("_"))` → `e.to_string()` → `"'_'"` (quotes preserved).
- **Introspect** (`src/pg/introspect.rs:1424-1431`) — `pg_proc.proconfig` stores simple identifiers as barewords; `normalize_proconfig_value("_")` → `"_"` (no quotes added).

Both are valid SQL for the same GUC value. PG normalises them identically at storage time. pgmold did not normalise them at compare time.

The same snapshot's `SET search_path = public` (already-bareword) form matched correctly on both sides — only the SQL-string-literal form was failing.

## Fix

Add `normalize_config_value` + `config_params_equal` in `src/model/mod.rs` and use them in `Function::semantically_equals`. Strips a single layer of surrounding single quotes; multi-element values (`'pg_temp, public'`) match unchanged on both sides.

## Convergence ratchet: 50 → 30

Removing the 38 AlterFunction ops drops the second-diff to 30. The remaining 30 are four distinct, pre-existing bug classes that were absorbed by the original 50-op ratchet:

| Count | Op kind | Issue |
|---|---|---|
| 23 | `COMMENT ON` | gh#298 — introspect never reads `pg_description` for any object kind |
| 4 | `DROP+CREATE FUNCTION` | gh#299 — `char(N)[]` (parser) vs `character[]` (introspect) mismatches function-signature key |
| 2 | `CREATE EXTENSION` | gh#300 — `ALTER EXTENSION SET SCHEMA` not emitted when extension exists in wrong schema |
| 1 | `ALTER TABLE SET DEFAULT` | gh#301 — scrubber rewrote a sequence default to `pg_catalog.pg_class` |

`tests/corpus_sagri_mrv.rs` ratchets to `CONVERGENCE_BASELINE = 30` with the breakdown inline in the test comment, including the per-issue decrement to apply when each lands.

## Test plan

- New unit tests in `src/model/mod.rs`:
  - `function_semantically_equals_normalises_quoted_config_value` — covers `'_' == _`, `'public' == public`, multi-element symmetric + asymmetric cases, and a true-negative.
  - `normalize_config_value_strips_outer_single_quotes` — exercises edge cases (empty string, single quote char alone, empty input).
- `Corpus Convergence (sagri/mrv)` CI job converges at exactly 30 ops; the panic dump on regression includes the full op list + SQL.