### PR TITLE
fix(scrubber): preserve regclass cast literals in sagri/mrv snapshot

### DIFF
--- a/scripts/sanitize_schema.py
+++ b/scripts/sanitize_schema.py
@@ -135,10 +135,14 @@ def _typed_cast_replacement(cast_target: str) -> str:
     PG validates constant casts at function-create time (the JSONB cast
     is the case CI surfaced), so the literal content has to be valid for
     the target type, not just any old `'_'`.
+
+    Scalar `regclass` is intentionally NOT handled here — see `repl_cast`,
+    which preserves the original literal so the identifier-rename pass
+    can rewrite the inner object name (gh#301).
     """
     target = cast_target.strip().lower()
     is_array = target.endswith("[]")
-    base = target.rstrip("[] ")
+    base = target.rstrip("[]").strip()
     if is_array:
         return f"'{{}}'::{cast_target}"
     if base in ("jsonb", "json"):
@@ -147,8 +151,6 @@ def _typed_cast_replacement(cast_target: str) -> str:
         return f"'00000000-0000-0000-0000-000000000000'::{cast_target}"
     if base == "interval":
         return f"'1 day'::{cast_target}"
-    if base == "regclass":
-        return f"'pg_catalog.pg_class'::{cast_target}"
     if base in ("date",):
         return f"'1970-01-01'::{cast_target}"
     if base in ("timestamp", "timestamptz", "time", "timetz"):
@@ -217,8 +219,15 @@ def scrub_text(sql: str) -> str:
     # Typed-cast literals (`'X'::TYPE`) need a value valid for the target
     # type. PG evaluates constant casts at function-create time and the
     # blanket `'_'` substitution would fail for jsonb / uuid / etc.
+    # Scalar `'X'::regclass` is preserved verbatim: the literal names a
+    # real PG object (sequence / table / function) and the later
+    # identifier-rename pass rewrites the inner name to its opaque form
+    # (gh#301). Array `regclass[]` falls through and gets `'{}'::regclass[]`.
     def repl_cast(m: re.Match[str]) -> str:
-        return stash(_typed_cast_replacement(m.group(1)))
+        cast_target = m.group(1)
+        if cast_target.strip().lower() == "regclass":
+            return stash(m.group(0))
+        return stash(_typed_cast_replacement(cast_target))
 
     sql = RE_TYPED_CAST.sub(repl_cast, sql)
 

--- a/scripts/sanitize_schema_test.py
+++ b/scripts/sanitize_schema_test.py
@@ -1,0 +1,69 @@
+"""Unit tests for scripts/sanitize_schema.py.
+
+The scrubber is a developer tool: its consumer is tests/corpus/sagri_mrv.sql.
+The end-to-end signal is the corpus convergence test in
+tests/corpus_sagri_mrv.rs (run in CI). These unit assertions pin specific
+scrubber invariants whose regressions would silently break the snapshot.
+
+Run: python3 scripts/sanitize_schema_test.py
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+from sanitize_schema import (
+    apply_rename,
+    build_manifest,
+    discover_identifiers,
+    scrub_text,
+)
+
+
+def regclass_cast_preserves_inner_identifier_through_full_pipeline() -> None:
+    sql = (
+        "CREATE SEQUENCE auth.refresh_tokens_id_seq;\n"
+        "CREATE TABLE auth.refresh_tokens ("
+        "  id BIGINT NOT NULL DEFAULT nextval('auth.refresh_tokens_id_seq'::regclass)"
+        ");"
+    )
+    discovered = discover_identifiers(sql)
+    manifest = build_manifest(discovered)
+    scrubbed = scrub_text(sql)
+    out = apply_rename(scrubbed, manifest)
+    renamed_seq = manifest["refresh_tokens_id_seq"]
+    assert f"'auth.{renamed_seq}'::regclass" in out, out
+    assert "refresh_tokens_id_seq" not in out, out
+    assert "pg_catalog.pg_class" not in out, out
+
+
+def regclass_array_cast_falls_back_to_empty_array() -> None:
+    sql = "SELECT 'foo'::regclass[]"
+    out = scrub_text(sql)
+    assert "'{}'::regclass[]" in out, out
+
+
+def jsonb_cast_replaced_with_valid_literal() -> None:
+    sql = "SELECT '{\"k\":1}'::jsonb"
+    out = scrub_text(sql)
+    assert "'null'::jsonb" in out, out
+
+
+def main() -> int:
+    cases = [
+        regclass_cast_preserves_inner_identifier_through_full_pipeline,
+        regclass_array_cast_falls_back_to_empty_array,
+        jsonb_cast_replaced_with_valid_literal,
+    ]
+    for case in cases:
+        case()
+        print(f"ok  {case.__name__}")
+    print(f"\n{len(cases)} passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/corpus/sagri_mrv.sql
+++ b/tests/corpus/sagri_mrv.sql
@@ -425,7 +425,7 @@ ALTER TABLE "auth"."t_0070" ADD CONSTRAINT "con_0127" FOREIGN KEY ("c_0438") REF
 
 CREATE TABLE "auth"."t_0077" (
     "c_0094" TIMESTAMP WITH TIME ZONE,
-    "id" BIGINT NOT NULL DEFAULT nextval('pg_catalog.pg_class'::regclass),
+    "id" BIGINT NOT NULL DEFAULT nextval('auth.seq_0001'::regclass),
     "c_0237" UUID,
     "c_0338" VARCHAR(255),
     "c_0412" BOOLEAN,

--- a/tests/corpus_sagri_mrv.rs
+++ b/tests/corpus_sagri_mrv.rs
@@ -123,16 +123,15 @@ async fn sagri_mrv_snapshot_converges() {
 
     // Convergence ratchet: pgmold currently emits some no-op ops in the
     // second diff for object kinds that pgmold doesn't fully model yet.
-    // The 3-op baseline is fully attributed:
+    // The 2-op baseline is fully attributed:
     //   -  2 CreateExt    — ALTER EXTENSION SET SCHEMA missing      (gh#300)
-    //   -  1 ALTER TABLE  — scrubber rewrote default to pg_catalog  (gh#301)
     // Drop the baseline by the corresponding op count as each issue lands.
-    const CONVERGENCE_BASELINE: usize = 3;
+    const CONVERGENCE_BASELINE: usize = 2;
     if second_diff.len() > CONVERGENCE_BASELINE {
         let remaining_sql = generate_sql(&plan_migration(second_diff.clone()));
         panic!(
             "sagri_mrv convergence regressed: {} op(s) remain (baseline {}). \
-             A new convergence bug appeared — see gh#300, gh#301 for tracked classes.\n\
+             A new convergence bug appeared — see gh#300 for tracked classes.\n\
              remaining ops: {:#?}\n\
              remaining SQL:\n{}",
             second_diff.len(),


### PR DESCRIPTION
## Summary

The `sanitize_schema.py` scrubber was substituting `'pg_catalog.pg_class'` for every `'X'::regclass` cast in source SQL when sanitizing real-world schemas for the regression corpus. That corrupted `nextval('seq'::regclass)` column DEFAULTs — `pg_class` is a table, not a sequence — and surfaced as 1 ALTER TABLE op in the sagri/mrv second-diff.

## Fix

The scalar `regclass` branch is hoisted into `repl_cast`, which stashes the *original* literal verbatim. The identifier-rename pass that runs later rewrites the inner sequence/table name textually (e.g. `'auth.refresh_tokens_id_seq'::regclass` → `'auth.seq_NNNN'::regclass`) because `\b<name>\b` matches inside single-quoted literals.

Array `regclass[]` still falls through to the existing empty-array literal — OID arrays don't reference any specific named object.

## Convergence ratchet

`tests/corpus_sagri_mrv.rs` drops `CONVERGENCE_BASELINE` from 3 to 2. The remaining 2 are CreateExtension ops attributed to gh#300 (already fixed in #307; will be ratcheted further once verified).

## Test plan

- [x] `python3 scripts/sanitize_schema_test.py` — three cases: full-pipeline rename invariant for scalar regclass, array fallback, jsonb regression
- [x] `cargo fmt --all` clean
- [ ] CI `Corpus Convergence (sagri/mrv)` job converges at exactly 2 ops

Closes #301