### PR TITLE
docs: document column-rename limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,9 +400,9 @@ Set `PGMOLD_PROD=1` for production mode, which blocks table drops entirely.
 pgmold compares two snapshots (schema files vs. live database), so a rename of a column, table, index, or constraint looks identical to a drop + add. pgmold will emit the destructive form, which **destroys the column data and cascades to dependent objects**.
 
 ```sql
--- Schema file change: rename entity_id → supplier_id
+-- Schema file change: rename entity_id to supplier_id
 -- pgmold emits:
-ALTER TABLE orders ADD COLUMN supplier_id <type>;
+ALTER TABLE orders ADD COLUMN supplier_id UUID;
 ALTER TABLE orders DROP COLUMN entity_id CASCADE;
 ```
 

--- a/README.md
+++ b/README.md
@@ -393,6 +393,29 @@ By default, pgmold blocks destructive operations:
 
 Set `PGMOLD_PROD=1` for production mode, which blocks table drops entirely.
 
+## Known Limitations
+
+### Renames are not detected
+
+pgmold compares two snapshots — schema files vs. live database — so a rename of a column, table, index, or constraint looks identical to a drop + add. pgmold will emit the destructive form, which **destroys the column data and cascades to dependent objects**.
+
+```sql
+-- Schema file change: rename entity_id → supplier_id
+-- pgmold emits:
+ALTER TABLE orders ADD COLUMN supplier_id <type>;
+ALTER TABLE orders DROP COLUMN entity_id CASCADE;
+```
+
+Heuristic detection was rejected: a wrong guess silently destroys data.
+
+**Workaround**: apply the rename directly to the database first, then update the schema file:
+
+```sql
+ALTER TABLE orders RENAME COLUMN entity_id TO supplier_id;
+```
+
+`pgmold plan` will then show no changes. An explicit rename directive is under design — see [Known Limitations](https://pgmold.dev/docs/reference/limitations/) for details.
+
 ## Comparison with Other Tools
 
 ### vs Declarative Schema-as-Code Tools

--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ Set `PGMOLD_PROD=1` for production mode, which blocks table drops entirely.
 
 ### Renames are not detected
 
-pgmold compares two snapshots — schema files vs. live database — so a rename of a column, table, index, or constraint looks identical to a drop + add. pgmold will emit the destructive form, which **destroys the column data and cascades to dependent objects**.
+pgmold compares two snapshots (schema files vs. live database), so a rename of a column, table, index, or constraint looks identical to a drop + add. pgmold will emit the destructive form, which **destroys the column data and cascades to dependent objects**.
 
 ```sql
 -- Schema file change: rename entity_id → supplier_id
@@ -414,7 +414,7 @@ Heuristic detection was rejected: a wrong guess silently destroys data.
 ALTER TABLE orders RENAME COLUMN entity_id TO supplier_id;
 ```
 
-`pgmold plan` will then show no changes. An explicit rename directive is under design — see [Known Limitations](https://pgmold.dev/docs/reference/limitations/) for details.
+`pgmold plan` will then show no changes. An explicit rename directive is under design; full rationale and edge cases are in the [limitations reference](https://pgmold.dev/docs/reference/limitations/).
 
 ## Comparison with Other Tools
 

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -69,6 +69,7 @@ export default defineConfig({
 						{ label: 'Terraform Provider', slug: 'reference/terraform' },
 						{ label: 'GitHub Action', slug: 'reference/github-action' },
 						{ label: 'PostgreSQL Compatibility', slug: 'reference/compatibility' },
+						{ label: 'Known Limitations', slug: 'reference/limitations' },
 					],
 				},
 				{

--- a/site/src/content/docs/reference/limitations.md
+++ b/site/src/content/docs/reference/limitations.md
@@ -34,7 +34,7 @@ Then update the schema file to use the new name and run `pgmold plan`. The colum
 
 `ALTER TABLE ... RENAME COLUMN` is instant in PostgreSQL: a catalog-only operation with no data movement. The same approach works for `RENAME TABLE`, `RENAME INDEX`, and `RENAME CONSTRAINT`.
 
-If a view or function references the renamed column by name in its body, recreate or replace it after the rename. PostgreSQL resolves view column dependencies by OID, so most views stay valid, but pgmold's view introspection may still surface a diff until the schema file matches the regenerated definition text. Function bodies are stored as text and are not rewritten; they must be edited explicitly.
+If a view or function references the renamed column, it may need updating. PostgreSQL tracks view dependencies by OID so views stay valid after a column rename, but pgmold's view introspection may still surface a diff until the schema file matches the regenerated definition. Function bodies are stored as plain text and are not rewritten; they must be edited explicitly.
 
 ### Catching unintended renames in CI
 

--- a/site/src/content/docs/reference/limitations.md
+++ b/site/src/content/docs/reference/limitations.md
@@ -3,11 +3,11 @@ title: Known Limitations
 description: Architectural limitations of pgmold and recommended workarounds.
 ---
 
-pgmold compares two snapshots — your SQL schema files (desired state) against the live database (current state) — and emits the difference. This is simple, deterministic, and safe for most schema changes, but it cannot express certain transitions where the snapshot alone loses the relevant information.
+pgmold compares two snapshots (your SQL schema files as desired state, the live database as current state) and emits the difference. This is simple, deterministic, and safe for most schema changes, but it cannot express certain transitions where the snapshot alone loses the relevant information.
 
 ## Renames are not detected
 
-pgmold cannot detect renames of columns, tables, indexes, or constraints. After a rename, the schema file contains no evidence that one identifier used to be another — the old name is simply absent and the new name is simply present.
+pgmold cannot detect renames of columns, tables, indexes, or constraints. After a rename, the schema file contains no evidence that one identifier used to be another. The old name is simply absent and the new name is simply present.
 
 For a column rename like `entity_id → supplier_id`, pgmold emits:
 
@@ -18,11 +18,9 @@ ALTER TABLE orders DROP COLUMN entity_id CASCADE;
 
 **This destroys the column data and cascades to dependent indexes, constraints, and views.**
 
-The same applies to table renames, index renames, and constraint renames.
-
 ### Why pgmold doesn't guess
 
-Heuristic matching ("this dropped column looks like that added column") was considered and rejected. A wrong guess silently destroys data — strictly worse than failing loudly. Until pgmold has an explicit way for you to declare "this is a rename," the safe behavior is to emit drop + add and require `--allow-destructive`.
+Heuristic matching ("this dropped column looks like that added column") was considered and rejected. A wrong guess silently destroys data: strictly worse than failing loudly. Until pgmold has an explicit way for you to declare "this is a rename," the safe behavior is to emit drop + add and require `--allow-destructive`.
 
 ### Workaround
 
@@ -32,9 +30,11 @@ Apply the rename directly to the database before running pgmold:
 ALTER TABLE orders RENAME COLUMN entity_id TO supplier_id;
 ```
 
-Then update the schema file to use the new name and run `pgmold plan`. The diff will be empty.
+Then update the schema file to use the new name and run `pgmold plan`. The column diff will be empty.
 
-`ALTER TABLE ... RENAME COLUMN` is an instant, catalog-only operation in PostgreSQL with no data movement. The same pattern applies to `ALTER TABLE RENAME`, `ALTER INDEX RENAME`, and `ALTER ... RENAME CONSTRAINT`.
+`ALTER TABLE ... RENAME COLUMN` is instant in PostgreSQL: a catalog-only operation with no data movement. The same approach works for `RENAME TABLE`, `RENAME INDEX`, and `RENAME CONSTRAINT`.
+
+If a view or function references the renamed column by name in its body, recreate or replace it after the rename. PostgreSQL resolves view column dependencies by OID, so most views stay valid, but pgmold's view introspection may still surface a diff until the schema file matches the regenerated definition text. Function bodies are stored as text and are not rewritten; they must be edited explicitly.
 
 ### Catching unintended renames in CI
 
@@ -49,4 +49,4 @@ A reviewer who sees `DROP COLUMN entity_id` paired with `ADD COLUMN supplier_id`
 
 ### Future direction
 
-Support for an explicit rename directive (sidecar file or inline annotation) is under design. The mechanical implementation is small; the authoring surface — how you declare a rename without polluting the schema snapshot — is the open question.
+Support for an explicit rename directive (sidecar file or inline annotation) is under design. The mechanical implementation is small; the authoring surface (how you declare a rename without polluting the schema snapshot) is the open question.

--- a/site/src/content/docs/reference/limitations.md
+++ b/site/src/content/docs/reference/limitations.md
@@ -9,10 +9,10 @@ pgmold compares two snapshots (your SQL schema files as desired state, the live 
 
 pgmold cannot detect renames of columns, tables, indexes, or constraints. After a rename, the schema file contains no evidence that one identifier used to be another. The old name is simply absent and the new name is simply present.
 
-For a column rename like `entity_id → supplier_id`, pgmold emits:
+For a column rename from `entity_id` to `supplier_id`, pgmold emits:
 
 ```sql
-ALTER TABLE orders ADD COLUMN supplier_id <type>;
+ALTER TABLE orders ADD COLUMN supplier_id UUID;
 ALTER TABLE orders DROP COLUMN entity_id CASCADE;
 ```
 
@@ -24,17 +24,21 @@ Heuristic matching ("this dropped column looks like that added column") was cons
 
 ### Workaround
 
-Apply the rename directly to the database before running pgmold:
+1. Apply the rename directly to the database:
 
-```sql
-ALTER TABLE orders RENAME COLUMN entity_id TO supplier_id;
-```
+   ```sql
+   ALTER TABLE orders RENAME COLUMN entity_id TO supplier_id;
+   ```
 
-Then update the schema file to use the new name and run `pgmold plan`. The column diff will be empty.
+2. Update any function bodies that reference the old column name. Function source is stored as plain text in `pg_proc.prosrc` and is not rewritten by `RENAME COLUMN`. Functions referencing the old name will fail at next call or return wrong results.
+
+3. Update the schema file to use the new column name.
+
+4. Run `pgmold plan`. The column diff will be empty.
 
 `ALTER TABLE ... RENAME COLUMN` is instant in PostgreSQL: a catalog-only operation with no data movement. The same approach works for `RENAME TABLE`, `RENAME INDEX`, and `RENAME CONSTRAINT`.
 
-If a view or function references the renamed column, it may need updating. PostgreSQL tracks view dependencies by OID so views stay valid after a column rename, but pgmold's view introspection may still surface a diff until the schema file matches the regenerated definition. Function bodies are stored as plain text and are not rewritten; they must be edited explicitly.
+Views are usually safe to leave alone. PostgreSQL tracks view dependencies by OID, so a view that selected the old column keeps working after the rename. pgmold's view introspection may surface a transient diff in the view's definition text until you align the schema file with the regenerated form; that diff is cosmetic, not a correctness issue.
 
 ### Catching unintended renames in CI
 

--- a/site/src/content/docs/reference/limitations.md
+++ b/site/src/content/docs/reference/limitations.md
@@ -1,0 +1,52 @@
+---
+title: Known Limitations
+description: Architectural limitations of pgmold and recommended workarounds.
+---
+
+pgmold compares two snapshots — your SQL schema files (desired state) against the live database (current state) — and emits the difference. This is simple, deterministic, and safe for most schema changes, but it cannot express certain transitions where the snapshot alone loses the relevant information.
+
+## Renames are not detected
+
+pgmold cannot detect renames of columns, tables, indexes, or constraints. After a rename, the schema file contains no evidence that one identifier used to be another — the old name is simply absent and the new name is simply present.
+
+For a column rename like `entity_id → supplier_id`, pgmold emits:
+
+```sql
+ALTER TABLE orders ADD COLUMN supplier_id <type>;
+ALTER TABLE orders DROP COLUMN entity_id CASCADE;
+```
+
+**This destroys the column data and cascades to dependent indexes, constraints, and views.**
+
+The same applies to table renames, index renames, and constraint renames.
+
+### Why pgmold doesn't guess
+
+Heuristic matching ("this dropped column looks like that added column") was considered and rejected. A wrong guess silently destroys data — strictly worse than failing loudly. Until pgmold has an explicit way for you to declare "this is a rename," the safe behavior is to emit drop + add and require `--allow-destructive`.
+
+### Workaround
+
+Apply the rename directly to the database before running pgmold:
+
+```sql
+ALTER TABLE orders RENAME COLUMN entity_id TO supplier_id;
+```
+
+Then update the schema file to use the new name and run `pgmold plan`. The diff will be empty.
+
+`ALTER TABLE ... RENAME COLUMN` is an instant, catalog-only operation in PostgreSQL with no data movement. The same pattern applies to `ALTER TABLE RENAME`, `ALTER INDEX RENAME`, and `ALTER ... RENAME CONSTRAINT`.
+
+### Catching unintended renames in CI
+
+To prevent an accidental rename from sneaking through, run CI without `--allow-destructive`. pgmold will refuse the plan, surfacing the drop + add for review:
+
+```bash
+pgmold plan -s sql:schema/ -d $DATABASE_URL
+# Error: destructive operations present (use --allow-destructive)
+```
+
+A reviewer who sees `DROP COLUMN entity_id` paired with `ADD COLUMN supplier_id` of the same type in the same diff can recognize the intent and apply the rename manually before merging.
+
+### Future direction
+
+Support for an explicit rename directive (sidecar file or inline annotation) is under design. The mechanical implementation is small; the authoring surface — how you declare a rename without polluting the schema snapshot — is the open question.


### PR DESCRIPTION
## Summary

Document the column-rename limitation in the README and a new site reference page.

pgmold compares two snapshots (SQL files vs live DB), so a column/table/index/constraint rename looks identical to a drop + add. The destructive form gets emitted, which loses data. Heuristic detection was rejected in pgmold-3po5 because a wrong guess silently destroys data.

This PR does not fix the limitation; it just documents it so users discover the failure mode and the safe workaround before they trip on it.

## Changes

- `README.md`: new Known Limitations section between Safety Rules and Comparison
- `site/src/content/docs/reference/limitations.md`: new Starlight page covering failure mode, why pgmold does not guess, ALTER ... RENAME workaround, the views/functions caveat, and a CI hint
- `site/astro.config.mjs`: sidebar entry under Reference

## Test plan

- [x] `npx astro build` clean in the worktree, new page in sitemap (`/docs/reference/limitations/`)
- [x] No em-dashes in new content (project style)
- [x] README link target matches the generated slug
- [x] code-reviewer pass: factual claims about PG view OID resolution and function-body text storage verified accurate
- [ ] Read the rendered page on pgmold.dev after merge to confirm sidebar order

## Related

- Beads: pgmold-3po5 (fix itself, separate work)
- Beads: pgmold-mnfs (this doc task)