### PR TITLE
test(corpus): assert sagri/mrv convergence baseline exactly

### DIFF
--- a/tests/corpus_sagri_mrv.rs
+++ b/tests/corpus_sagri_mrv.rs
@@ -121,17 +121,18 @@ async fn sagri_mrv_snapshot_converges() {
         .expect("introspect after apply");
     let second_diff = diff_modulo_drop_ext(&after, &target);
 
-    // Convergence ratchet: pgmold currently emits some no-op ops in the
-    // second diff for object kinds that pgmold doesn't fully model yet.
-    // The 2-op baseline is fully attributed:
-    //   -  2 CreateExt    — ALTER EXTENSION SET SCHEMA missing      (gh#300)
-    // Drop the baseline by the corresponding op count as each issue lands.
+    // Convergence baseline asserted exactly: any deviation (regression OR
+    // unannounced improvement) prints the full residual op list and SQL so we
+    // can either ratchet down or open a follow-up. The previous `>` form let
+    // silent improvements hide — gh#300's fix in #307 closed the issue but
+    // never ratcheted, leaving 2-op slack of unknown attribution.
     const CONVERGENCE_BASELINE: usize = 2;
-    if second_diff.len() > CONVERGENCE_BASELINE {
+    if second_diff.len() != CONVERGENCE_BASELINE {
         let remaining_sql = generate_sql(&plan_migration(second_diff.clone()));
         panic!(
-            "sagri_mrv convergence regressed: {} op(s) remain (baseline {}). \
-             A new convergence bug appeared — see gh#300 for tracked classes.\n\
+            "sagri_mrv convergence baseline drift: {} op(s) remain (baseline {}). \
+             If fewer than baseline, ratchet the baseline down. If more, a new \
+             convergence bug appeared — open a follow-up.\n\
              remaining ops: {:#?}\n\
              remaining SQL:\n{}",
             second_diff.len(),

--- a/tests/corpus_sagri_mrv.rs
+++ b/tests/corpus_sagri_mrv.rs
@@ -121,16 +121,9 @@ async fn sagri_mrv_snapshot_converges() {
         .expect("introspect after apply");
     let second_diff = diff_modulo_drop_ext(&after, &target);
 
-    // Convergence baseline asserted exactly. The `>` form historically let
-    // silent improvements hide: gh#300's fix in #307 closed the issue but
-    // never ratcheted this constant, leaving 2-op slack of unknown
-    // attribution today. With `!=`, the next CI run prints the actual
-    // residual op list. Action on failure:
-    //   - actual < baseline → ratchet the constant down to actual
-    //   - actual > baseline → open a follow-up issue, attribute the new ops
-    //
-    // Attribution unverified pending CI output (see commit history if you
-    // are revisiting this).
+    // Exact match. On failure:
+    //   actual < baseline → ratchet this constant down to actual
+    //   actual > baseline → open a follow-up issue and attribute the new ops
     const CONVERGENCE_BASELINE: usize = 2;
     if second_diff.len() != CONVERGENCE_BASELINE {
         let remaining_sql = generate_sql(&plan_migration(second_diff.clone()));

--- a/tests/corpus_sagri_mrv.rs
+++ b/tests/corpus_sagri_mrv.rs
@@ -121,18 +121,21 @@ async fn sagri_mrv_snapshot_converges() {
         .expect("introspect after apply");
     let second_diff = diff_modulo_drop_ext(&after, &target);
 
-    // Convergence baseline asserted exactly: any deviation (regression OR
-    // unannounced improvement) prints the full residual op list and SQL so we
-    // can either ratchet down or open a follow-up. The previous `>` form let
-    // silent improvements hide — gh#300's fix in #307 closed the issue but
-    // never ratcheted, leaving 2-op slack of unknown attribution.
+    // Convergence baseline asserted exactly. The `>` form historically let
+    // silent improvements hide: gh#300's fix in #307 closed the issue but
+    // never ratcheted this constant, leaving 2-op slack of unknown
+    // attribution today. With `!=`, the next CI run prints the actual
+    // residual op list. Action on failure:
+    //   - actual < baseline → ratchet the constant down to actual
+    //   - actual > baseline → open a follow-up issue, attribute the new ops
+    //
+    // Attribution unverified pending CI output (see commit history if you
+    // are revisiting this).
     const CONVERGENCE_BASELINE: usize = 2;
     if second_diff.len() != CONVERGENCE_BASELINE {
         let remaining_sql = generate_sql(&plan_migration(second_diff.clone()));
         panic!(
-            "sagri_mrv convergence baseline drift: {} op(s) remain (baseline {}). \
-             If fewer than baseline, ratchet the baseline down. If more, a new \
-             convergence bug appeared — open a follow-up.\n\
+            "sagri_mrv convergence baseline drift: actual={} expected={}.\n\
              remaining ops: {:#?}\n\
              remaining SQL:\n{}",
             second_diff.len(),


### PR DESCRIPTION
Switch the residual-op check in `tests/corpus_sagri_mrv.rs` from `second_diff.len() > CONVERGENCE_BASELINE` to `!=`. The `>` form lets silent improvements pass without forcing a baseline ratchet — that is how gh#300 ended up "fixed" by #307 without dropping this constant. Today the inline comment still attributes 2 ops to a closed issue and we cannot tell from CI alone whether the residual is 0, 1, or 2.

With `!=`, the next CI run prints the actual residual op list. Action paths are documented above the constant.

## Test plan

- [x] cargo fmt clean
- [x] sagri/mrv convergence test invokes the `!=` path on next CI run, output tells us the actual residual count
- [ ] follow-up: ratchet `CONVERGENCE_BASELINE` to the actual count once CI surfaces it (separate one-line PR), or open a follow-up issue if there are unexplained ops