### PR TITLE
chore: bump version to 0.34.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1587,7 +1587,7 @@ dependencies = [
 
 [[package]]
 name = "pgmold"
-version = "0.34.12"
+version = "0.34.13"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "pgmold"
-version = "0.34.12"
+version = "0.34.13"
 edition = "2021"
 exclude = [".auto-claude/", ".auto-claude-security.json", ".claude_settings.json"]
 description = "PostgreSQL schema-as-code management tool"


### PR DESCRIPTION
release 0.34.13.

changes since 0.34.12:
- fix(parser): truncate identifiers at NAMEDATALEN-1 so declared names converge with PG's truncated storage form (#324, closes #323)
- fix(diff): rebuild cross-table policies that reference a dropped column instead of leaving a stale ALTER POLICY after DROP COLUMN CASCADE (#336, fixes #332)
- docs: document column-rename limitation (#334, #335)