### PR TITLE
fix(parser): truncate identifiers at NAMEDATALEN-1 to converge with live DB

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -155,7 +155,7 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
                 let idx_name = ci
                     .name
                     .as_ref()
-                    .map(truncated_ident)
+                    .map(|n| truncated_ident(n))
                     .ok_or_else(|| SchemaError::ParseError("Index must have name".into()))?;
                 let (tbl_schema, tbl_name) = extract_qualified_name(&ci.table_name);
                 let tbl_key = qualified_name(&tbl_schema, &tbl_name);

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -155,7 +155,7 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
                 let idx_name = ci
                     .name
                     .as_ref()
-                    .map(|n| truncated_ident(n))
+                    .map(truncated_ident)
                     .ok_or_else(|| SchemaError::ParseError("Index must have name".into()))?;
                 let (tbl_schema, tbl_name) = extract_qualified_name(&ci.table_name);
                 let tbl_key = qualified_name(&tbl_schema, &tbl_name);

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -153,7 +153,7 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
             Statement::CreateIndex(ci) => {
                 let idx_name = ci
                     .name
-                    .map(|n| unquote_ident(&n.to_string()).to_string())
+                    .map(|n| truncate_identifier(unquote_ident(&n.to_string())))
                     .ok_or_else(|| SchemaError::ParseError("Index must have name".into()))?;
                 let (tbl_schema, tbl_name) = extract_qualified_name(&ci.table_name);
                 let tbl_key = qualified_name(&tbl_schema, &tbl_name);
@@ -212,7 +212,7 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
             }) => {
                 let (tbl_schema, tbl_name) = extract_qualified_name(&table_name);
                 let policy = Policy {
-                    name: unquote_ident(&name.to_string()).to_string(),
+                    name: truncate_identifier(unquote_ident(&name.to_string())),
                     table_schema: tbl_schema,
                     table: tbl_name,
                     command: parse_policy_command(&command),
@@ -334,7 +334,7 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
                                         };
 
                                         table.check_constraints.push(CheckConstraint {
-                                            name: constraint_name,
+                                            name: truncate_identifier(&constraint_name),
                                             expression: normalize_expr(&chk.expr.to_string()),
                                         });
                                         table.check_constraints.sort();
@@ -347,7 +347,7 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
                                             .unwrap_or_else(|| format!("{tbl_name}_unique"));
 
                                         table.indexes.push(Index {
-                                            name: constraint_name,
+                                            name: truncate_identifier(&constraint_name),
                                             columns: uniq
                                                 .columns
                                                 .iter()
@@ -833,7 +833,7 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
                 ..
             }) => {
                 let (tbl_schema, tbl_name) = extract_qualified_name(&table_name);
-                let trigger_name = unquote_ident(&name.to_string()).to_string();
+                let trigger_name = truncate_identifier(unquote_ident(&name.to_string()));
                 let exec = exec_body.as_ref().ok_or_else(|| {
                     SchemaError::ParseError(format!(
                         "Trigger '{trigger_name}' missing EXECUTE clause"
@@ -1000,7 +1000,7 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
                     comment: None,
                 };
 
-                let key = format!("{tbl_schema}.{tbl_name}.{trigger_name}");
+                let key = make_trigger_key(&tbl_schema, &tbl_name, &trigger_name);
                 schema.triggers.insert(key, trigger);
             }
             Statement::CreateSequence {
@@ -1010,7 +1010,8 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
                 owned_by,
                 ..
             } => {
-                let (seq_schema, seq_name) = extract_qualified_name(&name);
+                let (seq_schema, raw_seq_name) = extract_qualified_name(&name);
+                let seq_name = truncate_identifier(&raw_seq_name);
                 let sequence = parse_create_sequence(
                     &seq_schema,
                     &seq_name,
@@ -1037,7 +1038,9 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
                             schema.views.remove(&key);
                         }
                         ObjectType::Sequence => {
-                            schema.sequences.remove(&key);
+                            let truncated = truncate_identifier(&obj_name);
+                            let truncated_key = qualified_name(&obj_schema, &truncated);
+                            schema.sequences.remove(&truncated_key);
                         }
                         ObjectType::Schema => {
                             schema.schemas.remove(&obj_name);
@@ -1046,11 +1049,12 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
                             schema.enums.remove(&key);
                         }
                         ObjectType::Index => {
+                            let truncated = truncate_identifier(&obj_name);
                             for table in schema.tables.values_mut() {
-                                table.indexes.retain(|idx| idx.name != obj_name);
+                                table.indexes.retain(|idx| idx.name != truncated);
                             }
                             for partition in schema.partitions.values_mut() {
-                                partition.indexes.retain(|idx| idx.name != obj_name);
+                                partition.indexes.retain(|idx| idx.name != truncated);
                             }
                         }
                         // Cluster-level objects (Database, Role, User) and
@@ -1099,11 +1103,10 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
                 ..
             }) => {
                 let (tbl_schema, tbl_name) = extract_qualified_name(tbl);
-                let trigger_key = format!(
-                    "{}.{}.{}",
-                    tbl_schema,
-                    tbl_name,
-                    unquote_ident(&trigger_name.to_string())
+                let trigger_key = make_trigger_key(
+                    &tbl_schema,
+                    &tbl_name,
+                    unquote_ident(&trigger_name.to_string()),
                 );
                 schema.triggers.remove(&trigger_key);
             }
@@ -1113,7 +1116,7 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
             }) => {
                 let (tbl_schema, tbl_name) = extract_qualified_name(&table_name);
                 let tbl_key = qualified_name(&tbl_schema, &tbl_name);
-                let policy_name = unquote_ident(&name.to_string()).to_string();
+                let policy_name = truncate_identifier(unquote_ident(&name.to_string()));
 
                 if let Some(table) = schema.tables.get_mut(&tbl_key) {
                     table.policies.retain(|p| p.name != policy_name);
@@ -1241,10 +1244,12 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
             | Statement::CreateUserMapping(_)
             | Statement::CreateTablespace(_) => {}
             Statement::AlterIndex { name, operation } => {
-                let (idx_schema, idx_name) = extract_qualified_name(&name);
+                let (idx_schema, raw_idx_name) = extract_qualified_name(&name);
+                let idx_name = truncate_identifier(&raw_idx_name);
                 match operation {
                     AlterIndexOperation::RenameIndex { index_name } => {
-                        let (_, new_name) = extract_qualified_name(&index_name);
+                        let (_, raw_new_name) = extract_qualified_name(&index_name);
+                        let new_name = truncate_identifier(&raw_new_name);
                         let mut found = false;
                         for table in schema.tables.values_mut() {
                             for idx in &mut table.indexes {
@@ -1672,5 +1677,5 @@ fn parse_create_server(stmt: CreateServerStatement, schema: &mut Schema) {
 }
 
 fn make_trigger_key(schema: &str, table: &str, trigger_name: &str) -> String {
-    format!("{}.{}.{}", schema, table, trigger_name)
+    format!("{}.{}.{}", schema, table, truncate_identifier(trigger_name))
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -465,8 +465,10 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
                             }
                         }
                         AlterTableOperation::RenameConstraint { old_name, new_name } => {
-                            let old_constraint_name = unquote_ident(&old_name.value).to_string();
-                            let new_constraint_name = unquote_ident(&new_name.value).to_string();
+                            let old_constraint_name =
+                                truncate_identifier(unquote_ident(&old_name.value));
+                            let new_constraint_name =
+                                truncate_identifier(unquote_ident(&new_name.value));
 
                             if let Some(table) = schema.tables.get_mut(&tbl_key) {
                                 for idx in &mut table.indexes {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -61,7 +61,8 @@ use tables::{
 };
 use util::{
     extract_qualified_name, normalize_expr, parse_data_type, parse_for_values,
-    parse_for_values_required, parse_policy_command, truncate_identifier, unquote_ident,
+    parse_for_values_required, parse_policy_command, truncate_identifier, truncated_ident,
+    unquote_ident,
 };
 
 pub fn parse_sql_file(path: &str) -> Result<Schema> {
@@ -153,7 +154,8 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
             Statement::CreateIndex(ci) => {
                 let idx_name = ci
                     .name
-                    .map(|n| truncate_identifier(unquote_ident(&n.to_string())))
+                    .as_ref()
+                    .map(truncated_ident)
                     .ok_or_else(|| SchemaError::ParseError("Index must have name".into()))?;
                 let (tbl_schema, tbl_name) = extract_qualified_name(&ci.table_name);
                 let tbl_key = qualified_name(&tbl_schema, &tbl_name);
@@ -212,7 +214,7 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
             }) => {
                 let (tbl_schema, tbl_name) = extract_qualified_name(&table_name);
                 let policy = Policy {
-                    name: truncate_identifier(unquote_ident(&name.to_string())),
+                    name: truncated_ident(&name),
                     table_schema: tbl_schema,
                     table: tbl_name,
                     command: parse_policy_command(&command),
@@ -833,7 +835,7 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
                 ..
             }) => {
                 let (tbl_schema, tbl_name) = extract_qualified_name(&table_name);
-                let trigger_name = truncate_identifier(unquote_ident(&name.to_string()));
+                let trigger_name = truncated_ident(&name);
                 let exec = exec_body.as_ref().ok_or_else(|| {
                     SchemaError::ParseError(format!(
                         "Trigger '{trigger_name}' missing EXECUTE clause"
@@ -1010,8 +1012,8 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
                 owned_by,
                 ..
             } => {
-                let (seq_schema, raw_seq_name) = extract_qualified_name(&name);
-                let seq_name = truncate_identifier(&raw_seq_name);
+                let (seq_schema, seq_name) = extract_qualified_name(&name);
+                let seq_name = truncate_identifier(&seq_name);
                 let sequence = parse_create_sequence(
                     &seq_schema,
                     &seq_name,
@@ -1116,7 +1118,7 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
             }) => {
                 let (tbl_schema, tbl_name) = extract_qualified_name(&table_name);
                 let tbl_key = qualified_name(&tbl_schema, &tbl_name);
-                let policy_name = truncate_identifier(unquote_ident(&name.to_string()));
+                let policy_name = truncated_ident(&name);
 
                 if let Some(table) = schema.tables.get_mut(&tbl_key) {
                     table.policies.retain(|p| p.name != policy_name);
@@ -1244,12 +1246,12 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
             | Statement::CreateUserMapping(_)
             | Statement::CreateTablespace(_) => {}
             Statement::AlterIndex { name, operation } => {
-                let (idx_schema, raw_idx_name) = extract_qualified_name(&name);
-                let idx_name = truncate_identifier(&raw_idx_name);
+                let (idx_schema, idx_name) = extract_qualified_name(&name);
+                let idx_name = truncate_identifier(&idx_name);
                 match operation {
                     AlterIndexOperation::RenameIndex { index_name } => {
-                        let (_, raw_new_name) = extract_qualified_name(&index_name);
-                        let new_name = truncate_identifier(&raw_new_name);
+                        let (_, new_name) = extract_qualified_name(&index_name);
+                        let new_name = truncate_identifier(&new_name);
                         let mut found = false;
                         for table in schema.tables.values_mut() {
                             for idx in &mut table.indexes {

--- a/src/parser/tables.rs
+++ b/src/parser/tables.rs
@@ -378,7 +378,7 @@ pub(super) fn parse_column_with_serial(
     }
 
     if let Some(seq_data_type) = detect_serial_type(&col_def.data_type) {
-        let seq_name = format!("{table_name}_{col_name}_seq");
+        let seq_name = truncate_identifier(&format!("{table_name}_{col_name}_seq"));
         let seq_qualified = qualified_name(table_schema, &seq_name);
 
         let pg_type = match seq_data_type {

--- a/src/parser/tables.rs
+++ b/src/parser/tables.rs
@@ -15,8 +15,8 @@ use sqlparser::ast::{
 use std::collections::BTreeMap;
 
 use super::util::{
-    extract_qualified_name, normalize_expr, parse_data_type, truncate_identifier, unquote_ident,
-    PG_MAX_IDENTIFIER_LENGTH,
+    extract_qualified_name, normalize_expr, parse_data_type, truncate_identifier,
+    truncate_to_bytes, unquote_ident, PG_MAX_IDENTIFIER_LENGTH,
 };
 
 pub(super) struct ParsedTable {
@@ -519,11 +519,7 @@ pub(super) fn dedup_check_constraint_name(base: &str, table: &Table) -> String {
     loop {
         let suffix = counter.to_string();
         let max_base = PG_MAX_IDENTIFIER_LENGTH.saturating_sub(suffix.len());
-        let truncated_base = if base.len() > max_base {
-            &base[..max_base]
-        } else {
-            base
-        };
+        let truncated_base = truncate_to_bytes(base, max_base);
         let candidate = format!("{truncated_base}{suffix}");
         if !check_name_taken(&candidate, table) {
             return candidate;

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -5541,3 +5541,59 @@ fn alter_index_rename_with_64_byte_names_applies_truncation() {
     assert_eq!(table.indexes.len(), 1);
     assert_eq!(table.indexes[0].name, "n".repeat(63));
 }
+
+#[test]
+fn truncate_identifier_stops_at_char_boundary_for_multibyte_input() {
+    // `あ` is a 3-byte UTF-8 char. 22 of them is 66 bytes; the 63-byte cap lands on a
+    // char boundary (21 chars = 63 bytes), so the result is exactly 63 bytes of valid UTF-8.
+    let input = "あ".repeat(22);
+    assert_eq!(input.len(), 66);
+    let truncated = truncate_identifier(&input);
+    assert_eq!(truncated, "あ".repeat(21));
+    assert_eq!(truncated.len(), 63);
+}
+
+#[test]
+fn truncate_identifier_does_not_split_codepoint_below_the_byte_cap() {
+    // `À` is a 2-byte UTF-8 char. 32 of them is 64 bytes; byte 63 falls mid-codepoint, so
+    // a byte-safe truncation must back off to byte 62 (31 chars), never produce 63 bytes.
+    let input = "À".repeat(32);
+    assert_eq!(input.len(), 64);
+    let truncated = truncate_identifier(&input);
+    assert_eq!(truncated, "À".repeat(31));
+    assert_eq!(truncated.len(), 62);
+}
+
+#[test]
+fn dedup_check_constraint_name_does_not_panic_on_multibyte_collision() {
+    // The suffix-disambiguation loop truncates the base to fit a numeric suffix. With a
+    // multibyte base, the byte offset can land mid-codepoint; a raw byte slice would panic.
+    let base = "あ".repeat(22);
+    let table = Table {
+        schema: "public".to_string(),
+        name: "t".to_string(),
+        columns: BTreeMap::new(),
+        primary_key: None,
+        indexes: Vec::new(),
+        foreign_keys: Vec::new(),
+        check_constraints: vec![CheckConstraint {
+            name: truncate_identifier(&base),
+            expression: "true".to_string(),
+        }],
+        exclusion_constraints: Vec::new(),
+        comment: None,
+        row_level_security: false,
+        force_row_level_security: false,
+        policies: Vec::new(),
+        partition_by: None,
+        owner: None,
+        grants: Vec::new(),
+    };
+
+    let chosen = dedup_check_constraint_name(&base, &table);
+
+    assert_ne!(chosen, truncate_identifier(&base));
+    assert!(chosen.ends_with('1'));
+    assert!(chosen.len() <= 63);
+    assert!(chosen.is_char_boundary(chosen.len()));
+}

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -5597,3 +5597,38 @@ fn dedup_check_constraint_name_does_not_panic_on_multibyte_collision() {
     assert!(chosen.len() <= 63);
     assert!(chosen.is_char_boundary(chosen.len()));
 }
+
+#[test]
+fn alter_table_rename_constraint_truncates_new_name_to_63_bytes() {
+    let long_new = "n".repeat(64);
+    let sql = format!(
+        r#"
+        CREATE TABLE users (id BIGINT NOT NULL, email TEXT NOT NULL);
+        CREATE INDEX users_email_idx ON users (email);
+        ALTER TABLE users RENAME CONSTRAINT users_email_idx TO "{long_new}";
+        "#
+    );
+    let schema = parse_sql_string(&sql).unwrap();
+    let table = schema.tables.get("public.users").unwrap();
+    assert_eq!(table.indexes.len(), 1);
+    assert_eq!(table.indexes[0].name, "n".repeat(63));
+}
+
+#[test]
+fn alter_table_rename_constraint_matches_already_truncated_old_name() {
+    // A 64-char constraint name is stored truncated to 63 bytes at creation time. Renaming
+    // from the 64-char form must match the stored 63-byte name, so the old name needs the
+    // same truncation before lookup.
+    let long_old = "o".repeat(64);
+    let sql = format!(
+        r#"
+        CREATE TABLE users (id BIGINT NOT NULL, email TEXT NOT NULL);
+        CREATE INDEX "{long_old}" ON users (email);
+        ALTER TABLE users RENAME CONSTRAINT "{long_old}" TO users_email_index;
+        "#
+    );
+    let schema = parse_sql_string(&sql).unwrap();
+    let table = schema.tables.get("public.users").unwrap();
+    assert_eq!(table.indexes.len(), 1);
+    assert_eq!(table.indexes[0].name, "users_email_index");
+}

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -5357,3 +5357,218 @@ fn aggregate_args_and_stype_preserve_typmod() {
     assert_eq!(agg.args, vec!["numeric(12,4)".to_string()]);
     assert_eq!(agg.stype, "numeric(12,4)");
 }
+
+#[test]
+fn standalone_create_index_name_is_truncated_to_63_bytes() {
+    let long_name = "i".repeat(64);
+    let sql = format!(
+        r#"
+        CREATE TABLE t (id BIGINT NOT NULL, val TEXT);
+        CREATE INDEX "{long_name}" ON t (val);
+        "#
+    );
+    let schema = parse_sql_string(&sql).unwrap();
+    let table = schema.tables.get("public.t").unwrap();
+    assert_eq!(table.indexes.len(), 1);
+    let name = &table.indexes[0].name;
+    assert!(
+        name.len() <= 63,
+        "standalone CREATE INDEX name must be truncated to 63 bytes; got {} bytes: {name}",
+        name.len()
+    );
+}
+
+#[test]
+fn create_trigger_name_is_truncated_to_63_bytes() {
+    let long_name = "t".repeat(64);
+    let sql = format!(
+        r#"
+        CREATE TABLE users (id BIGINT PRIMARY KEY);
+        CREATE FUNCTION audit_fn() RETURNS TRIGGER LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END; $$;
+        CREATE TRIGGER "{long_name}"
+        AFTER INSERT ON users
+        FOR EACH ROW
+        EXECUTE FUNCTION audit_fn();
+        "#
+    );
+    let schema = parse_sql_string(&sql).unwrap();
+    assert_eq!(schema.triggers.len(), 1);
+    let (key, trigger) = schema.triggers.iter().next().unwrap();
+    assert!(
+        trigger.name.len() <= 63,
+        "Trigger.name must be truncated to 63 bytes; got {} bytes: {}",
+        trigger.name.len(),
+        trigger.name
+    );
+    let trigger_part = key.rsplit('.').next().unwrap();
+    assert!(
+        trigger_part.len() <= 63,
+        "Trigger map key trailing name must be truncated to 63 bytes; got {} bytes: {key}",
+        trigger_part.len()
+    );
+}
+
+#[test]
+fn create_sequence_name_is_truncated_to_63_bytes() {
+    let long_name = "s".repeat(64);
+    let sql = format!(r#"CREATE SEQUENCE "{long_name}";"#);
+    let schema = parse_sql_string(&sql).unwrap();
+    assert_eq!(schema.sequences.len(), 1);
+    let (key, seq) = schema.sequences.iter().next().unwrap();
+    assert!(
+        seq.name.len() <= 63,
+        "Sequence.name must be truncated to 63 bytes; got {} bytes: {}",
+        seq.name.len(),
+        seq.name
+    );
+    let seq_part = key.split_once('.').map(|(_, n)| n).unwrap_or(key.as_str());
+    assert!(
+        seq_part.len() <= 63,
+        "Sequence map key trailing name must be truncated to 63 bytes; got: {key}"
+    );
+}
+
+#[test]
+fn alter_table_add_unique_constraint_name_is_truncated_to_63_bytes() {
+    let long_name = "u".repeat(64);
+    let sql = format!(
+        r#"
+        CREATE TABLE t (id BIGINT NOT NULL, val TEXT NOT NULL);
+        ALTER TABLE t ADD CONSTRAINT "{long_name}" UNIQUE (val);
+        "#
+    );
+    let schema = parse_sql_string(&sql).unwrap();
+    let table = schema.tables.get("public.t").unwrap();
+    assert_eq!(table.indexes.len(), 1);
+    let name = &table.indexes[0].name;
+    assert!(
+        name.len() <= 63,
+        "ALTER TABLE ADD CONSTRAINT UNIQUE name must be truncated to 63 bytes; got {} bytes: {name}",
+        name.len()
+    );
+}
+
+#[test]
+fn drop_trigger_with_64_byte_name_removes_trigger() {
+    let long_name = "t".repeat(64);
+    let sql = format!(
+        r#"
+        CREATE TABLE users (id BIGINT PRIMARY KEY);
+        CREATE FUNCTION audit_fn() RETURNS TRIGGER LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END; $$;
+        CREATE TRIGGER "{long_name}"
+        AFTER INSERT ON users
+        FOR EACH ROW
+        EXECUTE FUNCTION audit_fn();
+        DROP TRIGGER "{long_name}" ON users;
+        "#
+    );
+    let schema = parse_sql_string(&sql).unwrap();
+    assert_eq!(
+        schema.triggers.len(),
+        0,
+        "DROP TRIGGER with overlong name must remove the trigger; remaining: {:?}",
+        schema.triggers.keys().collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn alter_table_disable_trigger_with_64_byte_name_updates_state() {
+    let long_name = "t".repeat(64);
+    let sql = format!(
+        r#"
+        CREATE TABLE users (id BIGINT PRIMARY KEY);
+        CREATE FUNCTION audit_fn() RETURNS TRIGGER LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END; $$;
+        CREATE TRIGGER "{long_name}"
+        AFTER INSERT ON users
+        FOR EACH ROW
+        EXECUTE FUNCTION audit_fn();
+        ALTER TABLE users DISABLE TRIGGER "{long_name}";
+        "#
+    );
+    let schema = parse_sql_string(&sql).unwrap();
+    assert_eq!(schema.triggers.len(), 1);
+    let trigger = schema.triggers.values().next().unwrap();
+    assert_eq!(trigger.enabled, TriggerEnabled::Disabled);
+}
+
+#[test]
+fn drop_index_with_64_byte_name_removes_index() {
+    let long_name = "i".repeat(64);
+    let sql = format!(
+        r#"
+        CREATE TABLE t (id BIGINT NOT NULL, val TEXT);
+        CREATE INDEX "{long_name}" ON t (val);
+        DROP INDEX "{long_name}";
+        "#
+    );
+    let schema = parse_sql_string(&sql).unwrap();
+    let table = schema.tables.get("public.t").unwrap();
+    assert_eq!(
+        table.indexes.len(),
+        0,
+        "DROP INDEX with overlong name must remove the index; remaining: {:?}",
+        table.indexes.iter().map(|i| &i.name).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn drop_sequence_with_64_byte_name_removes_sequence() {
+    let long_name = "s".repeat(64);
+    let sql = format!(
+        r#"
+        CREATE SEQUENCE "{long_name}";
+        DROP SEQUENCE "{long_name}";
+        "#
+    );
+    let schema = parse_sql_string(&sql).unwrap();
+    assert_eq!(
+        schema.sequences.len(),
+        0,
+        "DROP SEQUENCE with overlong name must remove the sequence; remaining: {:?}",
+        schema.sequences.keys().collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn drop_policy_with_64_byte_name_removes_policy() {
+    let long_name = "p".repeat(64);
+    let sql = format!(
+        r#"
+        CREATE TABLE t (id BIGINT NOT NULL, val TEXT);
+        ALTER TABLE t ENABLE ROW LEVEL SECURITY;
+        CREATE POLICY "{long_name}" ON t FOR SELECT USING (true);
+        DROP POLICY "{long_name}" ON t;
+        "#
+    );
+    let schema = parse_sql_string(&sql).unwrap();
+    let table = schema.tables.get("public.t").unwrap();
+    assert_eq!(
+        table.policies.len(),
+        0,
+        "DROP POLICY with overlong name must remove the policy; remaining: {:?}",
+        table.policies.iter().map(|p| &p.name).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn alter_index_rename_with_64_byte_names_applies_truncation() {
+    let long_old = "o".repeat(64);
+    let long_new = "n".repeat(64);
+    let sql = format!(
+        r#"
+        CREATE TABLE t (id BIGINT NOT NULL, val TEXT);
+        CREATE INDEX "{long_old}" ON t (val);
+        ALTER INDEX "{long_old}" RENAME TO "{long_new}";
+        "#
+    );
+    let schema = parse_sql_string(&sql).unwrap();
+    let table = schema.tables.get("public.t").unwrap();
+    assert_eq!(table.indexes.len(), 1);
+    let renamed = &table.indexes[0].name;
+    assert!(
+        renamed.len() <= 63,
+        "ALTER INDEX RENAME target name must be truncated to 63 bytes; got {} bytes: {renamed}",
+        renamed.len()
+    );
+    assert_eq!(renamed, &"n".repeat(63));
+}

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -5361,6 +5361,7 @@ fn aggregate_args_and_stype_preserve_typmod() {
 #[test]
 fn standalone_create_index_name_is_truncated_to_63_bytes() {
     let long_name = "i".repeat(64);
+    let truncated = "i".repeat(63);
     let sql = format!(
         r#"
         CREATE TABLE t (id BIGINT NOT NULL, val TEXT);
@@ -5370,17 +5371,13 @@ fn standalone_create_index_name_is_truncated_to_63_bytes() {
     let schema = parse_sql_string(&sql).unwrap();
     let table = schema.tables.get("public.t").unwrap();
     assert_eq!(table.indexes.len(), 1);
-    let name = &table.indexes[0].name;
-    assert!(
-        name.len() <= 63,
-        "standalone CREATE INDEX name must be truncated to 63 bytes; got {} bytes: {name}",
-        name.len()
-    );
+    assert_eq!(table.indexes[0].name, truncated);
 }
 
 #[test]
 fn create_trigger_name_is_truncated_to_63_bytes() {
     let long_name = "t".repeat(64);
+    let truncated = "t".repeat(63);
     let sql = format!(
         r#"
         CREATE TABLE users (id BIGINT PRIMARY KEY);
@@ -5394,43 +5391,26 @@ fn create_trigger_name_is_truncated_to_63_bytes() {
     let schema = parse_sql_string(&sql).unwrap();
     assert_eq!(schema.triggers.len(), 1);
     let (key, trigger) = schema.triggers.iter().next().unwrap();
-    assert!(
-        trigger.name.len() <= 63,
-        "Trigger.name must be truncated to 63 bytes; got {} bytes: {}",
-        trigger.name.len(),
-        trigger.name
-    );
-    let trigger_part = key.rsplit('.').next().unwrap();
-    assert!(
-        trigger_part.len() <= 63,
-        "Trigger map key trailing name must be truncated to 63 bytes; got {} bytes: {key}",
-        trigger_part.len()
-    );
+    assert_eq!(trigger.name, truncated);
+    assert_eq!(key, &format!("public.users.{truncated}"));
 }
 
 #[test]
 fn create_sequence_name_is_truncated_to_63_bytes() {
     let long_name = "s".repeat(64);
+    let truncated = "s".repeat(63);
     let sql = format!(r#"CREATE SEQUENCE "{long_name}";"#);
     let schema = parse_sql_string(&sql).unwrap();
     assert_eq!(schema.sequences.len(), 1);
     let (key, seq) = schema.sequences.iter().next().unwrap();
-    assert!(
-        seq.name.len() <= 63,
-        "Sequence.name must be truncated to 63 bytes; got {} bytes: {}",
-        seq.name.len(),
-        seq.name
-    );
-    let seq_part = key.split_once('.').map(|(_, n)| n).unwrap_or(key.as_str());
-    assert!(
-        seq_part.len() <= 63,
-        "Sequence map key trailing name must be truncated to 63 bytes; got: {key}"
-    );
+    assert_eq!(seq.name, truncated);
+    assert_eq!(key, &format!("public.{truncated}"));
 }
 
 #[test]
 fn alter_table_add_unique_constraint_name_is_truncated_to_63_bytes() {
     let long_name = "u".repeat(64);
+    let truncated = "u".repeat(63);
     let sql = format!(
         r#"
         CREATE TABLE t (id BIGINT NOT NULL, val TEXT NOT NULL);
@@ -5440,12 +5420,7 @@ fn alter_table_add_unique_constraint_name_is_truncated_to_63_bytes() {
     let schema = parse_sql_string(&sql).unwrap();
     let table = schema.tables.get("public.t").unwrap();
     assert_eq!(table.indexes.len(), 1);
-    let name = &table.indexes[0].name;
-    assert!(
-        name.len() <= 63,
-        "ALTER TABLE ADD CONSTRAINT UNIQUE name must be truncated to 63 bytes; got {} bytes: {name}",
-        name.len()
-    );
+    assert_eq!(table.indexes[0].name, truncated);
 }
 
 #[test]
@@ -5564,11 +5539,5 @@ fn alter_index_rename_with_64_byte_names_applies_truncation() {
     let schema = parse_sql_string(&sql).unwrap();
     let table = schema.tables.get("public.t").unwrap();
     assert_eq!(table.indexes.len(), 1);
-    let renamed = &table.indexes[0].name;
-    assert!(
-        renamed.len() <= 63,
-        "ALTER INDEX RENAME target name must be truncated to 63 bytes; got {} bytes: {renamed}",
-        renamed.len()
-    );
-    assert_eq!(renamed, &"n".repeat(63));
+    assert_eq!(table.indexes[0].name, "n".repeat(63));
 }

--- a/src/parser/util.rs
+++ b/src/parser/util.rs
@@ -15,10 +15,17 @@ pub(super) const PG_MAX_IDENTIFIER_LENGTH: usize = 63;
 
 pub(super) fn truncate_identifier(s: &str) -> String {
     if s.len() <= PG_MAX_IDENTIFIER_LENGTH {
-        s.to_string()
-    } else {
-        s[..PG_MAX_IDENTIFIER_LENGTH].to_string()
+        return s.to_string();
     }
+    // PG's truncate_identifier uses pg_mbcliplen and stops at a character
+    // boundary, never mid-codepoint. Mirror that to match the live-DB
+    // identifier byte-for-byte and to avoid panicking on a UTF-8 slice that
+    // would otherwise split a multibyte sequence.
+    let mut end = PG_MAX_IDENTIFIER_LENGTH;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    s[..end].to_string()
 }
 
 pub(super) fn unquote_ident(s: &str) -> &str {

--- a/src/parser/util.rs
+++ b/src/parser/util.rs
@@ -17,10 +17,7 @@ pub(super) fn truncate_identifier(s: &str) -> String {
     if s.len() <= PG_MAX_IDENTIFIER_LENGTH {
         return s.to_string();
     }
-    // PG's truncate_identifier uses pg_mbcliplen and stops at a character
-    // boundary, never mid-codepoint. Mirror that to match the live-DB
-    // identifier byte-for-byte and to avoid panicking on a UTF-8 slice that
-    // would otherwise split a multibyte sequence.
+    // Match PG's pg_mbcliplen: stop at a UTF-8 char boundary, not mid-codepoint.
     let mut end = PG_MAX_IDENTIFIER_LENGTH;
     while end > 0 && !s.is_char_boundary(end) {
         end -= 1;
@@ -30,6 +27,10 @@ pub(super) fn truncate_identifier(s: &str) -> String {
 
 pub(super) fn unquote_ident(s: &str) -> &str {
     s.trim_matches('"')
+}
+
+pub(super) fn truncated_ident(name: &ObjectName) -> String {
+    truncate_identifier(unquote_ident(&name.to_string()))
 }
 
 pub(super) fn normalize_expr(expr: &str) -> String {

--- a/src/parser/util.rs
+++ b/src/parser/util.rs
@@ -14,15 +14,20 @@ use sqlparser::ast::{
 pub(super) const PG_MAX_IDENTIFIER_LENGTH: usize = 63;
 
 pub(super) fn truncate_identifier(s: &str) -> String {
-    if s.len() <= PG_MAX_IDENTIFIER_LENGTH {
-        return s.to_string();
+    truncate_to_bytes(s, PG_MAX_IDENTIFIER_LENGTH).to_string()
+}
+
+/// Truncate `s` to at most `max_bytes` bytes, backing off to the nearest UTF-8 char
+/// boundary at or below the cap. Mirrors PG's `pg_mbcliplen`: never split a codepoint.
+pub(super) fn truncate_to_bytes(s: &str, max_bytes: usize) -> &str {
+    if s.len() <= max_bytes {
+        return s;
     }
-    // Match PG's pg_mbcliplen: stop at a UTF-8 char boundary, not mid-codepoint.
-    let mut end = PG_MAX_IDENTIFIER_LENGTH;
+    let mut end = max_bytes;
     while end > 0 && !s.is_char_boundary(end) {
         end -= 1;
     }
-    s[..end].to_string()
+    &s[..end]
 }
 
 pub(super) fn unquote_ident(s: &str) -> &str {

--- a/src/parser/util.rs
+++ b/src/parser/util.rs
@@ -29,7 +29,7 @@ pub(super) fn unquote_ident(s: &str) -> &str {
     s.trim_matches('"')
 }
 
-pub(super) fn truncated_ident(name: &ObjectName) -> String {
+pub(super) fn truncated_ident(name: &impl std::fmt::Display) -> String {
     truncate_identifier(unquote_ident(&name.to_string()))
 }
 

--- a/tests/convergence.rs
+++ b/tests/convergence.rs
@@ -1327,3 +1327,19 @@ async fn aggregate_referenced_by_view_converges() {
     )
     .await;
 }
+
+#[tokio::test]
+async fn index_with_64_byte_name_converges() {
+    let long_name = "x".repeat(64);
+    let sql = format!(
+        r#"
+        CREATE TABLE public.t (
+            a TEXT NOT NULL,
+            b TEXT NOT NULL,
+            c TIMESTAMP WITH TIME ZONE NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS "{long_name}" ON public.t (a, b, c DESC);
+        "#
+    );
+    assert_convergence_public(&sql).await;
+}


### PR DESCRIPTION
## Summary

Postgres silently truncates identifiers exceeding 63 bytes (`NAMEDATALEN-1`) at object creation, so introspection always reads back the truncated form. The parser was carrying the declared name verbatim into the canonical model, producing a perpetual `DROP+CREATE` diff for any name >= 64 bytes — convergence never reached.

Repro (from #323):

```sql
CREATE INDEX IF NOT EXISTS "VcsDocumentPackage_supplierId_methodologyVersion_generatedAt_idx"
ON "mrv"."VcsDocumentPackage"("supplierId", "methodologyVersion", "generatedAt" DESC);
```

The declared name is 64 bytes; Postgres stores `..._id` (63 bytes, trailing `x` dropped); every subsequent `pgmold plan` emits `DropIndex(63-byte name) + CreateIndex(64-byte name)`.

## What changed

- Apply `truncate_identifier` at the remaining parser gap sites: `CREATE INDEX`, `CREATE TRIGGER`, `CREATE SEQUENCE`, `CREATE POLICY`, `ALTER TABLE ADD CHECK / ADD UNIQUE`, and the SERIAL-implicit sequence name.
- Route every trigger key through `make_trigger_key`, which now truncates internally so create, drop, and `ENABLE/DISABLE` lookups stay symmetric.
- Truncate the lookup side for `DROP SEQUENCE`, `DROP INDEX`, `DROP POLICY`, and `ALTER INDEX ... RENAME TO ...`.
- Fix `truncate_identifier` to stop at a UTF-8 character boundary (matching PG's `pg_mbcliplen`) rather than panicking mid-codepoint.

## Scope

Same family as #299 / #303 / #305 / #311 — parser-side normalization to match PG's storage form. No introspection changes needed: `pg_catalog` stores names in `name_t` (max 63 bytes), so the read side is already truncated.

Pre-existing untruncated CREATE paths (Table / View / Type / Function / Domain) are left untouched here — they're symmetrically untruncated on both create and drop, and widening to fix them is a separate, broader change. Follow-up issues:

- `pgmold lint` warning for declared identifiers > 63 bytes (from the issue, scope-cut to keep this PR focused).
- Comprehensive truncation for Table / View / Type / Function CREATE paths.

## Test plan

- [x] `cargo fmt --all`
- [x] New parser unit tests covering each gap site:
  - `standalone_create_index_name_is_truncated_to_63_bytes`
  - `create_trigger_name_is_truncated_to_63_bytes`
  - `create_sequence_name_is_truncated_to_63_bytes`
  - `alter_table_add_unique_constraint_name_is_truncated_to_63_bytes`
  - `drop_trigger_with_64_byte_name_removes_trigger`
  - `alter_table_disable_trigger_with_64_byte_name_updates_state`
  - `drop_index_with_64_byte_name_removes_index`
  - `drop_sequence_with_64_byte_name_removes_sequence`
  - `drop_policy_with_64_byte_name_removes_policy`
  - `alter_index_rename_with_64_byte_names_applies_truncation`
- [x] New convergence integration test: `index_with_64_byte_name_converges` (full apply + re-introspect + assert empty diff).
- [ ] Verify against `sagri-tokyo/mrv` staging once merged (per the repro path in #323).

Closes #323