### PR TITLE
fix(diff): emit ALTER EXTENSION SET SCHEMA for relocated extensions

### DIFF
--- a/src/diff/dump_planner.rs
+++ b/src/diff/dump_planner.rs
@@ -48,6 +48,7 @@ pub(crate) fn plan_dump(ops: Vec<MigrationOp>) -> Vec<MigrationOp> {
             MigrationOp::SetComment { .. } => set_comments.push(op),
             MigrationOp::DropSchema(_)
             | MigrationOp::DropExtension(_)
+            | MigrationOp::AlterExtensionSetSchema { .. }
             | MigrationOp::DropServer(_)
             | MigrationOp::AlterServer { .. }
             | MigrationOp::DropEnum(_)

--- a/src/diff/mod.rs
+++ b/src/diff/mod.rs
@@ -1869,6 +1869,123 @@ mod tests {
         assert!(ops.is_empty(), "no migration ops expected, got {ops:?}");
     }
 
+    #[test]
+    fn detects_extension_schema_change() {
+        let mut from = empty_schema();
+        from.extensions.insert(
+            "pgcrypto".to_string(),
+            crate::model::Extension {
+                name: "pgcrypto".to_string(),
+                version: None,
+                schema: Some("public".to_string()),
+                comment: None,
+            },
+        );
+        let mut to = empty_schema();
+        to.extensions.insert(
+            "pgcrypto".to_string(),
+            crate::model::Extension {
+                name: "pgcrypto".to_string(),
+                version: None,
+                schema: Some("extensions".to_string()),
+                comment: None,
+            },
+        );
+
+        let ops = compute_diff(&from, &to);
+        assert_eq!(
+            ops,
+            vec![MigrationOp::AlterExtensionSetSchema {
+                name: "pgcrypto".to_string(),
+                new_schema: "extensions".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn no_op_when_target_extension_schema_is_unmanaged() {
+        // `CREATE EXTENSION pgcrypto;` (no SCHEMA clause) means the source
+        // does not pin a schema. Pre-installed schemas in the live DB must
+        // be left in place.
+        let mut from = empty_schema();
+        from.extensions.insert(
+            "pgcrypto".to_string(),
+            crate::model::Extension {
+                name: "pgcrypto".to_string(),
+                version: None,
+                schema: Some("public".to_string()),
+                comment: None,
+            },
+        );
+        let mut to = empty_schema();
+        to.extensions.insert(
+            "pgcrypto".to_string(),
+            crate::model::Extension {
+                name: "pgcrypto".to_string(),
+                version: None,
+                schema: None,
+                comment: None,
+            },
+        );
+
+        let ops = compute_diff(&from, &to);
+        assert!(
+            ops.is_empty(),
+            "source-silent extension schema must be unmanaged, got {ops:?}"
+        );
+    }
+
+    #[test]
+    fn no_op_when_source_extension_schema_is_unmanaged() {
+        // `from.schema = None` happens in SQL-vs-SQL diffs when the prior
+        // file has no SCHEMA clause. We have no basis to pick a target, so
+        // pgmold must not emit an ALTER even if the target pins a schema.
+        let mut from = empty_schema();
+        from.extensions.insert(
+            "pgcrypto".to_string(),
+            crate::model::Extension {
+                name: "pgcrypto".to_string(),
+                version: None,
+                schema: None,
+                comment: None,
+            },
+        );
+        let mut to = empty_schema();
+        to.extensions.insert(
+            "pgcrypto".to_string(),
+            crate::model::Extension {
+                name: "pgcrypto".to_string(),
+                version: None,
+                schema: Some("extensions".to_string()),
+                comment: None,
+            },
+        );
+
+        let ops = compute_diff(&from, &to);
+        assert!(
+            ops.is_empty(),
+            "unmanaged source schema must not trigger ALTER, got {ops:?}"
+        );
+    }
+
+    #[test]
+    fn no_op_when_extension_schema_matches() {
+        let mut from = empty_schema();
+        from.extensions.insert(
+            "pgcrypto".to_string(),
+            crate::model::Extension {
+                name: "pgcrypto".to_string(),
+                version: None,
+                schema: Some("extensions".to_string()),
+                comment: None,
+            },
+        );
+        let to = from.clone();
+
+        let ops = compute_diff(&from, &to);
+        assert!(ops.is_empty(), "no migration ops expected, got {ops:?}");
+    }
+
     fn table_with_policy(comment: Option<&str>) -> crate::model::Table {
         let mut t = simple_table("users");
         t.row_level_security = true;

--- a/src/diff/objects.rs
+++ b/src/diff/objects.rs
@@ -238,7 +238,24 @@ pub(super) fn diff_extensions(
         &from.extensions,
         &to.extensions,
         |_key, ext| MigrationOp::CreateExtension(ext.clone()),
-        |_ops, _key, _from_val, _to_val| {},
+        |ops, _key, from_ext, to_ext| {
+            // Both schemas must be pinned for the diff to fire. A `None` on
+            // either side means the source is silent about placement, and
+            // pgmold leaves it alone. Concretely:
+            //   - `to.schema = None`: target is unmanaged; never relocate.
+            //   - `from.schema = None`: prior placement is unknown, so we
+            //     can't justify an ALTER to a specific schema. This case
+            //     only arises in SQL-vs-SQL diffs; introspection always
+            //     populates `schema`.
+            if let (Some(from_schema), Some(target_schema)) = (&from_ext.schema, &to_ext.schema) {
+                if from_schema != target_schema {
+                    ops.push(MigrationOp::AlterExtensionSetSchema {
+                        name: to_ext.name.clone(),
+                        new_schema: target_schema.clone(),
+                    });
+                }
+            }
+        },
         |name, _val| MigrationOp::DropExtension(name.clone()),
         |name, _val| ObjectCoords {
             schema: String::new(),

--- a/src/diff/op_key.rs
+++ b/src/diff/op_key.rs
@@ -35,6 +35,7 @@ pub(crate) enum OpKey {
     DropSchema(String),
     CreateExtension(String),
     DropExtension(String),
+    AlterExtensionSetSchema(String),
     CreateServer(String),
     DropServer(String),
     AlterServer(String),
@@ -237,6 +238,9 @@ impl OpKey {
             MigrationOp::DropSchema(name) => OpKey::DropSchema(name.clone()),
             MigrationOp::CreateExtension(ext) => OpKey::CreateExtension(ext.name.clone()),
             MigrationOp::DropExtension(name) => OpKey::DropExtension(name.clone()),
+            MigrationOp::AlterExtensionSetSchema { name, .. } => {
+                OpKey::AlterExtensionSetSchema(name.clone())
+            }
             MigrationOp::CreateServer(s) => OpKey::CreateServer(s.name.clone()),
             MigrationOp::DropServer(name) => OpKey::DropServer(name.clone()),
             MigrationOp::AlterServer { name, .. } => OpKey::AlterServer(name.clone()),

--- a/src/diff/planner.rs
+++ b/src/diff/planner.rs
@@ -27,6 +27,7 @@ struct NodeSets {
     schemas: Vec<NodeIndex>,
     version_schemas: Vec<NodeIndex>,
     extensions: Vec<NodeIndex>,
+    alter_extension_set_schemas: Vec<NodeIndex>,
     servers: Vec<NodeIndex>,
     enums: Vec<NodeIndex>,
     add_enum_values: Vec<NodeIndex>,
@@ -82,6 +83,8 @@ impl NodeSets {
             version_schemas: graph
                 .nodes_matching(|k| matches!(k, OpKey::CreateVersionSchema { .. })),
             extensions: graph.nodes_matching(|k| matches!(k, OpKey::CreateExtension(_))),
+            alter_extension_set_schemas: graph
+                .nodes_matching(|k| matches!(k, OpKey::AlterExtensionSetSchema(_))),
             servers: graph.nodes_matching(|k| matches!(k, OpKey::CreateServer(_))),
             enums: graph.nodes_matching(|k| matches!(k, OpKey::CreateEnum(_))),
             add_enum_values: graph.nodes_matching(|k| matches!(k, OpKey::AddEnumValue { .. })),
@@ -220,6 +223,15 @@ impl MigrationGraph {
         self.edges_all_to_all(&ns.extensions, &ns.domains);
         self.edges_all_to_all(&ns.extensions, &ns.tables);
         self.edges_all_to_all(&ns.extensions, &ns.servers);
+
+        // Relocating an existing extension must wait until its destination
+        // schema exists, and must finish before any new object that resolves
+        // a type through the extension via its post-move schema.
+        self.edges_all_to_all(&ns.schemas, &ns.alter_extension_set_schemas);
+        self.edges_all_to_all(&ns.alter_extension_set_schemas, &ns.enums);
+        self.edges_all_to_all(&ns.alter_extension_set_schemas, &ns.domains);
+        self.edges_all_to_all(&ns.alter_extension_set_schemas, &ns.tables);
+        self.edges_all_to_all(&ns.alter_extension_set_schemas, &ns.servers);
     }
 
     /// Tier 2: Type system — enums, enum values, and domains before tables and columns.
@@ -467,6 +479,7 @@ impl MigrationGraph {
             &ns.schemas,
             &ns.version_schemas,
             &ns.extensions,
+            &ns.alter_extension_set_schemas,
             &ns.servers,
             &ns.enums,
             &ns.add_enum_values,
@@ -3849,6 +3862,77 @@ mod tests {
             "CreateTable",
             |op| matches!(op, MigrationOp::CreateExtension(_)),
             |op| matches!(op, MigrationOp::CreateTable(_)),
+        );
+    }
+
+    #[test]
+    fn create_schema_before_alter_extension_set_schema() {
+        let ops = vec![
+            MigrationOp::AlterExtensionSetSchema {
+                name: "pgcrypto".to_string(),
+                new_schema: "extensions".to_string(),
+            },
+            MigrationOp::CreateSchema(make_schema("extensions")),
+        ];
+        let planned = plan_migration(ops);
+        assert_op_position(
+            &planned,
+            "CreateSchema",
+            "AlterExtensionSetSchema",
+            |op| matches!(op, MigrationOp::CreateSchema(_)),
+            |op| matches!(op, MigrationOp::AlterExtensionSetSchema { .. }),
+        );
+    }
+
+    #[test]
+    fn alter_extension_set_schema_before_table() {
+        let ops = vec![
+            MigrationOp::CreateTable(simple_table_with_fks("orders", vec![])),
+            MigrationOp::AlterExtensionSetSchema {
+                name: "pgcrypto".to_string(),
+                new_schema: "extensions".to_string(),
+            },
+        ];
+        let planned = plan_migration(ops);
+        assert_op_position(
+            &planned,
+            "AlterExtensionSetSchema",
+            "CreateTable",
+            |op| matches!(op, MigrationOp::AlterExtensionSetSchema { .. }),
+            |op| matches!(op, MigrationOp::CreateTable(_)),
+        );
+    }
+
+    #[test]
+    fn create_schema_then_alter_extension_then_create_table() {
+        let ops = vec![
+            MigrationOp::CreateTable(simple_table_with_fks("orders", vec![])),
+            MigrationOp::AlterExtensionSetSchema {
+                name: "pgcrypto".to_string(),
+                new_schema: "extensions".to_string(),
+            },
+            MigrationOp::CreateSchema(make_schema("extensions")),
+        ];
+        let planned = plan_migration(ops);
+        let schema_idx = planned
+            .iter()
+            .position(|op| matches!(op, MigrationOp::CreateSchema(_)))
+            .expect("CreateSchema must appear in plan");
+        let alter_idx = planned
+            .iter()
+            .position(|op| matches!(op, MigrationOp::AlterExtensionSetSchema { .. }))
+            .expect("AlterExtensionSetSchema must appear in plan");
+        let table_idx = planned
+            .iter()
+            .position(|op| matches!(op, MigrationOp::CreateTable(_)))
+            .expect("CreateTable must appear in plan");
+        assert!(
+            schema_idx < alter_idx,
+            "CreateSchema must precede AlterExtensionSetSchema (got {schema_idx} vs {alter_idx})"
+        );
+        assert!(
+            alter_idx < table_idx,
+            "AlterExtensionSetSchema must precede CreateTable (got {alter_idx} vs {table_idx})"
         );
     }
 

--- a/src/diff/types.rs
+++ b/src/diff/types.rs
@@ -67,6 +67,10 @@ pub enum MigrationOp {
     DropSchema(String),
     CreateExtension(Extension),
     DropExtension(String),
+    AlterExtensionSetSchema {
+        name: String,
+        new_schema: String,
+    },
     CreateServer(Server),
     DropServer(String),
     AlterServer {

--- a/src/lint/mod.rs
+++ b/src/lint/mod.rs
@@ -225,6 +225,7 @@ fn lint_op(op: &MigrationOp, options: &LintOptions) -> Vec<LintResult> {
 
         MigrationOp::CreateSchema(_)
         | MigrationOp::CreateExtension(_)
+        | MigrationOp::AlterExtensionSetSchema { .. }
         | MigrationOp::CreateServer(_)
         | MigrationOp::DropServer(_)
         | MigrationOp::AlterServer { .. }

--- a/src/pg/sqlgen.rs
+++ b/src/pg/sqlgen.rs
@@ -45,6 +45,14 @@ fn generate_op_sql(op: &MigrationOp) -> Vec<String> {
             vec![format!("DROP EXTENSION IF EXISTS {};", quote_ident(name))]
         }
 
+        MigrationOp::AlterExtensionSetSchema { name, new_schema } => {
+            vec![format!(
+                "ALTER EXTENSION {} SET SCHEMA {};",
+                quote_ident(name),
+                quote_ident(new_schema)
+            )]
+        }
+
         MigrationOp::CreateServer(server) => {
             vec![generate_create_server(server)]
         }
@@ -2262,6 +2270,21 @@ mod tests {
         let sql = generate_sql(&ops);
         assert_eq!(sql.len(), 1);
         assert_eq!(sql[0], "DROP EXTENSION IF EXISTS \"uuid-ossp\";");
+    }
+
+    #[test]
+    fn alter_extension_set_schema_generates_valid_sql() {
+        let ops = vec![MigrationOp::AlterExtensionSetSchema {
+            name: "pgcrypto".to_string(),
+            new_schema: "extensions".to_string(),
+        }];
+
+        let sql = generate_sql(&ops);
+        assert_eq!(sql.len(), 1);
+        assert_eq!(
+            sql[0],
+            "ALTER EXTENSION \"pgcrypto\" SET SCHEMA \"extensions\";"
+        );
     }
 
     #[test]

--- a/tests/edge_cases.rs
+++ b/tests/edge_cases.rs
@@ -386,7 +386,7 @@ async fn extension_relocation_emits_alter_set_schema_and_converges() {
     let target = parse_sql_string(
         r#"
         CREATE SCHEMA IF NOT EXISTS extensions;
-        CREATE EXTENSION IF NOT EXISTS pgcrypto SCHEMA extensions;
+        CREATE EXTENSION IF NOT EXISTS "pgcrypto" WITH SCHEMA extensions;
         "#,
     )
     .unwrap();

--- a/tests/edge_cases.rs
+++ b/tests/edge_cases.rs
@@ -371,6 +371,73 @@ async fn extension_comment_round_trips_through_apply_and_introspect() {
 }
 
 #[tokio::test]
+async fn extension_relocation_emits_alter_set_schema_and_converges() {
+    // Reproduces gh#300: when pgcrypto is pre-installed in `public` but the
+    // snapshot pins it in `extensions`, plan must emit
+    // `ALTER EXTENSION ... SET SCHEMA ...` and the second-diff must be empty.
+    let (_container, url) = setup_postgres().await;
+    let connection = PgConnection::new(&url).await.unwrap();
+
+    sqlx::query("CREATE EXTENSION IF NOT EXISTS pgcrypto SCHEMA public")
+        .execute(connection.pool())
+        .await
+        .unwrap();
+
+    let target = parse_sql_string(
+        r#"
+        CREATE SCHEMA IF NOT EXISTS extensions;
+        CREATE EXTENSION IF NOT EXISTS pgcrypto SCHEMA extensions;
+        "#,
+    )
+    .unwrap();
+
+    let current = introspect_schema(
+        &connection,
+        &["public".to_string(), "extensions".to_string()],
+        false,
+    )
+    .await
+    .unwrap();
+
+    let ops = compute_diff(&current, &target);
+    let expected_alter = MigrationOp::AlterExtensionSetSchema {
+        name: "pgcrypto".to_string(),
+        new_schema: "extensions".to_string(),
+    };
+    assert!(
+        ops.contains(&expected_alter),
+        "expected {expected_alter:?} in plan, got {ops:?}"
+    );
+
+    let sql_stmts = generate_sql(&plan_migration(ops));
+    for stmt in &sql_stmts {
+        sqlx::query(stmt)
+            .execute(connection.pool())
+            .await
+            .unwrap_or_else(|error| panic!("Failed to execute statement: {stmt}\nError: {error}"));
+    }
+
+    let after = introspect_schema(
+        &connection,
+        &["public".to_string(), "extensions".to_string()],
+        false,
+    )
+    .await
+    .unwrap();
+    let ext = after
+        .extensions
+        .get("pgcrypto")
+        .expect("pgcrypto should still be installed");
+    assert_eq!(ext.schema.as_deref(), Some("extensions"));
+
+    let drift_ops = compute_diff(&after, &target);
+    assert!(
+        drift_ops.is_empty(),
+        "no drift expected after apply; got {drift_ops:?}"
+    );
+}
+
+#[tokio::test]
 async fn table_constraint_comment_round_trips_through_apply_and_introspect() {
     let (_container, url) = setup_postgres().await;
     let connection = PgConnection::new(&url).await.unwrap();


### PR DESCRIPTION
## Summary

When pgcrypto / uuid-ossp are pre-installed in `public` (Docker images, platform-managed setups) but the snapshot pins them in `extensions`, pgmold currently emits `CREATE EXTENSION IF NOT EXISTS \"pgcrypto\" SCHEMA \"extensions\"` on every plan. The `IF NOT EXISTS` clause makes apply a no-op — the extension stays in `public`, the next diff re-emits the same op, and `drift` never converges. Surfaced by the sagri/mrv canary in #284 and isolated in #297.

This adds the missing diff path:

- New `MigrationOp::AlterExtensionSetSchema` variant + matching `OpKey`.
- `diff_extensions` now compares schemas of existing extensions and emits the ALTER when both sides are pinned and differ. Either side `None` is treated as unmanaged (target with no `SCHEMA` clause = source silent; introspected extensions always have `Some`).
- `pg::sqlgen` emits `ALTER EXTENSION \"name\" SET SCHEMA \"new\";`.
- Planner orders `CreateSchema → AlterExtensionSetSchema → enums/domains/tables/servers`, mirroring the existing `CreateExtension` edges so a fresh destination schema is created first and the relocated extension is in place before anything resolves a type through it.
- Catch-all `MigrationOp` matches in `lint/mod.rs` and `dump_planner.rs` updated.

`CONVERGENCE_BASELINE` in #297 will drop by 2 (uuid-ossp + pgcrypto) once this lands.

## Test plan

- [x] Unit: `detects_extension_schema_change` (Some(public) → Some(extensions) emits ALTER).
- [x] Unit: `no_op_when_target_extension_schema_is_unmanaged` (target None ⇒ no ALTER).
- [x] Unit: `no_op_when_source_extension_schema_is_unmanaged` (source None ⇒ no ALTER, covers SQL-vs-SQL diff edge case).
- [x] Unit: `no_op_when_extension_schema_matches`.
- [x] sqlgen: `alter_extension_set_schema_generates_valid_sql`.
- [x] Planner: `create_schema_before_alter_extension_set_schema`, `alter_extension_set_schema_before_table`, three-way `create_schema_then_alter_extension_then_create_table`.
- [x] Integration: `extension_relocation_emits_alter_set_schema_and_converges` — pre-installs `pgcrypto` in `public`, applies snapshot pinning it to `extensions`, confirms the ALTER fires, applies the plan, and asserts the second-diff is empty.

Closes #300