### PR TITLE
ci: retry docker pulls with exponential backoff, cap matrix parallelism

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,10 +92,19 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Pre-pull postgres image via ECR Public mirror
         run: |
-          docker pull public.ecr.aws/docker/library/postgres:16.12
-          docker tag  public.ecr.aws/docker/library/postgres:16.12 postgres:16
+          for attempt in 1 2 3 4 5; do
+            docker pull public.ecr.aws/docker/library/postgres:16.12 && break
+            echo "Pull attempt $attempt failed, retrying in $((attempt * 10))s..."
+            sleep $((attempt * 10))
+          done
+          docker tag public.ecr.aws/docker/library/postgres:16.12 postgres:16
       - name: Pre-pull postgis image
-        run: docker pull postgis/postgis:16-3.4
+        run: |
+          for attempt in 1 2 3 4 5; do
+            docker pull postgis/postgis:16-3.4 && break
+            echo "Pull attempt $attempt failed, retrying in $((attempt * 10))s..."
+            sleep $((attempt * 10))
+          done
       - name: Run integration tests
         run: cargo test --all-features --test '*' -- --test-threads=4
 
@@ -108,8 +117,12 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Pre-pull postgres image via ECR Public mirror
         run: |
-          docker pull public.ecr.aws/docker/library/postgres:16.12
-          docker tag  public.ecr.aws/docker/library/postgres:16.12 postgres:16
+          for attempt in 1 2 3 4 5; do
+            docker pull public.ecr.aws/docker/library/postgres:16.12 && break
+            echo "Pull attempt $attempt failed, retrying in $((attempt * 10))s..."
+            sleep $((attempt * 10))
+          done
+          docker tag public.ecr.aws/docker/library/postgres:16.12 postgres:16
       - name: Run corpus convergence tests
         run: cargo test --all-features --test corpus -- --ignored --test-threads=1
 
@@ -121,7 +134,12 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Pre-pull postgis image
-        run: docker pull postgis/postgis:16-3.4
+        run: |
+          for attempt in 1 2 3 4 5; do
+            docker pull postgis/postgis:16-3.4 && break
+            echo "Pull attempt $attempt failed, retrying in $((attempt * 10))s..."
+            sleep $((attempt * 10))
+          done
       - name: Run sagri/mrv snapshot convergence
         run: cargo test --all-features --test corpus_sagri_mrv -- --ignored --test-threads=1 --nocapture
 
@@ -140,6 +158,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      max-parallel: 2
       matrix:
         include:
           - pg-version: "13.23"
@@ -153,8 +172,12 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Pre-pull postgres image via ECR Public mirror
         run: |
-          docker pull public.ecr.aws/docker/library/postgres:${{ matrix.pg-version }}
-          docker tag  public.ecr.aws/docker/library/postgres:${{ matrix.pg-version }} postgres:${{ matrix.pg-version }}
+          for attempt in 1 2 3 4 5; do
+            docker pull public.ecr.aws/docker/library/postgres:${{ matrix.pg-version }} && break
+            echo "Pull attempt $attempt failed, retrying in $((attempt * 10))s..."
+            sleep $((attempt * 10))
+          done
+          docker tag public.ecr.aws/docker/library/postgres:${{ matrix.pg-version }} postgres:${{ matrix.pg-version }}
       - name: Run integration tests against PostgreSQL ${{ matrix.pg-version }}
         env:
           PGMOLD_TEST_PG_VERSION: ${{ matrix.pg-version }}


### PR DESCRIPTION
## Summary

- Wraps every `docker pull` (ECR Public and Docker Hub) in a 5-attempt retry loop with exponential backoff (10s × attempt number) to survive transient `toomanyrequests` rate-limit errors
- Adds `max-parallel: 2` to the `pg-version-matrix` strategy so at most 2 of the 5 PG-version jobs hammer ECR simultaneously

## Context

PR #320 continued to fail at "Pre-pull postgres image via ECR Public mirror" for PG 15.17 with `toomanyrequests: Rate exceeded` even after #321 switched to ECR Public. ECR Public also throttles anonymous pulls from shared GHA runner pools when multiple jobs fire at once.