### PR TITLE
docs: add pg-delta to declarative tools comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,20 +399,29 @@ Set `PGMOLD_PROD=1` for production mode, which blocks table drops entirely.
 
 These tools share pgmold's approach: define desired state, compute diffs automatically.
 
-| Feature | pgmold | [Atlas](https://atlasgo.io/) | [pg-schema-diff](https://github.com/stripe/pg-schema-diff) | [pgschema](https://www.pgschema.com/) |
-|---------|--------|-------|----------------|----------|
-| **Language** | Rust | Go | Go | Go |
-| **Schema Format** | Native SQL | HCL, SQL, ORM | Native SQL | SQL |
-| **Multi-DB Support** | PostgreSQL | ✅ Many | PostgreSQL | PostgreSQL |
-| **Drift Detection** | ✅ | ✅ | ❌ | ❌ |
-| **Lock Hazard Warnings** | ✅ | ✅ | ✅ | ❌ |
-| **Safety Linting** | ✅ | ✅ | ❌ | ❌ |
-| **RLS Policies** | ✅ | ✅ | ❌ | ✅ |
-| **Partitioned Tables** | ✅ | ✅ | ✅ | ⚠️ parent only[^pgschema-partitions] |
-| **Cloud Service** | ❌ | Atlas Cloud | ❌ | ❌ |
-| **Library Mode** | ❌ | ❌ | ✅ | ❌ |
+| Feature | pgmold | [Atlas](https://atlasgo.io/) | [pg-schema-diff](https://github.com/stripe/pg-schema-diff) | [pgschema](https://www.pgschema.com/) | [pg-delta](https://github.com/supabase/pg-toolbelt/tree/main/packages/pg-delta) |
+|---------|--------|-------|----------------|----------|----------|
+| **Language** | Rust | Go | Go | Go | TypeScript |
+| **Schema Format** | Native SQL | HCL, SQL, ORM | Native SQL | SQL | Native SQL |
+| **Multi-DB Support** | PostgreSQL | ✅ Many | PostgreSQL | PostgreSQL | PostgreSQL |
+| **Drift Detection** | ✅ | ✅ | ❌ | ❌ | ❌[^pgdelta-drift] |
+| **Lock Hazard Warnings** | ✅ | ✅ | ✅ | ❌ | ❌ |
+| **Safety Linting** | ✅ | ✅ | ❌ | ❌ | ⚠️ data-loss only[^pgdelta-safety] |
+| **RLS Policies** | ✅ | ✅ | ❌ | ✅ | ✅ |
+| **Partitioned Tables** | ✅ | ✅ | ✅ | ⚠️ parent only[^pgschema-partitions] | ✅ |
+| **Cloud Service** | ❌ | Atlas Cloud | ❌ | ❌ | Supabase Cloud[^pgdelta-cloud] |
+| **Library Mode** | ❌ | ❌ | ✅ | ❌ | ✅ |
+| **Stability** | ✅ stable | ✅ stable | ✅ stable | ✅ stable | ⚠️ alpha[^pgdelta-alpha] |
 
 [^pgschema-partitions]: pgschema v1.9.0 dumps the parent's `PARTITION BY` clause correctly but emits children as standalone `CREATE TABLE` statements without `PARTITION OF`, so re-applying a dump loses the partition hierarchy.
+
+[^pgdelta-drift]: pg-delta has no dedicated `drift` command. An empty `pgdelta plan` between schema source and live database is functionally equivalent, but there is no fingerprint-based drift report or CI exit-code contract.
+
+[^pgdelta-safety]: pg-delta classifies plans as `safe` or `data-loss (N)` and gates `apply`/`sync` behind `--unsafe` for `DROP TABLE`, `DROP COLUMN`, and `DROP SEQUENCE`. It does not warn on lock-class hazards (e.g. `ALTER TABLE ... SET NOT NULL` on a large table) or type-narrowing risks.
+
+[^pgdelta-cloud]: pg-delta is the diffing engine behind Supabase's dashboard branching since the [May 2026 announcement](https://supabase.com/blog/branching-without-git-is-now-the-default), but it is also published as a standalone CLI/library on npm.
+
+[^pgdelta-alpha]: As of `1.0.0-alpha.24` (May 2026), the package is still pre-1.0 and its maintainers explicitly solicit bug reports. The npm `latest` tag points to a `0.0.0` placeholder; real releases ship under the `alpha` dist-tag.
 
 ### vs Migration-Based Tools
 
@@ -441,6 +450,8 @@ Traditional tools where you write numbered migration files manually.
 - **Multi-database support** → [Atlas](https://atlasgo.io/), [Flyway](https://flywaydb.org), [Liquibase](https://www.liquibase.org/)
 - **HCL/Terraform-style syntax** → [Atlas](https://atlasgo.io/)
 - **Embeddable Go library** → [pg-schema-diff](https://github.com/stripe/pg-schema-diff)
+- **Embeddable TypeScript library** → [pg-delta](https://github.com/supabase/pg-toolbelt/tree/main/packages/pg-delta)
+- **Supabase-native projects** with dashboard branching → [pg-delta](https://github.com/supabase/pg-toolbelt/tree/main/packages/pg-delta)
 - **Zero-downtime migrations** → [pgroll](https://github.com/xataio/pgroll), [Reshape](https://github.com/fabianlindfors/reshape)
 - **Enterprise compliance/audit** → [Liquibase](https://www.liquibase.org/), [Bytebase](https://www.bytebase.com/)
 - **Managed cloud service** → [Atlas Cloud](https://atlasgo.io/cloud/getting-started)


### PR DESCRIPTION
## Summary

Adds [`@supabase/pg-delta`](https://github.com/supabase/pg-toolbelt/tree/main/packages/pg-delta) — the schema-diff engine that now powers Supabase's dashboard branching — to the declarative tools comparison table, plus a "Stability" row to acknowledge that pg-delta is still alpha while the other entries are stable.

## What changed

- New column in the **vs Declarative Schema-as-Code Tools** table covering language, schema format, drift detection, lock-hazard warnings, safety linting, RLS, partitions, cloud, library mode, and stability.
- Five footnotes explaining where pg-delta sits on each axis:
  - No dedicated drift command (empty plan is functionally equivalent but no fingerprint contract)
  - Safety linting is data-loss-only (`DROP TABLE` / `DROP COLUMN` / `DROP SEQUENCE`); no lock-hazard or type-narrowing warnings
  - Cloud integration is Supabase Cloud's branching feature
  - Alpha versioning: latest npm release is `1.0.0-alpha.24` under the `alpha` dist-tag (the `latest` tag points to a `0.0.0` placeholder)
- Two new bullets under "When to Choose Alternatives" — embeddable TypeScript library and Supabase-native projects.

## How the claims were verified

Hands-on against `@supabase/pg-delta@1.0.0-alpha.24`, run from a vanilla `postgis/postgis:16-3.4` container with a representative schema covering: PostGIS geometry, `PARTITION BY RANGE` with child partitions, `DEFERRABLE INITIALLY IMMEDIATE`, RLS policies with cross-schema function calls, and partial/functional indexes.

- Plan/sync/apply commands all worked; `--unsafe` is required for data-loss operations.
- Risk classifier source (`src/core/plan/risk.ts`) confirms it only flags table/column/sequence drops.
- No `drift` subcommand in `pgdelta --help`; no fingerprint comparison primitives in source.
- npm metadata: `npm view @supabase/pg-delta` shows `latest: 0.0.0` and `alpha: 1.0.0-alpha.24`.

## Test plan

- [x] Markdown renders: footnotes link from table cells to definitions
- [x] Existing pgschema partition footnote still resolves
- [x] No broken links (verified Supabase blog and pg-toolbelt URLs)