### PR TITLE
fix(diff): rebuild cross-table policies referencing a dropped column (#332)

### DIFF
--- a/src/diff/dependencies.rs
+++ b/src/diff/dependencies.rs
@@ -104,7 +104,6 @@ pub(super) fn tables_with_dropped_columns(ops: &[MigrationOp]) -> HashSet<String
         .collect()
 }
 
-/// Extract (table_qualified_name, column) pairs for columns being dropped.
 pub(super) fn dropped_columns(ops: &[MigrationOp]) -> HashSet<(String, String)> {
     ops.iter()
         .filter_map(|op| {

--- a/src/diff/dependencies.rs
+++ b/src/diff/dependencies.rs
@@ -164,15 +164,15 @@ pub(super) fn generate_policy_ops_for_cross_table_column_drops(
                 .get(table_name)
                 .and_then(|t| t.policies.iter().find(|p| p.name == policy.name));
 
-            policies_to_filter.insert((qualified_table_str.clone(), policy.name.clone()));
-
-            additional_ops.push(MigrationOp::DropPolicy {
-                table: QualifiedName::new(&table.schema, &table.name),
-                name: policy.name.clone(),
-            });
-            let effective_policy = target_policy.unwrap_or(policy).clone();
-            additional_ops.push(MigrationOp::CreatePolicy(effective_policy.clone()));
-            push_policy_recreate_comment(&mut additional_ops, &effective_policy);
+            emit_policy_rebuild(
+                &mut additional_ops,
+                &mut policies_to_filter,
+                &table.schema,
+                &table.name,
+                &qualified_table_str,
+                policy,
+                target_policy,
+            );
         }
     }
 
@@ -252,20 +252,50 @@ pub(super) fn generate_policy_ops_for_affected_tables(
                     .get(table_name)
                     .and_then(|t| t.policies.iter().find(|p| p.name == policy.name));
 
-                policies_to_filter.insert((qualified_table_str.clone(), policy.name.clone()));
-
-                additional_ops.push(MigrationOp::DropPolicy {
-                    table: QualifiedName::new(&from_table.schema, &from_table.name),
-                    name: policy.name.clone(),
-                });
-                let effective_policy = target_policy.unwrap_or(policy).clone();
-                additional_ops.push(MigrationOp::CreatePolicy(effective_policy.clone()));
-                push_policy_recreate_comment(&mut additional_ops, &effective_policy);
+                emit_policy_rebuild(
+                    &mut additional_ops,
+                    &mut policies_to_filter,
+                    &from_table.schema,
+                    &from_table.name,
+                    &qualified_table_str,
+                    policy,
+                    target_policy,
+                );
             }
         }
     }
 
     (additional_ops, policies_to_filter)
+}
+
+/// Emit the DropPolicy + CreatePolicy (+ comment) sequence shared by every
+/// policy-rebuild path (cross-table column drops, same-table affected columns,
+/// function changes) and record the policy in `policies_to_filter` so the
+/// caller can strip any duplicate AlterPolicy.
+///
+/// The caller performs its own `to`-side lookup and passes the result as
+/// `target_policy`; the three callers key that lookup differently (two by the
+/// map key, one by the qualified-name string), so the key choice stays with
+/// the caller and this helper stays behaviour-preserving for all of them.
+/// When `target_policy` is `None` the `from`-side `policy` is rebuilt as-is.
+fn emit_policy_rebuild(
+    additional_ops: &mut Vec<MigrationOp>,
+    policies_to_filter: &mut HashSet<(String, String)>,
+    table_schema: &str,
+    table_name: &str,
+    qualified_table_str: &str,
+    policy: &Policy,
+    target_policy: Option<&Policy>,
+) {
+    policies_to_filter.insert((qualified_table_str.to_string(), policy.name.clone()));
+
+    additional_ops.push(MigrationOp::DropPolicy {
+        table: QualifiedName::new(table_schema, table_name),
+        name: policy.name.clone(),
+    });
+    let effective_policy = target_policy.unwrap_or(policy).clone();
+    additional_ops.push(MigrationOp::CreatePolicy(effective_policy.clone()));
+    push_policy_recreate_comment(additional_ops, &effective_policy);
 }
 
 /// When a policy is dropped+recreated due to a column or function dependency,
@@ -466,20 +496,20 @@ pub(super) fn generate_policy_ops_for_function_changes(
                 && !existing_policy_drops
                     .contains(&(qualified_table_str.clone(), policy.name.clone()))
             {
-                policies_to_filter.insert((qualified_table_str.clone(), policy.name.clone()));
-
                 let target_policy = to
                     .tables
                     .get(&qualified_table_str)
                     .and_then(|t| t.policies.iter().find(|p| p.name == policy.name));
 
-                additional_ops.push(MigrationOp::DropPolicy {
-                    table: QualifiedName::new(&table.schema, &table.name),
-                    name: policy.name.clone(),
-                });
-                let effective_policy = target_policy.unwrap_or(policy).clone();
-                additional_ops.push(MigrationOp::CreatePolicy(effective_policy.clone()));
-                push_policy_recreate_comment(&mut additional_ops, &effective_policy);
+                emit_policy_rebuild(
+                    &mut additional_ops,
+                    &mut policies_to_filter,
+                    &table.schema,
+                    &table.name,
+                    &qualified_table_str,
+                    policy,
+                    target_policy,
+                );
             }
         }
     }

--- a/src/diff/dependencies.rs
+++ b/src/diff/dependencies.rs
@@ -560,8 +560,8 @@ mod tests {
     use crate::diff::{compute_diff, MigrationOp};
     use crate::model::{
         qualified_name, ArgMode, Column, ForeignKey, Function, FunctionArg, PgType, Policy,
-        PolicyCommand, ReferentialAction, SecurityType, Trigger, TriggerEnabled, TriggerEvent,
-        TriggerTiming, View, Volatility,
+        PolicyCommand, ReferentialAction, Schema, SecurityType, Trigger, TriggerEnabled,
+        TriggerEvent, TriggerTiming, View, Volatility,
     };
 
     #[test]
@@ -1296,6 +1296,276 @@ mod tests {
             create_policy_ops.len(),
             1,
             "Should have exactly 1 CreatePolicy op"
+        );
+    }
+
+    #[test]
+    fn cross_table_and_same_table_paths_do_not_duplicate_policy_rebuild() {
+        // gh#332 over-rebuild collision: a policy on `mrv.sample` references
+        // `mrv.sampling_project.entity_id` (dropped) through a subquery, AND
+        // `mrv.sample` carries its own local column named `entity_id` plus an
+        // unrelated dropped column (`legacy`). The local drop puts `mrv.sample`
+        // in the same-table rebuild set, while the cross-table reference to the
+        // dropped `entity_id` matches the cross-table path on bare column name.
+        // Both paths could fire on the same policy; the `existing_policy_drops`
+        // guard must keep it to exactly one DropPolicy + one CreatePolicy with
+        // no surviving AlterPolicy and no duplicate OpKey.
+        let cross_table_using = "EXISTS (SELECT 1 FROM mrv.sampling_project sp \
+            WHERE sp.id = sampling_project_id AND sp.entity_id IS NOT NULL)";
+
+        let mut from = empty_schema();
+
+        let mut sampling_project = simple_table_with_schema("sampling_project", "mrv");
+        sampling_project
+            .columns
+            .insert("id".to_string(), simple_column("id", PgType::Integer));
+        sampling_project.columns.insert(
+            "entity_id".to_string(),
+            simple_column("entity_id", PgType::Integer),
+        );
+        from.tables
+            .insert("mrv.sampling_project".to_string(), sampling_project);
+
+        let mut sample = simple_table_with_schema("sample", "mrv");
+        sample
+            .columns
+            .insert("id".to_string(), simple_column("id", PgType::Integer));
+        sample.columns.insert(
+            "sampling_project_id".to_string(),
+            simple_column("sampling_project_id", PgType::Integer),
+        );
+        sample.columns.insert(
+            "entity_id".to_string(),
+            simple_column("entity_id", PgType::Integer),
+        );
+        sample
+            .columns
+            .insert("legacy".to_string(), simple_column("legacy", PgType::Text));
+        sample.policies.push(Policy {
+            name: "sample_access".to_string(),
+            table_schema: "mrv".to_string(),
+            table: "sample".to_string(),
+            command: PolicyCommand::Select,
+            roles: vec!["authenticated".to_string()],
+            using_expr: Some(cross_table_using.to_string()),
+            check_expr: None,
+            comment: None,
+        });
+        from.tables.insert("mrv.sample".to_string(), sample);
+
+        let mut to = empty_schema();
+
+        let mut sampling_project_to = simple_table_with_schema("sampling_project", "mrv");
+        sampling_project_to
+            .columns
+            .insert("id".to_string(), simple_column("id", PgType::Integer));
+        to.tables
+            .insert("mrv.sampling_project".to_string(), sampling_project_to);
+
+        let mut sample_to = simple_table_with_schema("sample", "mrv");
+        sample_to
+            .columns
+            .insert("id".to_string(), simple_column("id", PgType::Integer));
+        sample_to.columns.insert(
+            "sampling_project_id".to_string(),
+            simple_column("sampling_project_id", PgType::Integer),
+        );
+        sample_to.columns.insert(
+            "entity_id".to_string(),
+            simple_column("entity_id", PgType::Integer),
+        );
+        sample_to.policies.push(Policy {
+            name: "sample_access".to_string(),
+            table_schema: "mrv".to_string(),
+            table: "sample".to_string(),
+            command: PolicyCommand::Select,
+            roles: vec!["authenticated".to_string()],
+            using_expr: Some(cross_table_using.to_string()),
+            check_expr: None,
+            comment: None,
+        });
+        to.tables.insert("mrv.sample".to_string(), sample_to);
+
+        let ops = compute_diff(&from, &to);
+
+        let keys: Vec<_> = ops
+            .iter()
+            .map(crate::diff::op_key::OpKey::from_op)
+            .collect();
+        let unique: std::collections::HashSet<_> = keys.iter().cloned().collect();
+        assert_eq!(
+            keys.len(),
+            unique.len(),
+            "no duplicate OpKey in the plan: {keys:?}"
+        );
+
+        let drop_policy_ops: Vec<_> = ops
+            .iter()
+            .filter_map(|op| match op {
+                MigrationOp::DropPolicy { table, name } if name == "sample_access" => {
+                    Some(table.to_string())
+                }
+                _ => None,
+            })
+            .collect();
+        let create_policy_ops: Vec<_> = ops
+            .iter()
+            .filter(|op| matches!(op, MigrationOp::CreatePolicy(p) if p.name == "sample_access"))
+            .collect();
+        let alter_policy_ops: Vec<_> = ops
+            .iter()
+            .filter(
+                |op| matches!(op, MigrationOp::AlterPolicy { name, .. } if name == "sample_access"),
+            )
+            .collect();
+
+        assert_eq!(
+            drop_policy_ops,
+            vec!["mrv.sample".to_string()],
+            "exactly one DropPolicy for the colliding policy"
+        );
+        assert_eq!(
+            create_policy_ops.len(),
+            1,
+            "exactly one CreatePolicy for the colliding policy"
+        );
+        assert_eq!(
+            alter_policy_ops.len(),
+            0,
+            "no surviving AlterPolicy for the colliding policy"
+        );
+    }
+
+    fn cross_table_policy_fixture() -> (Schema, Schema) {
+        let cross_table_using = "EXISTS (SELECT 1 FROM mrv.sampling_project sp \
+            WHERE sp.id = sampling_project_id AND sp.entity_id IS NOT NULL)";
+
+        let mut from = empty_schema();
+        let mut sampling_project = simple_table_with_schema("sampling_project", "mrv");
+        sampling_project
+            .columns
+            .insert("id".to_string(), simple_column("id", PgType::Integer));
+        sampling_project.columns.insert(
+            "entity_id".to_string(),
+            simple_column("entity_id", PgType::Integer),
+        );
+        from.tables
+            .insert("mrv.sampling_project".to_string(), sampling_project);
+
+        let mut sample = simple_table_with_schema("sample", "mrv");
+        sample
+            .columns
+            .insert("id".to_string(), simple_column("id", PgType::Integer));
+        sample.columns.insert(
+            "sampling_project_id".to_string(),
+            simple_column("sampling_project_id", PgType::Integer),
+        );
+        sample.policies.push(Policy {
+            name: "sample_access".to_string(),
+            table_schema: "mrv".to_string(),
+            table: "sample".to_string(),
+            command: PolicyCommand::Select,
+            roles: vec!["authenticated".to_string()],
+            using_expr: Some(cross_table_using.to_string()),
+            check_expr: None,
+            comment: None,
+        });
+        from.tables.insert("mrv.sample".to_string(), sample);
+
+        let to = from.clone();
+        (from, to)
+    }
+
+    #[test]
+    fn cross_table_column_drops_fast_path_when_nothing_dropped() {
+        let (from, to) = cross_table_policy_fixture();
+        let dropped = std::collections::HashSet::new();
+
+        let (ops, filter) =
+            super::generate_policy_ops_for_cross_table_column_drops(&[], &from, &to, &dropped);
+
+        assert!(ops.is_empty(), "no ops when no column is dropped");
+        assert!(
+            filter.is_empty(),
+            "no policies to filter when no column is dropped"
+        );
+    }
+
+    #[test]
+    fn cross_table_column_drops_rebuilds_referencing_policy() {
+        let (from, to) = cross_table_policy_fixture();
+        let dropped = std::collections::HashSet::from([(
+            "mrv.sampling_project".to_string(),
+            "entity_id".to_string(),
+        )]);
+
+        let (ops, filter) =
+            super::generate_policy_ops_for_cross_table_column_drops(&[], &from, &to, &dropped);
+
+        assert_eq!(
+            filter,
+            std::collections::HashSet::from([(
+                "mrv.sample".to_string(),
+                "sample_access".to_string()
+            )]),
+            "the referencing policy is marked for AlterPolicy removal"
+        );
+
+        let drop_policy_ops: Vec<_> = ops
+            .iter()
+            .filter_map(|op| match op {
+                MigrationOp::DropPolicy { table, name } => Some((table.to_string(), name.clone())),
+                _ => None,
+            })
+            .collect();
+        let create_policy_ops: Vec<_> = ops
+            .iter()
+            .filter(|op| matches!(op, MigrationOp::CreatePolicy(p) if p.name == "sample_access"))
+            .collect();
+
+        assert_eq!(
+            drop_policy_ops,
+            vec![("mrv.sample".to_string(), "sample_access".to_string())],
+            "exactly one DropPolicy for the cross-table referencing policy"
+        );
+        assert_eq!(
+            create_policy_ops.len(),
+            1,
+            "exactly one CreatePolicy to rebuild the policy"
+        );
+    }
+
+    #[test]
+    fn cross_table_column_drops_falls_back_to_from_policy_when_absent_in_to() {
+        // The `to` schema has no matching policy (renamed/removed from the
+        // model), so the unwrap_or(policy) fallback must rebuild from the
+        // `from`-side policy definition rather than panicking.
+        let (from, mut to) = cross_table_policy_fixture();
+        to.tables.get_mut("mrv.sample").unwrap().policies.clear();
+
+        let dropped = std::collections::HashSet::from([(
+            "mrv.sampling_project".to_string(),
+            "entity_id".to_string(),
+        )]);
+
+        let (ops, _filter) =
+            super::generate_policy_ops_for_cross_table_column_drops(&[], &from, &to, &dropped);
+
+        let created: Vec<_> = ops
+            .iter()
+            .filter_map(|op| match op {
+                MigrationOp::CreatePolicy(p) => Some(p),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(created.len(), 1, "one CreatePolicy from the fallback path");
+        assert_eq!(
+            created[0].using_expr.as_deref(),
+            Some(
+                "EXISTS (SELECT 1 FROM mrv.sampling_project sp \
+                WHERE sp.id = sampling_project_id AND sp.entity_id IS NOT NULL)"
+            ),
+            "rebuilt from the from-side policy definition"
         );
     }
 

--- a/src/diff/dependencies.rs
+++ b/src/diff/dependencies.rs
@@ -1,7 +1,9 @@
 use std::collections::HashSet;
 
 use crate::model::{parse_qualified_name, qualified_name, Policy, QualifiedName, Schema};
-use crate::parser::{extract_function_references, extract_table_references};
+use crate::parser::{
+    extract_column_references, extract_function_references, extract_table_references,
+};
 
 use super::MigrationOp;
 
@@ -100,6 +102,116 @@ pub(super) fn tables_with_dropped_columns(ops: &[MigrationOp]) -> HashSet<String
             }
         })
         .collect()
+}
+
+/// Extract (table_qualified_name, column) pairs for columns being dropped.
+pub(super) fn dropped_columns(ops: &[MigrationOp]) -> HashSet<(String, String)> {
+    ops.iter()
+        .filter_map(|op| {
+            if let MigrationOp::DropColumn { table, column } = op {
+                Some((table.to_string(), column.clone()))
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+/// Generate policy drop/create ops for policies on OTHER tables whose USING /
+/// WITH CHECK expressions reference a column being dropped (gh#332).
+///
+/// `generate_policy_ops_for_affected_tables` only rebuilds policies on the same
+/// table as the dropped column. A policy on a different table can reference the
+/// dropped column through a subquery join; PostgreSQL cascade-drops it when the
+/// column is dropped, so an `AlterPolicy` against it fails. Rebuilding it
+/// (DropPolicy + CreatePolicy) is cascade-safe and keeps it ordered before the
+/// DropColumn via the existing planner edges.
+///
+/// Returns the generated ops and the set of (table_qualified_name, policy_name)
+/// pairs that had a DropPolicy emitted, so callers can drop any duplicate
+/// AlterPolicy ops.
+pub(super) fn generate_policy_ops_for_cross_table_column_drops(
+    ops: &[MigrationOp],
+    from: &Schema,
+    to: &Schema,
+    dropped: &HashSet<(String, String)>,
+) -> (Vec<MigrationOp>, HashSet<(String, String)>) {
+    let mut additional_ops = Vec::new();
+    let mut policies_to_filter = HashSet::new();
+
+    if dropped.is_empty() {
+        return (additional_ops, policies_to_filter);
+    }
+
+    let existing_policy_drops: HashSet<(String, String)> =
+        collect_existing_drops(ops, |op| match op {
+            MigrationOp::DropPolicy { table, name } => Some((table.to_string(), name.clone())),
+            _ => None,
+        });
+
+    for (table_name, table) in &from.tables {
+        let qualified_table_str = qualified_name(&table.schema, &table.name);
+        for policy in &table.policies {
+            if !policy_references_dropped_cross_table_column(policy, &qualified_table_str, dropped)
+            {
+                continue;
+            }
+            if existing_policy_drops.contains(&(qualified_table_str.clone(), policy.name.clone())) {
+                continue;
+            }
+
+            let target_policy = to
+                .tables
+                .get(table_name)
+                .and_then(|t| t.policies.iter().find(|p| p.name == policy.name));
+
+            policies_to_filter.insert((qualified_table_str.clone(), policy.name.clone()));
+
+            additional_ops.push(MigrationOp::DropPolicy {
+                table: QualifiedName::new(&table.schema, &table.name),
+                name: policy.name.clone(),
+            });
+            let effective_policy = target_policy.unwrap_or(policy).clone();
+            additional_ops.push(MigrationOp::CreatePolicy(effective_policy.clone()));
+            push_policy_recreate_comment(&mut additional_ops, &effective_policy);
+        }
+    }
+
+    (additional_ops, policies_to_filter)
+}
+
+/// Check whether a policy's USING/CHECK expressions reference a dropped column
+/// that lives on a DIFFERENT table than the policy itself. The policy must both
+/// reference the affected table (via a subquery/join) and mention the dropped
+/// column name.
+fn policy_references_dropped_cross_table_column(
+    policy: &Policy,
+    policy_table: &str,
+    dropped: &HashSet<(String, String)>,
+) -> bool {
+    let exprs: Vec<&String> = [&policy.using_expr, &policy.check_expr]
+        .into_iter()
+        .flatten()
+        .collect();
+    if exprs.is_empty() {
+        return false;
+    }
+
+    let referenced_tables: HashSet<String> = exprs
+        .iter()
+        .flat_map(|expr| extract_table_references(expr, &policy.table_schema))
+        .map(|reference| reference.qualified_name())
+        .collect();
+    let referenced_columns: HashSet<String> = exprs
+        .iter()
+        .flat_map(|expr| extract_column_references(expr, &policy.table_schema))
+        .collect();
+
+    dropped.iter().any(|(table, column)| {
+        table != policy_table
+            && referenced_tables.contains(table)
+            && referenced_columns.contains(column)
+    })
 }
 
 /// Generate policy drop/create ops for tables with affected columns (type changes or drops).

--- a/src/diff/mod.rs
+++ b/src/diff/mod.rs
@@ -16,9 +16,10 @@ pub use types::{
 };
 
 use dependencies::{
-    generate_fk_ops_for_type_changes, generate_policy_ops_for_affected_tables,
-    generate_policy_ops_for_function_changes, generate_trigger_ops_for_affected_tables,
-    generate_view_ops_for_affected_tables, tables_with_dropped_columns, type_changed_columns,
+    dropped_columns, generate_fk_ops_for_type_changes, generate_policy_ops_for_affected_tables,
+    generate_policy_ops_for_cross_table_column_drops, generate_policy_ops_for_function_changes,
+    generate_trigger_ops_for_affected_tables, generate_view_ops_for_affected_tables,
+    tables_with_dropped_columns, type_changed_columns,
 };
 use grants::diff_default_privileges;
 use objects::{
@@ -162,6 +163,23 @@ pub fn compute_diff_with_flags(
         });
     }
     ops.extend(column_drop_view_ops);
+
+    // Drop/recreate policies on OTHER tables that reference a dropped column
+    // through a subquery join (gh#332). A DropColumn ... CASCADE destroys these
+    // policies, so an AlterPolicy against them fails; rebuild them instead.
+    let dropped_column_pairs = dropped_columns(&ops);
+    let (cross_table_policy_ops, cross_table_policies_to_filter) =
+        generate_policy_ops_for_cross_table_column_drops(&ops, from, to, &dropped_column_pairs);
+    if !cross_table_policies_to_filter.is_empty() {
+        ops.retain(|op| {
+            if let MigrationOp::AlterPolicy { table, name, .. } = op {
+                !cross_table_policies_to_filter.contains(&(table.to_string(), name.clone()))
+            } else {
+                true
+            }
+        });
+    }
+    ops.extend(cross_table_policy_ops);
 
     // Drop/recreate policies that reference functions being dropped
     let (policy_ops, policies_to_filter) = generate_policy_ops_for_function_changes(&ops, from, to);
@@ -4514,6 +4532,121 @@ CREATE TRIGGER "on_user_role_change" AFTER INSERT OR UPDATE OR DELETE ON "public
         assert_eq!(drop_col_count, 1, "should have exactly 1 DropColumn");
         assert_eq!(alter_policy_count, 0, "AlterPolicy should be filtered out");
         assert_eq!(alter_view_count, 0, "AlterView should be filtered out");
+    }
+
+    #[test]
+    fn drop_column_rebuilds_cross_table_policy_referencing_dropped_column() {
+        // gh#332: a policy on `sampling_upload` references
+        // `sampling_project.entity_id` via a subquery join. Dropping
+        // `entity_id` from `sampling_project` cascade-drops that policy.
+        // The planner must rebuild the cross-table policy (DropPolicy +
+        // CreatePolicy) rather than emit an AlterPolicy that lands after the
+        // cascading DropColumn.
+        use crate::diff::planner::plan_migration;
+        use crate::model::{Policy, PolicyCommand};
+
+        let using_old = "EXISTS (SELECT 1 FROM mrv.sampling_project sp \
+            WHERE sp.id = sampling_project_id AND sp.entity_id IS NOT NULL)";
+        let using_new = "EXISTS (SELECT 1 FROM mrv.sampling_project sp \
+            WHERE sp.id = sampling_project_id AND sp.supplier_id IS NOT NULL)";
+
+        let build_schema = |project_col: &str, upload_using: &str| {
+            let mut schema = empty_schema();
+
+            let mut project = simple_table_with_schema("sampling_project", "mrv");
+            project
+                .columns
+                .insert("id".to_string(), simple_column("id", PgType::Uuid));
+            project.columns.insert(
+                project_col.to_string(),
+                simple_column(project_col, PgType::Uuid),
+            );
+            schema
+                .tables
+                .insert("mrv.sampling_project".to_string(), project);
+
+            let mut upload = simple_table_with_schema("sampling_upload", "mrv");
+            upload
+                .columns
+                .insert("id".to_string(), simple_column("id", PgType::Uuid));
+            upload.columns.insert(
+                "sampling_project_id".to_string(),
+                simple_column("sampling_project_id", PgType::Uuid),
+            );
+            upload.row_level_security = true;
+            upload.policies.push(Policy {
+                name: "sampling_upload_owner_select".to_string(),
+                table_schema: "mrv".to_string(),
+                table: "sampling_upload".to_string(),
+                command: PolicyCommand::Select,
+                roles: vec!["public".to_string()],
+                using_expr: Some(upload_using.to_string()),
+                check_expr: None,
+                comment: None,
+            });
+            schema
+                .tables
+                .insert("mrv.sampling_upload".to_string(), upload);
+
+            schema
+        };
+
+        let from = build_schema("entity_id", using_old);
+        let to = build_schema("supplier_id", using_new);
+
+        let ops = compute_diff(&from, &to);
+        let planned = plan_migration(ops);
+
+        let drop_col_pos = planned
+            .iter()
+            .position(
+                |op| matches!(op, MigrationOp::DropColumn { column, .. } if column == "entity_id"),
+            )
+            .expect("should have DropColumn for entity_id");
+
+        let cross_table_alter_after_drop = planned.iter().enumerate().any(|(index, op)| {
+            index > drop_col_pos
+                && matches!(
+                    op,
+                    MigrationOp::AlterPolicy { name, .. }
+                        if name == "sampling_upload_owner_select"
+                )
+        });
+        assert!(
+            !cross_table_alter_after_drop,
+            "cross-table AlterPolicy must not be placed after the cascading DropColumn"
+        );
+
+        let drop_policy_pos = planned
+            .iter()
+            .position(|op| {
+                matches!(op, MigrationOp::DropPolicy { name, .. } if name == "sampling_upload_owner_select")
+            })
+            .expect("cross-table policy must be rebuilt via DropPolicy");
+        let create_policy_pos = planned
+            .iter()
+            .position(|op| {
+                matches!(op, MigrationOp::CreatePolicy(p) if p.name == "sampling_upload_owner_select")
+            })
+            .expect("cross-table policy must be rebuilt via CreatePolicy");
+
+        assert!(
+            drop_policy_pos < drop_col_pos,
+            "DropPolicy ({drop_policy_pos}) must precede DropColumn ({drop_col_pos})"
+        );
+        assert!(
+            drop_col_pos < create_policy_pos,
+            "DropColumn ({drop_col_pos}) must precede CreatePolicy ({create_policy_pos})"
+        );
+
+        let alter_policy_count = planned
+            .iter()
+            .filter(|op| matches!(op, MigrationOp::AlterPolicy { name, .. } if name == "sampling_upload_owner_select"))
+            .count();
+        assert_eq!(
+            alter_policy_count, 0,
+            "cross-table AlterPolicy must be replaced by a rebuild"
+        );
     }
 
     #[test]

--- a/src/parser/dependencies.rs
+++ b/src/parser/dependencies.rs
@@ -149,6 +149,62 @@ pub fn extract_table_references(body: &str, default_schema: &str) -> HashSet<Obj
     refs
 }
 
+/// Extract bare column identifiers referenced in a SQL body.
+///
+/// Walks every expression in the parsed body and collects the unqualified
+/// name of each column identifier, dropping any table/alias qualifier. Used
+/// to decide whether a policy's USING/WITH CHECK expression depends on a
+/// column being dropped (gh#332). Like the other extractors here, an
+/// unparseable body degrades to an empty set rather than failing.
+pub fn extract_column_references(body: &str, default_schema: &str) -> HashSet<String> {
+    use core::ops::ControlFlow;
+    use sqlparser::ast::{visit_expressions, Ident};
+
+    let mut columns = HashSet::new();
+
+    if is_plpgsql_body(body) {
+        return columns;
+    }
+
+    let dialect = PostgreSqlDialect {};
+    let sql_as_where = format!("SELECT 1 WHERE {body}");
+    let sql_as_subquery = format!("SELECT * FROM ({body}) AS subq");
+
+    let statements = match Parser::parse_sql(&dialect, &sql_as_where)
+        .or_else(|_| Parser::parse_sql(&dialect, &sql_as_subquery))
+        .or_else(|_| Parser::parse_sql(&dialect, body))
+    {
+        Ok(stmts) => stmts,
+        Err(err) => {
+            if let Some(message) =
+                format_extract_table_references_failure(body, default_schema, &err.to_string())
+            {
+                eprintln!("{message}");
+            }
+            return columns;
+        }
+    };
+
+    let mut push_ident = |ident: &Ident| {
+        columns.insert(unquote_ident(&ident.to_string()).to_string());
+    };
+
+    let _ = visit_expressions(&statements, |expr| {
+        match expr {
+            Expr::Identifier(ident) => push_ident(ident),
+            Expr::CompoundIdentifier(parts) => {
+                if let Some(last) = parts.last() {
+                    push_ident(last);
+                }
+            }
+            _ => {}
+        }
+        ControlFlow::<()>::Continue(())
+    });
+
+    columns
+}
+
 /// Build the warning message for a total parse failure in
 /// `extract_table_references`. Returns `None` for trivially empty bodies
 /// and for PL/pgSQL function bodies — neither is expected to parse as
@@ -796,6 +852,34 @@ mod tests {
 
         assert_eq!(refs.len(), 1);
         assert!(refs.contains(&ObjectRef::new("public", "users")));
+    }
+
+    #[test]
+    fn extract_columns_from_policy_subquery_expression() {
+        let body = "EXISTS (SELECT 1 FROM mrv.sampling_project sp \
+            WHERE sp.id = sampling_project_id AND sp.entity_id IS NOT NULL)";
+        let columns = extract_column_references(body, "mrv");
+
+        assert!(columns.contains("entity_id"));
+        assert!(columns.contains("id"));
+        assert!(columns.contains("sampling_project_id"));
+    }
+
+    #[test]
+    fn extract_columns_strips_table_qualifier() {
+        let body = "sp.entity_id = other.id";
+        let columns = extract_column_references(body, "public");
+
+        assert!(columns.contains("entity_id"));
+        assert!(columns.contains("id"));
+        assert!(!columns.contains("sp.entity_id"));
+    }
+
+    #[test]
+    fn extract_columns_returns_empty_on_unparseable_body() {
+        let columns =
+            extract_column_references("this is not sql at all >>> complete nonsense", "public");
+        assert!(columns.is_empty());
     }
 
     #[test]

--- a/src/parser/dependencies.rs
+++ b/src/parser/dependencies.rs
@@ -860,9 +860,14 @@ mod tests {
             WHERE sp.id = sampling_project_id AND sp.entity_id IS NOT NULL)";
         let columns = extract_column_references(body, "mrv");
 
-        assert!(columns.contains("entity_id"));
-        assert!(columns.contains("id"));
-        assert!(columns.contains("sampling_project_id"));
+        assert_eq!(
+            columns,
+            HashSet::from([
+                "id".to_string(),
+                "sampling_project_id".to_string(),
+                "entity_id".to_string(),
+            ])
+        );
     }
 
     #[test]
@@ -870,9 +875,10 @@ mod tests {
         let body = "sp.entity_id = other.id";
         let columns = extract_column_references(body, "public");
 
-        assert!(columns.contains("entity_id"));
-        assert!(columns.contains("id"));
-        assert!(!columns.contains("sp.entity_id"));
+        assert_eq!(
+            columns,
+            HashSet::from(["entity_id".to_string(), "id".to_string()])
+        );
     }
 
     #[test]

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -21,8 +21,8 @@ mod util;
 mod tests;
 
 pub use dependencies::{
-    extract_function_references, extract_rowtype_references, extract_table_references,
-    topological_sort, ObjectRef,
+    extract_column_references, extract_function_references, extract_rowtype_references,
+    extract_table_references, topological_sort, ObjectRef,
 };
 pub use loader::load_schema_sources;
 pub use unrecognized::{find_unrecognized_statements, UnrecognizedStatement};


### PR DESCRIPTION
Fixes #332

## Root cause

A policy on one table can reference a column on a *different* table through a subquery join in its USING/CHECK expression. When that column is dropped, PostgreSQL cascade-drops the policy. pgmold's planner still emitted an `ALTER POLICY` against it, so apply failed with `policy "X" for table "Y" does not exist` and the whole migration rolled back.

#327 (v0.34.12) added `AddColumn -> AlterPolicy` edges, but only for policies on the *same* table as the column. The cross-table / DropColumn side was still broken:

```sql
ALTER TABLE "mrv"."sampling_project" ADD COLUMN "supplier_id" UUID NOT NULL;
ALTER TABLE "mrv"."sampling_project" DROP COLUMN "entity_id" CASCADE;   -- cascade-drops both policies on sampling_upload
ALTER POLICY "sampling_upload_owner_select" ON "mrv"."sampling_upload" USING (...);  -- FAILS: policy gone
ALTER POLICY "sampling_upload_owner_delete" ON "mrv"."sampling_upload" USING (...);  -- FAILS: policy gone
```

## Fix (option 1 from the issue: rebuild, matching the same-table model)

Extend the column-drop path to walk *every* table's policies and, for any policy whose USING/CHECK expression references both the affected table and the dropped column on another table, rebuild it (`DropPolicy` + `CreatePolicy`) instead of leaving an `AlterPolicy`. A rebuilt policy is dropped before the cascade and recreated after the new column exists, so the cascade is harmless.

This was chosen over adding an `AlterPolicy -> DropColumn` ordering edge (option 2) because it mirrors the existing same-table rebuild from #169 and the function-dependency rebuild, reusing the same `DropPolicy + CreatePolicy + SetComment + policies_to_filter` scaffolding. The planner's existing `drop_policies -> drop_columns` and `drop_columns -> policies` tier edges (src/diff/planner.rs) already order the rebuild correctly, so no planner change was needed.

New `extract_column_references` helper (src/parser/dependencies.rs) walks a policy expression's identifiers via sqlparser's visitor to decide which cross-table policies depend on the dropped column.

## Test (failed before, passes after)

`src/diff/mod.rs::drop_column_rebuilds_cross_table_policy_referencing_dropped_column` constructs the two-table scenario and asserts no `AlterPolicy` for the cross-table policy lands after the `DropColumn`, and that `DropPolicy < DropColumn < CreatePolicy`. Confirmed it failed against the pre-fix code (`cross-table AlterPolicy must not be placed after the cascading DropColumn`) and passes after. Added three `extract_column_references` unit tests.

## Empirical verification (live Postgres)

Applied v1, then applied v2 (the previously-failing migration), then re-planned:

```
=== APPLY v2 (was failing before fix) ===
Successfully applied 6 statements.

=== RE-PLAN (must be empty = convergence) ===
No changes required.
```

Plan ordering after the fix:
```
DROP POLICY IF EXISTS "sampling_upload_owner_select" ON "mrv"."sampling_upload";
DROP POLICY IF EXISTS "sampling_upload_owner_delete" ON "mrv"."sampling_upload";
ALTER TABLE "mrv"."sampling_project" ADD COLUMN "supplier_id" UUID NOT NULL;
ALTER TABLE "mrv"."sampling_project" DROP COLUMN "entity_id" CASCADE;
CREATE POLICY "sampling_upload_owner_select" ... sp.supplier_id IS NOT NULL ...;
CREATE POLICY "sampling_upload_owner_delete" ... sp.supplier_id IS NOT NULL ...;
```

Post-apply DB confirmed both policies present, `entity_id` gone, `supplier_id` present.

## Quality gates

- `cargo fmt`, `cargo clippy --all-targets -- -D warnings` clean.
- Full lib suite: 1309 passed (debug build, debug_assert invariants active).
- Integration suite NOT run locally: testcontainers images can't be pulled in this environment. CI will run them.

<!-- archie:start -->

## Diagram Analysis

### Where the fix plugs into the diff pipeline

New cross-table policy-rebuild pass runs after the existing column-drop passes, using a new column-reference extractor to decide which policies depend on the dropped column.

```mermaid
flowchart TD
    A[compute_diff] --> B[tables_with_dropped_columns]
    B --> C[generate_policy_ops_for_affected_tables: same-table policies]
    C --> D[dropped_columns: table,column pairs]
    D --> E[generate_policy_ops_for_cross_table_column_drops]
    E --> F[policy_references_dropped_cross_table_column]
    F --> G[extract_table_references]
    F --> H[extract_column_references: new]
    E --> I[emit DropPolicy + CreatePolicy, filter stale AlterPolicy]
    I --> J[plan_migration topological sort]
```

### Resulting plan ordering

Planner tier edges force the rebuilt cross-table policy to drop before the cascading DropColumn and recreate after the new column exists.

```mermaid
flowchart LR
    DP[DROP POLICY on sampling_upload] --> AC[ADD COLUMN supplier_id]
    AC --> DC[DROP COLUMN entity_id CASCADE]
    DC --> CP[CREATE POLICY references supplier_id]
```
<!-- archie:end -->
