### PR TITLE
chore: refresh Cargo.lock for pgmold-sqlparser 0.63.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1612,9 +1612,9 @@ dependencies = [
 
 [[package]]
 name = "pgmold-sqlparser"
-version = "0.62.0"
+version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "656c7eda01a307b0d5f8ade93d3b701d7bef9b89e7587913f9e1203a50916702"
+checksum = "149cdc1dd64b7bc0f3918f6b8f72f8ea3a7af8b52df3a87bcabc848bf8d023d2"
 dependencies = [
  "log",
  "recursive",


### PR DESCRIPTION
The `pgmold-sqlparser` constraint in Cargo.toml was bumped to `0.63.0` in #277, but Cargo.lock was never refreshed. Every `cargo build` since has silently auto-resolved to `0.63.0`. The `cargo publish` step for v0.34.11 surfaced the drift by writing the resolved version back to the working copy.

Pure lockfile sync; no Cargo.toml change.