### PR TITLE
chore: bump version to 0.34.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1587,7 +1587,7 @@ dependencies = [
 
 [[package]]
 name = "pgmold"
-version = "0.34.10"
+version = "0.34.11"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "pgmold"
-version = "0.34.10"
+version = "0.34.11"
 edition = "2021"
 exclude = [".auto-claude/", ".auto-claude-security.json", ".claude_settings.json"]
 description = "PostgreSQL schema-as-code management tool"


### PR DESCRIPTION
Cuts a 0.34.11 patch release. Dominant theme since v0.34.10 is sagri/mrv corpus convergence — the snapshot now applies and round-trips to zero diff ops.

## Changes since v0.34.10

### Convergence and normalization fixes

- **#297** normalise SQL-quoted SET values in function convergence
- **#302** read pg_description in introspect for 9 commentable kinds
- **#304** strip array-element typmod for function-signature key
- **#306** strip scalar typmod for function-signature key
- **#307** emit `ALTER EXTENSION SET SCHEMA` for relocated extensions (new `MigrationOp::AlterExtensionSetSchema` variant)
- **#312** defer parser-side typmod normalization to comparison time
- **#313** normalize default ORDER BY options for view convergence
- **#317** declare extension target schemas, drop sagri/mrv baseline to 0

### Parser

- **#290** parse `ALTER SCHEMA ... OWNER TO`

### Other fixes

- **#292** dedup auto-generated CHECK constraint names per Postgres scheme

### Test infrastructure / corpus

- **#284** vendor sanitized sagri/mrv schema as regression net
- **#285** preserve view bodies in sagri/mrv scrubber
- **#286** preserve plpgsql bodies in sagri/mrv scrubber
- **#295 / #296** drop CHECK CONSTRAINT-name workaround now that pgmold-289 is fixed
- **#308** preserve regclass cast literals in sagri/mrv snapshot
- **#314** assert sagri/mrv convergence baseline exactly

## Compatibility

API is additive. The `MigrationOp` enum gained an `AlterExtensionSetSchema` variant (#307); downstream consumers that match exhaustively will need to handle it. The project is `0.x` so this is treated as a patch.