### PR TITLE
docs: add industry context to rename-limitation page

### DIFF
--- a/site/src/content/docs/reference/limitations.md
+++ b/site/src/content/docs/reference/limitations.md
@@ -24,11 +24,11 @@ Heuristic matching ("this dropped column looks like that added column") was cons
 
 ### How other tools handle this
 
-pgmold's behavior is the dominant pattern in declarative schema-diff tools. Stripe's [pg-schema-diff](https://github.com/stripe/pg-schema-diff) documents it directly: "If you rename an object, it will be treated as a drop and an add." Supabase's [declarative-schemas guide](https://supabase.com/docs/guides/local-development/declarative-database-schemas) frames the constraint identically: "you can't differentiate between renaming a column and dropping + creating a column with a different name." [migra](https://github.com/djrobstep/migra) and [pgschema](https://www.pgschema.com/) behave the same.
+pgmold's behavior is the dominant pattern in declarative schema-diff tools. Stripe's [pg-schema-diff](https://github.com/stripe/pg-schema-diff) documents it directly: "If you rename an object, it will be treated as a drop and an add". Supabase's declarative schemas inherit the same limitation through their use of [migra](https://github.com/djrobstep/migra) under the hood; the [Supabase docs](https://supabase.com/docs/guides/local-development/declarative-database-schemas) list rename-relevant gaps in a "Known caveats" section, and an open CLI bug ([supabase/cli#1721](https://github.com/supabase/cli/issues/1721), "On table rename `supabase db pull` creates migration to DROP table, not RENAME") tracks the same drop-instead-of-rename behavior at the dump layer. [pgschema](https://www.pgschema.com/) behaves the same.
 
 Two alternatives exist in shipping tools:
 
-- **Interactive detection** ([Atlas](https://atlasgo.io)): the tool prompts at diff time, "did you rename column X to Y?". Works for local dev, less useful for CI and automated workflows.
+- **Interactive detection** ([Atlas](https://atlasgo.io)): in the versioned migration workflow, `atlas migrate diff` prompts at diff time ("Did you rename column X to Y?"). Works for local dev, less useful for CI and automated workflows.
 - **Explicit annotation** ([sqldef](https://github.com/sqldef/sqldef)): the author writes `-- @renamed from=old_name` inline in the SQL. The author carries the intent; the tool emits a safe `RENAME`.
 
 pgmold has not picked one. See [Future direction](#future-direction).

--- a/site/src/content/docs/reference/limitations.md
+++ b/site/src/content/docs/reference/limitations.md
@@ -22,6 +22,17 @@ ALTER TABLE orders DROP COLUMN entity_id CASCADE;
 
 Heuristic matching ("this dropped column looks like that added column") was considered and rejected. A wrong guess silently destroys data: strictly worse than failing loudly. Until pgmold has an explicit way for you to declare "this is a rename," the safe behavior is to emit drop + add and require `--allow-destructive`.
 
+### How other tools handle this
+
+pgmold's behavior is the dominant pattern in declarative schema-diff tools. Stripe's [pg-schema-diff](https://github.com/stripe/pg-schema-diff) documents it directly: "If you rename an object, it will be treated as a drop and an add." Supabase's [declarative-schemas guide](https://supabase.com/docs/guides/local-development/declarative-database-schemas) frames the constraint identically: "you can't differentiate between renaming a column and dropping + creating a column with a different name." [migra](https://github.com/djrobstep/migra) and [pgschema](https://www.pgschema.com/) behave the same.
+
+Two alternatives exist in shipping tools:
+
+- **Interactive detection** ([Atlas](https://atlasgo.io)): the tool prompts at diff time, "did you rename column X to Y?". Works for local dev, less useful for CI and automated workflows.
+- **Explicit annotation** ([sqldef](https://github.com/sqldef/sqldef)): the author writes `-- @renamed from=old_name` inline in the SQL. The author carries the intent; the tool emits a safe `RENAME`.
+
+pgmold has not picked one. See [Future direction](#future-direction).
+
 ### Workaround
 
 1. Apply the rename directly to the database:

--- a/site/src/content/docs/reference/limitations.md
+++ b/site/src/content/docs/reference/limitations.md
@@ -24,7 +24,7 @@ Heuristic matching ("this dropped column looks like that added column") was cons
 
 ### How other tools handle this
 
-pgmold's behavior is the dominant pattern in declarative schema-diff tools. Stripe's [pg-schema-diff](https://github.com/stripe/pg-schema-diff) documents it directly: "If you rename an object, it will be treated as a drop and an add". Supabase's declarative schemas inherit the same limitation through their use of [migra](https://github.com/djrobstep/migra) under the hood; the [Supabase docs](https://supabase.com/docs/guides/local-development/declarative-database-schemas) list rename-relevant gaps in a "Known caveats" section, and an open CLI bug ([supabase/cli#1721](https://github.com/supabase/cli/issues/1721), "On table rename `supabase db pull` creates migration to DROP table, not RENAME") tracks the same drop-instead-of-rename behavior at the dump layer. [pgschema](https://www.pgschema.com/) behaves the same.
+pgmold's behavior is the dominant pattern in declarative schema-diff tools. Stripe's [pg-schema-diff](https://github.com/stripe/pg-schema-diff) documents it directly: "If you rename an object, it will be treated as a drop and an add". Supabase's declarative schemas inherit the same limitation through their use of [migra](https://github.com/djrobstep/migra) under the hood; the [Supabase docs](https://supabase.com/docs/guides/local-development/declarative-database-schemas) list rename-relevant gaps in a "Known caveats" section, and an open CLI bug ([supabase/cli#1721](https://github.com/supabase/cli/issues/1721)) is tracked as "On table rename `supabase db pull` creates migration to DROP table, not RENAME". [pgschema](https://www.pgschema.com/) behaves the same.
 
 Two alternatives exist in shipping tools:
 


### PR DESCRIPTION
## Summary

Fold the oracle research findings into the rename-limitation page. Frame pgmold's silent drop+add as the dominant pattern in declarative schema-diff tools and name the two shipping alternatives (Atlas interactive prompt, sqldef inline annotation).

## Changes

- `site/src/content/docs/reference/limitations.md`: new "How other tools handle this" subsection between "Why pgmold doesn't guess" and "Workaround"

## Citations (all verified against primary sources before merge)

- Stripe pg-schema-diff README: "If you rename an object, it will be treated as a drop and an add" (verbatim, no terminal period in source)
- Supabase declarative-schemas docs: "Known caveats" section names `migra` as the underlying diff engine
- supabase/cli#1721 title (verbatim): "On table rename `supabase db pull` creates migration to DROP table, not RENAME"
- sqldef README: `-- @renamed from=old_name` annotation syntax (verbatim)
- Atlas v0.22 blog: interactive rename prompt in `atlas migrate diff`

## Review history

3 commits on the branch:
- Initial section
- Quote-integrity fix: Stripe punctuation, replaced unverifiable Supabase quote with verifiable cite, narrowed Atlas claim to versioned workflow
- Trim trailing clause that restated the Supabase issue title

Reviewed by code-reviewer + code-simplifier per commit.

## Test plan

- [x] `npx astro build` clean, page rendered at `/docs/reference/limitations/`
- [x] No em-dashes or arrows in new content
- [x] All upstream quotes confirmed verbatim against source

## Related

- Beads: pgmold-6i64 (this doc task)
- Beads: pgmold-3po5 (the fix itself, separate work)
- Parent PR: #334 (initial limitations page)