### PR TITLE
fix(parser): suppress warnings for plpgsql hash directive bodies

### DIFF
--- a/src/parser/dependencies.rs
+++ b/src/parser/dependencies.rs
@@ -194,6 +194,9 @@ fn format_extract_table_references_failure(
 /// sqlparser cannot and should not parse as raw SQL.
 fn is_plpgsql_body(body: &str) -> bool {
     let trimmed = body.trim_start();
+    if trimmed.starts_with('#') {
+        return true;
+    }
     ["DECLARE", "BEGIN"].iter().any(|keyword| {
         trimmed
             .get(..keyword.len())
@@ -1045,6 +1048,15 @@ mod tests {
         assert!(!is_plpgsql_body("  SELECT 1  "));
         assert!(!is_plpgsql_body(""));
         assert!(!is_plpgsql_body("   \n\t  "));
+    }
+
+    #[test]
+    fn is_plpgsql_body_detects_hash_directives() {
+        assert!(is_plpgsql_body(
+            "#variable_conflict use_column\nDECLARE\n    v uuid;\nBEGIN\n    NULL;\nEND"
+        ));
+        assert!(is_plpgsql_body("#print_strict_params on\nBEGIN\n    NULL;\nEND"));
+        assert!(is_plpgsql_body("  \n#variable_conflict use_column\nDECLARE\nBEGIN\nEND"));
     }
 
     #[test]

--- a/src/parser/dependencies.rs
+++ b/src/parser/dependencies.rs
@@ -1055,8 +1055,12 @@ mod tests {
         assert!(is_plpgsql_body(
             "#variable_conflict use_column\nDECLARE\n    v uuid;\nBEGIN\n    NULL;\nEND"
         ));
-        assert!(is_plpgsql_body("#print_strict_params on\nBEGIN\n    NULL;\nEND"));
-        assert!(is_plpgsql_body("  \n#variable_conflict use_column\nDECLARE\nBEGIN\nEND"));
+        assert!(is_plpgsql_body(
+            "#print_strict_params on\nBEGIN\n    NULL;\nEND"
+        ));
+        assert!(is_plpgsql_body(
+            "  \n#variable_conflict use_column\nDECLARE\nBEGIN\nEND"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
bodies starting with `#` (e.g. `#variable_conflict use_column`, `#print_strict_params`) fell through the three sql parse strategies, emitting `[pgmold:parser] extract_table_references: all parse strategies failed` to stderr on every plpgsql function that uses those directives.

- `is_plpgsql_body` now returns true for any body whose first non-whitespace char is `#`
- planner gates body-dependency walks to `LANGUAGE sql` only, so plpgsql bodies with hash directives carry no dependency-analysis value and can be skipped silently
- adds `is_plpgsql_body_detects_hash_directives` test covering `#variable_conflict use_column` and `#print_strict_params`