### PR TITLE
fix(diff): elide no-op column casts in view bodies

### DIFF
--- a/src/diff/objects.rs
+++ b/src/diff/objects.rs
@@ -494,7 +494,7 @@ pub(super) fn diff_views(from: &Schema, to: &Schema, options: &DiffOptions) -> V
         &to.views,
         |_key, view| MigrationOp::CreateView(view.clone()),
         |ops, _key, from_view, to_view| {
-            if !from_view.semantically_equals(to_view) {
+            if !from_view.semantically_equals_with_tables(to_view, &to.tables) {
                 ops.push(MigrationOp::AlterView {
                     name: qualified_name(&to_view.schema, &to_view.name),
                     new_view: to_view.clone(),

--- a/src/diff/objects.rs
+++ b/src/diff/objects.rs
@@ -494,6 +494,12 @@ pub(super) fn diff_views(from: &Schema, to: &Schema, options: &DiffOptions) -> V
         &to.views,
         |_key, view| MigrationOp::CreateView(view.clone()),
         |ops, _key, from_view, to_view| {
+            // Resolve cast no-ops against the desired (`to`) schema's tables, not the
+            // live DB's. The source view's body must be judged against the column
+            // types it will run on after this migration applies. When a column's type
+            // is itself changing in this run, `to.tables` already holds the new type,
+            // so a cast that is a no-op only under the old type stays preserved here
+            // (correctly, since the view will be recreated against the new type).
             if !from_view.semantically_equals_with_tables(to_view, &to.tables) {
                 ops.push(MigrationOp::AlterView {
                     name: qualified_name(&to_view.schema, &to_view.name),

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1,4 +1,6 @@
-use crate::util::{expressions_semantically_equal, views_semantically_equal};
+use crate::util::{
+    expressions_semantically_equal, views_semantically_equal, views_semantically_equal_with_columns,
+};
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet};
@@ -798,6 +800,27 @@ impl View {
             && self.schema == other.schema
             && self.materialized == other.materialized
             && views_semantically_equal(&self.query, &other.query)
+    }
+
+    /// Like [`View::semantically_equals`], but resolves column references in the
+    /// view bodies against `tables` so that a no-op `CAST(col AS T)` (one whose
+    /// target equals the referenced column's declared type) is treated as
+    /// equivalent to the un-cast form. PostgreSQL elides such casts when storing
+    /// a view, so without this the parsed and introspected bodies never converge.
+    pub fn semantically_equals_with_tables(
+        &self,
+        other: &View,
+        tables: &std::collections::BTreeMap<String, Table>,
+    ) -> bool {
+        self.name == other.name
+            && self.schema == other.schema
+            && self.materialized == other.materialized
+            && views_semantically_equal_with_columns(
+                &self.query,
+                &other.query,
+                tables,
+                &self.schema,
+            )
     }
 }
 

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -530,7 +530,12 @@ impl CastContext<'_> {
             },
         };
         let mut found: Option<&PgType> = None;
-        for source in self.aliases.base_sources.iter().filter(|s| matches_qualifier(s)) {
+        for source in self
+            .aliases
+            .base_sources
+            .iter()
+            .filter(|s| matches_qualifier(s))
+        {
             let key = format!("{}.{}", source.schema, source.table);
             let Some(table) = tables.get(&key) else {
                 continue;
@@ -671,6 +676,14 @@ fn column_reference_parts(expr: &Expr) -> Option<(Option<String>, String)> {
 
 /// Compares a column's declared `PgType` against a cast target `DataType`
 /// (both already normalized). Returns true only for an exact no-op match.
+///
+/// Only casts that survive the numeric/datetime/text early exit in `normalize_expr`
+/// reach this function for a column reference. That early exit already strips any
+/// identifier cast whose target is numeric (integer, bigint, smallint, real, double
+/// precision, ...) or datetime (date, timestamp), so those arms would be dead here
+/// and are intentionally omitted. Length-qualified character casts (`varchar(n)`,
+/// `char(n)`) and the non-numeric/non-datetime scalar types (`boolean`, `uuid`) are
+/// not stripped early, so they must be matched here.
 fn pg_type_matches_cast(pg_type: &PgType, cast_type: &DataType) -> bool {
     use sqlparser::ast::CharacterLength;
     let char_len = |len: &Option<CharacterLength>| -> Option<u64> {
@@ -686,14 +699,8 @@ fn pg_type_matches_cast(pg_type: &PgType, cast_type: &DataType) -> bool {
         (PgType::Char(col_len), DataType::Character(cast_len)) => {
             col_len.map(|l| l as u64) == char_len(cast_len)
         }
-        (PgType::Integer, DataType::Integer(_)) => true,
-        (PgType::BigInt, DataType::BigInt(_)) => true,
-        (PgType::SmallInt, DataType::SmallInt(_)) => true,
-        (PgType::Real, DataType::Real) => true,
-        (PgType::DoublePrecision, DataType::DoublePrecision) => true,
         (PgType::Boolean, DataType::Boolean) => true,
         (PgType::Uuid, DataType::Uuid) => true,
-        (PgType::Date, DataType::Date) => true,
         _ => false,
     }
 }
@@ -886,7 +893,10 @@ fn normalize_query(query: &Query, cast_context: CastContext) -> Query {
 fn normalize_group_by(group_by: &GroupByExpr, cast_context: CastContext) -> GroupByExpr {
     match group_by {
         GroupByExpr::Expressions(exprs, modifiers) => GroupByExpr::Expressions(
-            exprs.iter().map(|e| normalize_expr(e, cast_context)).collect(),
+            exprs
+                .iter()
+                .map(|e| normalize_expr(e, cast_context))
+                .collect(),
             modifiers.clone(),
         ),
         other => other.clone(),
@@ -939,7 +949,9 @@ fn normalize_order_by_options(opts: OrderByOptions) -> OrderByOptions {
 /// Normalizes a set expression (SELECT, UNION, etc).
 fn normalize_set_expr(body: &SetExpr, cast_context: CastContext) -> SetExpr {
     match body {
-        SetExpr::Select(select) => SetExpr::Select(Box::new(normalize_select(select, cast_context))),
+        SetExpr::Select(select) => {
+            SetExpr::Select(Box::new(normalize_select(select, cast_context)))
+        }
         SetExpr::Query(q) => SetExpr::Query(Box::new(normalize_query(q, cast_context))),
         SetExpr::SetOperation {
             op,
@@ -1068,9 +1080,9 @@ fn normalize_function_arg(
     cast_context: CastContext,
 ) -> sqlparser::ast::FunctionArg {
     match arg {
-        sqlparser::ast::FunctionArg::Unnamed(arg_expr) => {
-            sqlparser::ast::FunctionArg::Unnamed(normalize_function_arg_expr(arg_expr, cast_context))
-        }
+        sqlparser::ast::FunctionArg::Unnamed(arg_expr) => sqlparser::ast::FunctionArg::Unnamed(
+            normalize_function_arg_expr(arg_expr, cast_context),
+        ),
         sqlparser::ast::FunctionArg::Named {
             name,
             arg,
@@ -1132,10 +1144,16 @@ fn normalize_window_frame_bound(
 ) -> sqlparser::ast::WindowFrameBound {
     match bound {
         sqlparser::ast::WindowFrameBound::Preceding(Some(e)) => {
-            sqlparser::ast::WindowFrameBound::Preceding(Some(Box::new(normalize_expr(e, cast_context))))
+            sqlparser::ast::WindowFrameBound::Preceding(Some(Box::new(normalize_expr(
+                e,
+                cast_context,
+            ))))
         }
         sqlparser::ast::WindowFrameBound::Following(Some(e)) => {
-            sqlparser::ast::WindowFrameBound::Following(Some(Box::new(normalize_expr(e, cast_context))))
+            sqlparser::ast::WindowFrameBound::Following(Some(Box::new(normalize_expr(
+                e,
+                cast_context,
+            ))))
         }
         other => other.clone(),
     }
@@ -1251,8 +1269,11 @@ fn normalize_table_with_joins(
             let normalized_inner = normalize_table_with_joins(inner_twj, cast_context);
 
             // Normalize outer joins
-            let normalized_outer_joins: Vec<_> =
-                twj.joins.iter().map(|j| normalize_join(j, cast_context)).collect();
+            let normalized_outer_joins: Vec<_> = twj
+                .joins
+                .iter()
+                .map(|j| normalize_join(j, cast_context))
+                .collect();
 
             // Combine: inner joins first, then outer joins
             let mut combined_joins = normalized_inner.joins;
@@ -1270,7 +1291,11 @@ fn normalize_table_with_joins(
 
     sqlparser::ast::TableWithJoins {
         relation: normalized_relation,
-        joins: twj.joins.iter().map(|j| normalize_join(j, cast_context)).collect(),
+        joins: twj
+            .joins
+            .iter()
+            .map(|j| normalize_join(j, cast_context))
+            .collect(),
     }
 }
 
@@ -1537,7 +1562,9 @@ fn normalize_expr(expr: &Expr, cast_context: CastContext) -> Expr {
             // column against the FROM clause; elide only on an exact match,
             // otherwise preserve the cast (it is real, e.g. a truncating cast).
             if let Some((qualifier, column)) = &column_ref {
-                if let Some(pg_type) = cast_context.resolve_column_type(qualifier.as_deref(), column) {
+                if let Some(pg_type) =
+                    cast_context.resolve_column_type(qualifier.as_deref(), column)
+                {
                     if pg_type_matches_cast(pg_type, &norm_data_type) {
                         return norm_inner;
                     }
@@ -1638,7 +1665,9 @@ fn normalize_expr(expr: &Expr, cast_context: CastContext) -> Expr {
         } => Expr::Case {
             case_token: case_token.clone(),
             end_token: end_token.clone(),
-            operand: operand.as_ref().map(|e| Box::new(normalize_expr(e, cast_context))),
+            operand: operand
+                .as_ref()
+                .map(|e| Box::new(normalize_expr(e, cast_context))),
             conditions: conditions
                 .iter()
                 .map(|cw| sqlparser::ast::CaseWhen {
@@ -1668,10 +1697,16 @@ fn normalize_expr(expr: &Expr, cast_context: CastContext) -> Expr {
                 }
                 other => other.clone(),
             };
-            func.filter = f.filter.as_ref().map(|e| Box::new(normalize_expr(e, cast_context)));
+            func.filter = f
+                .filter
+                .as_ref()
+                .map(|e| Box::new(normalize_expr(e, cast_context)));
             func.over = f.over.as_ref().map(|w| match w {
                 sqlparser::ast::WindowType::WindowSpec(spec) => {
-                    sqlparser::ast::WindowType::WindowSpec(normalize_window_spec(spec, cast_context))
+                    sqlparser::ast::WindowType::WindowSpec(normalize_window_spec(
+                        spec,
+                        cast_context,
+                    ))
                 }
                 other => other.clone(),
             });
@@ -1705,7 +1740,10 @@ fn normalize_expr(expr: &Expr, cast_context: CastContext) -> Expr {
             negated,
         } => Expr::InList {
             expr: Box::new(normalize_expr(inner, cast_context)),
-            list: list.iter().map(|e| normalize_expr(e, cast_context)).collect(),
+            list: list
+                .iter()
+                .map(|e| normalize_expr(e, cast_context))
+                .collect(),
             negated: *negated,
         },
 
@@ -1779,7 +1817,11 @@ fn normalize_expr(expr: &Expr, cast_context: CastContext) -> Expr {
             if let Expr::Array(arr) = &norm_right {
                 Expr::InList {
                     expr: Box::new(norm_left),
-                    list: arr.elem.iter().map(|e| normalize_expr(e, cast_context)).collect(),
+                    list: arr
+                        .elem
+                        .iter()
+                        .map(|e| normalize_expr(e, cast_context))
+                        .collect(),
                     negated: false,
                 }
             } else {
@@ -1804,7 +1846,11 @@ fn normalize_expr(expr: &Expr, cast_context: CastContext) -> Expr {
             if let Expr::Array(arr) = &norm_right {
                 Expr::InList {
                     expr: Box::new(norm_left),
-                    list: arr.elem.iter().map(|e| normalize_expr(e, cast_context)).collect(),
+                    list: arr
+                        .elem
+                        .iter()
+                        .map(|e| normalize_expr(e, cast_context))
+                        .collect(),
                     negated: true,
                 }
             } else {
@@ -1818,7 +1864,11 @@ fn normalize_expr(expr: &Expr, cast_context: CastContext) -> Expr {
 
         // Normalize Array elements recursively (strips casts inside ARRAY[...])
         Expr::Array(arr) => Expr::Array(sqlparser::ast::Array {
-            elem: arr.elem.iter().map(|e| normalize_expr(e, cast_context)).collect(),
+            elem: arr
+                .elem
+                .iter()
+                .map(|e| normalize_expr(e, cast_context))
+                .collect(),
             named: arr.named,
         }),
 
@@ -3340,12 +3390,71 @@ fn cast_on_subquery_derived_column_preserved() {
 }
 
 #[test]
+#[allow(clippy::bool_assert_comparison)]
+fn noop_uuid_cast_on_single_table_column_elided() {
+    // A `CAST(col AS uuid)` is not stripped by the numeric/datetime/text early
+    // exit, so this elision relies on the Uuid arm of pg_type_matches_cast: the
+    // arm is reachable and must stay.
+    let tables = tables_from_sql("CREATE TABLE s.t (id uuid);");
+    let with_cast = "SELECT CAST(t1.id AS uuid) AS id FROM s.t t1";
+    let without_cast = "SELECT t1.id AS id FROM s.t t1";
+    assert_eq!(
+        views_semantically_equal_with_columns(with_cast, without_cast, &tables, "s"),
+        true,
+        "A no-op CAST to a uuid column's own type should be elided via the Uuid arm"
+    );
+}
+
+#[test]
+#[allow(clippy::bool_assert_comparison)]
+fn noop_boolean_cast_on_single_table_column_elided() {
+    // Like uuid, a boolean cast bypasses the numeric/datetime early exit, so this
+    // exercises the Boolean arm of pg_type_matches_cast; the arm is reachable.
+    let tables = tables_from_sql("CREATE TABLE s.t (flag boolean);");
+    let with_cast = "SELECT CAST(t1.flag AS boolean) AS flag FROM s.t t1";
+    let without_cast = "SELECT t1.flag AS flag FROM s.t t1";
+    assert_eq!(
+        views_semantically_equal_with_columns(with_cast, without_cast, &tables, "s"),
+        true,
+        "A no-op CAST to a boolean column's own type should be elided via the Boolean arm"
+    );
+}
+
+#[test]
+#[allow(clippy::bool_assert_comparison)]
+fn noop_char_cast_on_single_table_column_elided() {
+    let tables = tables_from_sql("CREATE TABLE s.t (c char(10));");
+    let with_cast = "SELECT CAST(t1.c AS char(10)) AS c FROM s.t t1";
+    let without_cast = "SELECT t1.c AS c FROM s.t t1";
+    assert_eq!(
+        views_semantically_equal_with_columns(with_cast, without_cast, &tables, "s"),
+        true,
+        "A no-op CAST to a char column's own declared length should be elided"
+    );
+}
+
+#[test]
+#[allow(clippy::bool_assert_comparison)]
+fn truncating_char_cast_on_single_table_column_preserved() {
+    let tables = tables_from_sql("CREATE TABLE s.t (c char(10));");
+    let with_cast = "SELECT CAST(t1.c AS char(5)) AS c FROM s.t t1";
+    let without_cast = "SELECT t1.c AS c FROM s.t t1";
+    assert_eq!(
+        views_semantically_equal_with_columns(with_cast, without_cast, &tables, "s"),
+        false,
+        "A truncating char cast (shorter target length) is real and must be preserved"
+    );
+}
+
+#[test]
+#[allow(clippy::bool_assert_comparison)]
 fn cast_on_cte_backed_column_preserved_even_when_colliding_base_table_exists() {
     // A real base table named `cte` exists in the same schema with a varchar(100)
     // `bn` column. The CTE shadows it: the CTE's `bn` may have a different type, so
     // the cast must be preserved rather than resolved against the colliding table.
     let tables = tables_from_sql("CREATE TABLE s.cte (bn varchar(100));");
-    let with_cast = "WITH cte AS (SELECT bn FROM s.t) SELECT CAST(cte.bn AS varchar(100)) AS bn FROM cte";
+    let with_cast =
+        "WITH cte AS (SELECT bn FROM s.t) SELECT CAST(cte.bn AS varchar(100)) AS bn FROM cte";
     let without_cast = "WITH cte AS (SELECT bn FROM s.t) SELECT cte.bn FROM cte";
     assert_eq!(
         views_semantically_equal_with_columns(with_cast, without_cast, &tables, "s"),

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::sync::LazyLock;
 
 use regex::Regex;
@@ -8,6 +9,8 @@ use sqlparser::ast::{
 use sqlparser::dialect::PostgreSqlDialect;
 use sqlparser::parser::Parser;
 use thiserror::Error;
+
+use crate::model::{PgType, Table};
 
 static RE_WHITESPACE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\s+").expect("valid regex"));
 
@@ -461,10 +464,257 @@ pub fn normalize_view_query(query: &str) -> String {
     remove_structural_parens(&result)
 }
 
+/// Context used while normalizing a view query so that a no-op `CAST(col AS T)`
+/// can be elided when (and only when) `col`'s declared base-table type equals `T`.
+///
+/// PostgreSQL elides a cast in a stored view definition only when it is a true
+/// no-op (the cast target equals the column's actual type). A cast to a different
+/// type (e.g. a truncating `varchar(50)` on a `varchar(100)` column) is real and
+/// kept. To reproduce that behavior we must resolve each column reference to its
+/// owning base table and look up its declared type. When the schema is not
+/// available (`tables` is `None`) we never elide a length-qualified cast: keeping
+/// a real cast in place is harmless, while wrongly stripping one causes silent
+/// divergence.
+#[derive(Clone, Copy)]
+struct CastCtx<'a> {
+    tables: Option<&'a BTreeMap<String, Table>>,
+    default_schema: &'a str,
+    aliases: &'a ColumnScope,
+}
+
+impl CastCtx<'_> {
+    fn disabled() -> CastCtx<'static> {
+        static EMPTY: ColumnScope = ColumnScope::empty();
+        CastCtx {
+            tables: None,
+            default_schema: "public",
+            aliases: &EMPTY,
+        }
+    }
+
+    /// Replaces the alias scope (used when descending into a SELECT with its own FROM).
+    fn with_scope<'b>(&self, aliases: &'b ColumnScope) -> CastCtx<'b>
+    where
+        Self: 'b,
+    {
+        CastCtx {
+            tables: self.tables,
+            default_schema: self.default_schema,
+            aliases,
+        }
+    }
+
+    /// Resolves the declared type of a column reference, returning `None` (fail
+    /// safe) when the column cannot be unambiguously tied to a single base table
+    /// column. `qualifier` is the lowercased table alias/name for `alias.col`
+    /// references, or `None` for a bare `col` reference.
+    fn resolve_column_type(&self, qualifier: Option<&str>, column: &str) -> Option<&PgType> {
+        let tables = self.tables?;
+        let column = column.to_lowercase();
+        let candidates: Vec<&FromSource> = match qualifier {
+            Some(qual) => self.aliases.matching(qual).into_iter().collect(),
+            None => self.aliases.base_sources(),
+        };
+        let mut found: Option<&PgType> = None;
+        for source in candidates {
+            let key = format!("{}.{}", source.schema, source.table);
+            let Some(table) = tables.get(&key) else {
+                continue;
+            };
+            let Some(col) = table.columns.get(&column) else {
+                continue;
+            };
+            if found.is_some() {
+                return None;
+            }
+            found = Some(&col.data_type);
+        }
+        found
+    }
+}
+
+/// A single base-table source visible in a FROM clause: its schema and table name.
+#[derive(Clone)]
+struct FromSource {
+    alias: Option<String>,
+    schema: String,
+    table: String,
+}
+
+/// The column-resolution scope for one SELECT: every base table reachable through
+/// its FROM/JOIN clause. Derived tables (subqueries) and other non-base sources
+/// are deliberately recorded as `opaque` so that any column referencing them fails
+/// to resolve, preserving the cast.
+struct ColumnScope {
+    base_sources: Vec<FromSource>,
+    opaque_aliases: Vec<String>,
+}
+
+impl ColumnScope {
+    const fn empty() -> ColumnScope {
+        ColumnScope {
+            base_sources: Vec::new(),
+            opaque_aliases: Vec::new(),
+        }
+    }
+
+    fn base_sources(&self) -> Vec<&FromSource> {
+        self.base_sources.iter().collect()
+    }
+
+    /// Returns the base sources whose alias (or bare table name when unaliased)
+    /// matches `qualifier`. Empty when the qualifier names an opaque source.
+    fn matching(&self, qualifier: &str) -> Vec<&FromSource> {
+        if self.opaque_aliases.iter().any(|a| a == qualifier) {
+            return Vec::new();
+        }
+        self.base_sources
+            .iter()
+            .filter(|s| match &s.alias {
+                Some(alias) => alias == qualifier,
+                None => s.table == qualifier,
+            })
+            .collect()
+    }
+}
+
+/// Builds the column scope for a SELECT from its FROM clause.
+fn build_column_scope(select: &Select, default_schema: &str) -> ColumnScope {
+    let mut scope = ColumnScope::empty();
+    for twj in &select.from {
+        collect_table_factor(&twj.relation, default_schema, &mut scope);
+        for join in &twj.joins {
+            collect_table_factor(&join.relation, default_schema, &mut scope);
+        }
+    }
+    scope
+}
+
+fn collect_table_factor(
+    factor: &sqlparser::ast::TableFactor,
+    default_schema: &str,
+    scope: &mut ColumnScope,
+) {
+    use sqlparser::ast::TableFactor;
+    match factor {
+        TableFactor::Table { name, alias, .. } => {
+            let parts: Vec<String> = name
+                .0
+                .iter()
+                .filter_map(|part| match part {
+                    sqlparser::ast::ObjectNamePart::Identifier(ident) => {
+                        Some(ident.value.to_lowercase())
+                    }
+                    _ => None,
+                })
+                .collect();
+            let (schema, table) = match parts.as_slice() {
+                [schema, table] => (schema.clone(), table.clone()),
+                [table] => (default_schema.to_lowercase(), table.clone()),
+                _ => return,
+            };
+            scope.base_sources.push(FromSource {
+                alias: alias.as_ref().map(|a| a.name.value.to_lowercase()),
+                schema,
+                table,
+            });
+        }
+        TableFactor::Derived { alias: Some(a), .. } => {
+            scope.opaque_aliases.push(a.name.value.to_lowercase());
+        }
+        TableFactor::NestedJoin { alias: Some(a), .. } => {
+            scope.opaque_aliases.push(a.name.value.to_lowercase());
+        }
+        TableFactor::NestedJoin {
+            table_with_joins,
+            alias: None,
+        } => {
+            collect_table_factor(&table_with_joins.relation, default_schema, scope);
+            for join in &table_with_joins.joins {
+                collect_table_factor(&join.relation, default_schema, scope);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Extracts a `(qualifier, column)` pair from a column reference expression,
+/// unwrapping any parentheses. `qualifier` is the lowercased last qualifier
+/// (the table alias/name in `alias.col` or `schema.table.col`); `None` for a
+/// bare `col`. Returns `None` for anything that is not a plain column reference.
+fn column_reference_parts(expr: &Expr) -> Option<(Option<String>, String)> {
+    match expr {
+        Expr::Nested(inner) => column_reference_parts(inner),
+        Expr::Identifier(ident) => Some((None, ident.value.to_lowercase())),
+        Expr::CompoundIdentifier(idents) => {
+            let column = idents.last()?.value.to_lowercase();
+            let qualifier = if idents.len() >= 2 {
+                Some(idents[idents.len() - 2].value.to_lowercase())
+            } else {
+                None
+            };
+            Some((qualifier, column))
+        }
+        _ => None,
+    }
+}
+
+/// Compares a column's declared `PgType` against a cast target `DataType`
+/// (both already normalized). Returns true only for an exact no-op match.
+fn pg_type_matches_cast(pg_type: &PgType, cast_type: &DataType) -> bool {
+    use sqlparser::ast::CharacterLength;
+    let char_len = |len: &Option<CharacterLength>| -> Option<u64> {
+        match len {
+            Some(CharacterLength::IntegerLength { length, .. }) => Some(*length),
+            _ => None,
+        }
+    };
+    match (pg_type, cast_type) {
+        (PgType::Varchar(col_len), DataType::CharacterVarying(cast_len)) => {
+            col_len.map(|l| l as u64) == char_len(cast_len)
+        }
+        (PgType::Char(col_len), DataType::Character(cast_len)) => {
+            col_len.map(|l| l as u64) == char_len(cast_len)
+        }
+        (PgType::Integer, DataType::Integer(_)) => true,
+        (PgType::BigInt, DataType::BigInt(_)) => true,
+        (PgType::SmallInt, DataType::SmallInt(_)) => true,
+        (PgType::Real, DataType::Real) => true,
+        (PgType::DoublePrecision, DataType::DoublePrecision) => true,
+        (PgType::Boolean, DataType::Boolean) => true,
+        (PgType::Uuid, DataType::Uuid) => true,
+        (PgType::Date, DataType::Date) => true,
+        _ => false,
+    }
+}
+
 /// Compares two SQL view queries semantically using AST comparison.
 /// This is more robust than text normalization because it compares structure, not text.
 /// Falls back to regex-based normalization if parsing fails.
 pub fn views_semantically_equal(query1: &str, query2: &str) -> bool {
+    compare_view_queries(query1, query2, CastCtx::disabled())
+}
+
+/// Like [`views_semantically_equal`], but resolves column references against the
+/// supplied base tables so that a no-op `CAST(col AS T)` is elided when `T` equals
+/// the column's declared type. `default_schema` is the schema used to qualify
+/// unqualified table names in the FROM clause (the view's own schema).
+pub fn views_semantically_equal_with_columns(
+    query1: &str,
+    query2: &str,
+    tables: &BTreeMap<String, Table>,
+    default_schema: &str,
+) -> bool {
+    static EMPTY: ColumnScope = ColumnScope::empty();
+    let ctx = CastCtx {
+        tables: Some(tables),
+        default_schema,
+        aliases: &EMPTY,
+    };
+    compare_view_queries(query1, query2, ctx)
+}
+
+fn compare_view_queries(query1: &str, query2: &str, ctx: CastCtx) -> bool {
     let dialect = PostgreSqlDialect {};
 
     let ast1 = Parser::parse_sql(&dialect, query1);
@@ -478,7 +728,7 @@ pub fn views_semantically_equal(query1: &str, query2: &str) -> bool {
             stmts1
                 .into_iter()
                 .zip(stmts2)
-                .all(|(s1, s2)| normalize_statement(&s1) == normalize_statement(&s2))
+                .all(|(s1, s2)| normalize_statement(&s1, ctx) == normalize_statement(&s2, ctx))
         }
         _ => {
             // Fallback to regex normalization if parsing fails
@@ -501,7 +751,10 @@ pub fn expressions_semantically_equal(expr1: &str, expr2: &str) -> bool {
         .and_then(|mut p| p.parse_expr());
 
     match (parse1, parse2) {
-        (Ok(ast1), Ok(ast2)) => normalize_expr(&ast1) == normalize_expr(&ast2),
+        (Ok(ast1), Ok(ast2)) => {
+            let ctx = CastCtx::disabled();
+            normalize_expr(&ast1, ctx) == normalize_expr(&ast2, ctx)
+        }
         _ => {
             // Fallback to regex normalization if parsing fails
             normalize_expression_regex(expr1) == normalize_expression_regex(expr2)
@@ -520,15 +773,15 @@ pub fn optional_expressions_equal(expr1: &Option<String>, expr2: &Option<String>
 }
 
 /// Normalizes a SQL statement to a canonical form for comparison.
-fn normalize_statement(stmt: &Statement) -> Statement {
+fn normalize_statement(stmt: &Statement, ctx: CastCtx) -> Statement {
     match stmt {
-        Statement::Query(query) => Statement::Query(Box::new(normalize_query(query))),
+        Statement::Query(query) => Statement::Query(Box::new(normalize_query(query, ctx))),
         other => other.clone(),
     }
 }
 
 /// Normalizes a query to canonical form.
-fn normalize_query(query: &Query) -> Query {
+fn normalize_query(query: &Query, ctx: CastCtx) -> Query {
     Query {
         with: query.with.as_ref().map(|w| sqlparser::ast::With {
             with_token: w.with_token.clone(),
@@ -538,14 +791,14 @@ fn normalize_query(query: &Query) -> Query {
                 .iter()
                 .map(|cte| sqlparser::ast::Cte {
                     alias: cte.alias.clone(),
-                    query: Box::new(normalize_query(&cte.query)),
+                    query: Box::new(normalize_query(&cte.query, ctx)),
                     from: cte.from.clone(),
                     materialized: cte.materialized,
                     closing_paren_token: cte.closing_paren_token.clone(),
                 })
                 .collect(),
         }),
-        body: Box::new(normalize_set_expr(&query.body)),
+        body: Box::new(normalize_set_expr(&query.body, ctx)),
         order_by: query.order_by.as_ref().map(normalize_order_by),
         limit_clause: query.limit_clause.clone(),
         fetch: query.fetch.clone(),
@@ -557,10 +810,10 @@ fn normalize_query(query: &Query) -> Query {
     }
 }
 
-fn normalize_group_by(group_by: &GroupByExpr) -> GroupByExpr {
+fn normalize_group_by(group_by: &GroupByExpr, ctx: CastCtx) -> GroupByExpr {
     match group_by {
         GroupByExpr::Expressions(exprs, modifiers) => GroupByExpr::Expressions(
-            exprs.iter().map(normalize_expr).collect(),
+            exprs.iter().map(|e| normalize_expr(e, ctx)).collect(),
             modifiers.clone(),
         ),
         other => other.clone(),
@@ -568,13 +821,14 @@ fn normalize_group_by(group_by: &GroupByExpr) -> GroupByExpr {
 }
 
 fn normalize_order_by(order_by: &OrderBy) -> OrderBy {
+    let ctx = CastCtx::disabled();
     OrderBy {
         kind: match &order_by.kind {
             OrderByKind::Expressions(exprs) => OrderByKind::Expressions(
                 exprs
                     .iter()
                     .map(|e| OrderByExpr {
-                        expr: normalize_expr(&e.expr),
+                        expr: normalize_expr(&e.expr, ctx),
                         options: normalize_order_by_options(e.options),
                         with_fill: e.with_fill.clone(),
                     })
@@ -610,10 +864,10 @@ fn normalize_order_by_options(opts: OrderByOptions) -> OrderByOptions {
 }
 
 /// Normalizes a set expression (SELECT, UNION, etc).
-fn normalize_set_expr(body: &SetExpr) -> SetExpr {
+fn normalize_set_expr(body: &SetExpr, ctx: CastCtx) -> SetExpr {
     match body {
-        SetExpr::Select(select) => SetExpr::Select(Box::new(normalize_select(select))),
-        SetExpr::Query(q) => SetExpr::Query(Box::new(normalize_query(q))),
+        SetExpr::Select(select) => SetExpr::Select(Box::new(normalize_select(select, ctx))),
+        SetExpr::Query(q) => SetExpr::Query(Box::new(normalize_query(q, ctx))),
         SetExpr::SetOperation {
             op,
             set_quantifier,
@@ -622,8 +876,8 @@ fn normalize_set_expr(body: &SetExpr) -> SetExpr {
         } => SetExpr::SetOperation {
             op: *op,
             set_quantifier: *set_quantifier,
-            left: Box::new(normalize_set_expr(left)),
-            right: Box::new(normalize_set_expr(right)),
+            left: Box::new(normalize_set_expr(left, ctx)),
+            right: Box::new(normalize_set_expr(right, ctx)),
         },
         other => other.clone(),
     }
@@ -723,10 +977,11 @@ fn normalize_nextval_args(expr: Expr) -> Expr {
 /// Normalizes a FunctionArgExpr, recursively normalizing contained expressions.
 fn normalize_function_arg_expr(
     arg_expr: &sqlparser::ast::FunctionArgExpr,
+    ctx: CastCtx,
 ) -> sqlparser::ast::FunctionArgExpr {
     match arg_expr {
         sqlparser::ast::FunctionArgExpr::Expr(e) => {
-            sqlparser::ast::FunctionArgExpr::Expr(normalize_expr(e))
+            sqlparser::ast::FunctionArgExpr::Expr(normalize_expr(e, ctx))
         }
         other => other.clone(),
     }
@@ -735,10 +990,13 @@ fn normalize_function_arg_expr(
 /// Normalizes a FunctionArg, handling all variants (Unnamed, Named, ExprNamed).
 /// This ensures that expressions inside function arguments are normalized,
 /// including stripping table qualifiers from column references.
-fn normalize_function_arg(arg: &sqlparser::ast::FunctionArg) -> sqlparser::ast::FunctionArg {
+fn normalize_function_arg(
+    arg: &sqlparser::ast::FunctionArg,
+    ctx: CastCtx,
+) -> sqlparser::ast::FunctionArg {
     match arg {
         sqlparser::ast::FunctionArg::Unnamed(arg_expr) => {
-            sqlparser::ast::FunctionArg::Unnamed(normalize_function_arg_expr(arg_expr))
+            sqlparser::ast::FunctionArg::Unnamed(normalize_function_arg_expr(arg_expr, ctx))
         }
         sqlparser::ast::FunctionArg::Named {
             name,
@@ -746,7 +1004,7 @@ fn normalize_function_arg(arg: &sqlparser::ast::FunctionArg) -> sqlparser::ast::
             operator,
         } => sqlparser::ast::FunctionArg::Named {
             name: normalize_ident(name),
-            arg: normalize_function_arg_expr(arg),
+            arg: normalize_function_arg_expr(arg, ctx),
             operator: operator.clone(),
         },
         sqlparser::ast::FunctionArg::ExprNamed {
@@ -754,22 +1012,29 @@ fn normalize_function_arg(arg: &sqlparser::ast::FunctionArg) -> sqlparser::ast::
             arg,
             operator,
         } => sqlparser::ast::FunctionArg::ExprNamed {
-            name: normalize_expr(name),
-            arg: normalize_function_arg_expr(arg),
+            name: normalize_expr(name, ctx),
+            arg: normalize_function_arg_expr(arg, ctx),
             operator: operator.clone(),
         },
     }
 }
 
-fn normalize_window_spec(spec: &sqlparser::ast::WindowSpec) -> sqlparser::ast::WindowSpec {
+fn normalize_window_spec(
+    spec: &sqlparser::ast::WindowSpec,
+    ctx: CastCtx,
+) -> sqlparser::ast::WindowSpec {
     sqlparser::ast::WindowSpec {
         window_name: spec.window_name.clone(),
-        partition_by: spec.partition_by.iter().map(normalize_expr).collect(),
+        partition_by: spec
+            .partition_by
+            .iter()
+            .map(|e| normalize_expr(e, ctx))
+            .collect(),
         order_by: spec
             .order_by
             .iter()
             .map(|e| sqlparser::ast::OrderByExpr {
-                expr: normalize_expr(&e.expr),
+                expr: normalize_expr(&e.expr, ctx),
                 options: normalize_order_by_options(e.options),
                 with_fill: e.with_fill.clone(),
             })
@@ -779,28 +1044,35 @@ fn normalize_window_spec(spec: &sqlparser::ast::WindowSpec) -> sqlparser::ast::W
             .as_ref()
             .map(|wf| sqlparser::ast::WindowFrame {
                 units: wf.units,
-                start_bound: normalize_window_frame_bound(&wf.start_bound),
-                end_bound: wf.end_bound.as_ref().map(normalize_window_frame_bound),
+                start_bound: normalize_window_frame_bound(&wf.start_bound, ctx),
+                end_bound: wf
+                    .end_bound
+                    .as_ref()
+                    .map(|b| normalize_window_frame_bound(b, ctx)),
             }),
     }
 }
 
 fn normalize_window_frame_bound(
     bound: &sqlparser::ast::WindowFrameBound,
+    ctx: CastCtx,
 ) -> sqlparser::ast::WindowFrameBound {
     match bound {
         sqlparser::ast::WindowFrameBound::Preceding(Some(e)) => {
-            sqlparser::ast::WindowFrameBound::Preceding(Some(Box::new(normalize_expr(e))))
+            sqlparser::ast::WindowFrameBound::Preceding(Some(Box::new(normalize_expr(e, ctx))))
         }
         sqlparser::ast::WindowFrameBound::Following(Some(e)) => {
-            sqlparser::ast::WindowFrameBound::Following(Some(Box::new(normalize_expr(e))))
+            sqlparser::ast::WindowFrameBound::Following(Some(Box::new(normalize_expr(e, ctx))))
         }
         other => other.clone(),
     }
 }
 
 /// Normalizes a TableFactor (the source in a FROM clause).
-fn normalize_table_factor(factor: &sqlparser::ast::TableFactor) -> sqlparser::ast::TableFactor {
+fn normalize_table_factor(
+    factor: &sqlparser::ast::TableFactor,
+    ctx: CastCtx,
+) -> sqlparser::ast::TableFactor {
     use sqlparser::ast::TableFactor;
     match factor {
         TableFactor::Table {
@@ -837,7 +1109,7 @@ fn normalize_table_factor(factor: &sqlparser::ast::TableFactor) -> sqlparser::as
             sample,
         } => TableFactor::Derived {
             lateral: *lateral,
-            subquery: Box::new(normalize_query(subquery)),
+            subquery: Box::new(normalize_query(subquery, ctx)),
             alias: alias.as_ref().map(|a| sqlparser::ast::TableAlias {
                 name: normalize_ident(&a.name),
                 explicit: a.explicit,
@@ -852,7 +1124,7 @@ fn normalize_table_factor(factor: &sqlparser::ast::TableFactor) -> sqlparser::as
             table_with_joins,
             alias,
         } => {
-            let normalized_twj = normalize_table_with_joins(table_with_joins);
+            let normalized_twj = normalize_table_with_joins(table_with_joins, ctx);
             // If there are no joins, just return the relation (unwrap parens)
             if normalized_twj.joins.is_empty() {
                 let mut inner = normalized_twj.relation;
@@ -891,6 +1163,7 @@ fn normalize_table_factor(factor: &sqlparser::ast::TableFactor) -> sqlparser::as
 /// Also unwraps NestedJoin when PostgreSQL wraps entire JOINs in parentheses.
 fn normalize_table_with_joins(
     twj: &sqlparser::ast::TableWithJoins,
+    ctx: CastCtx,
 ) -> sqlparser::ast::TableWithJoins {
     // If the relation is a NestedJoin without an alias, flatten it by combining joins
     // PostgreSQL stores `((A JOIN B) JOIN C)` as NestedJoin { inner: {A, [B]}, joins: [C] }
@@ -902,10 +1175,11 @@ fn normalize_table_with_joins(
     {
         if alias.is_none() {
             // Recursively normalize the inner TableWithJoins first
-            let normalized_inner = normalize_table_with_joins(inner_twj);
+            let normalized_inner = normalize_table_with_joins(inner_twj, ctx);
 
             // Normalize outer joins
-            let normalized_outer_joins: Vec<_> = twj.joins.iter().map(normalize_join).collect();
+            let normalized_outer_joins: Vec<_> =
+                twj.joins.iter().map(|j| normalize_join(j, ctx)).collect();
 
             // Combine: inner joins first, then outer joins
             let mut combined_joins = normalized_inner.joins;
@@ -919,20 +1193,21 @@ fn normalize_table_with_joins(
     }
 
     // Standard case: normalize relation and joins separately
-    let normalized_relation = normalize_table_factor(&twj.relation);
+    let normalized_relation = normalize_table_factor(&twj.relation, ctx);
 
     sqlparser::ast::TableWithJoins {
         relation: normalized_relation,
-        joins: twj.joins.iter().map(normalize_join).collect(),
+        joins: twj.joins.iter().map(|j| normalize_join(j, ctx)).collect(),
     }
 }
 
 /// Normalizes a single Join.
-fn normalize_join(j: &sqlparser::ast::Join) -> sqlparser::ast::Join {
+fn normalize_join(j: &sqlparser::ast::Join, ctx: CastCtx) -> sqlparser::ast::Join {
     use sqlparser::ast::{Join, JoinOperator};
-    let normalize_constraint = normalize_join_constraint;
+    let normalize_constraint =
+        |c: &sqlparser::ast::JoinConstraint| normalize_join_constraint(c, ctx);
     Join {
-        relation: normalize_table_factor(&j.relation),
+        relation: normalize_table_factor(&j.relation, ctx),
         global: j.global,
         join_operator: match &j.join_operator {
             JoinOperator::Join(c) | JoinOperator::Inner(c) => {
@@ -953,10 +1228,11 @@ fn normalize_join(j: &sqlparser::ast::Join) -> sqlparser::ast::Join {
 /// Normalizes a JoinConstraint.
 fn normalize_join_constraint(
     constraint: &sqlparser::ast::JoinConstraint,
+    ctx: CastCtx,
 ) -> sqlparser::ast::JoinConstraint {
     use sqlparser::ast::JoinConstraint;
     match constraint {
-        JoinConstraint::On(expr) => JoinConstraint::On(normalize_expr(expr)),
+        JoinConstraint::On(expr) => JoinConstraint::On(normalize_expr(expr, ctx)),
         JoinConstraint::Using(names) => {
             JoinConstraint::Using(names.iter().map(normalize_object_name).collect())
         }
@@ -984,7 +1260,7 @@ fn normalize_data_type(data_type: &DataType) -> DataType {
 ///
 /// Detects that pattern and reduces it back to the bare function call so that
 /// both forms compare as equal.
-fn try_simplify_scalar_subquery(query: &Query) -> Option<Expr> {
+fn try_simplify_scalar_subquery(query: &Query, ctx: CastCtx) -> Option<Expr> {
     if query.with.is_some() || query.order_by.is_some() || query.limit_clause.is_some() {
         return None;
     }
@@ -1015,11 +1291,13 @@ fn try_simplify_scalar_subquery(query: &Query) -> Option<Expr> {
     if !matches!(expr, Expr::Function(_)) {
         return None;
     }
-    Some(normalize_expr(expr))
+    Some(normalize_expr(expr, ctx))
 }
 
 /// Normalizes a SELECT statement.
-fn normalize_select(select: &Select) -> Select {
+fn normalize_select(select: &Select, ctx: CastCtx) -> Select {
+    let scope = build_column_scope(select, ctx.default_schema);
+    let scoped = ctx.with_scope(&scope);
     Select {
         select_token: select.select_token.clone(),
         distinct: select.distinct.clone(),
@@ -1028,21 +1306,25 @@ fn normalize_select(select: &Select) -> Select {
         projection: select
             .projection
             .iter()
-            .map(normalize_select_item)
+            .map(|item| normalize_select_item(item, scoped))
             .collect(),
         exclude: select.exclude.clone(),
         into: select.into.clone(),
-        from: select.from.iter().map(normalize_table_with_joins).collect(),
+        from: select
+            .from
+            .iter()
+            .map(|twj| normalize_table_with_joins(twj, ctx))
+            .collect(),
         lateral_views: select.lateral_views.clone(),
-        prewhere: select.prewhere.as_ref().map(normalize_expr),
-        selection: select.selection.as_ref().map(normalize_expr),
-        group_by: normalize_group_by(&select.group_by),
+        prewhere: select.prewhere.as_ref().map(|e| normalize_expr(e, scoped)),
+        selection: select.selection.as_ref().map(|e| normalize_expr(e, scoped)),
+        group_by: normalize_group_by(&select.group_by, scoped),
         cluster_by: select.cluster_by.clone(),
         distribute_by: select.distribute_by.clone(),
         sort_by: select.sort_by.clone(),
-        having: select.having.as_ref().map(normalize_expr),
+        having: select.having.as_ref().map(|e| normalize_expr(e, scoped)),
         named_window: select.named_window.clone(),
-        qualify: select.qualify.as_ref().map(normalize_expr),
+        qualify: select.qualify.as_ref().map(|e| normalize_expr(e, scoped)),
         window_before_qualify: select.window_before_qualify,
         value_table_mode: select.value_table_mode,
         connect_by: select.connect_by.clone(),
@@ -1056,12 +1338,15 @@ fn normalize_select(select: &Select) -> Select {
 /// Strips auto-generated aliases that PostgreSQL adds to scalar subquery results.
 /// PostgreSQL deparses `(SELECT func())` as `( SELECT func() AS func)`,
 /// adding an alias matching the function name.
-fn normalize_select_item(item: &sqlparser::ast::SelectItem) -> sqlparser::ast::SelectItem {
+fn normalize_select_item(
+    item: &sqlparser::ast::SelectItem,
+    ctx: CastCtx,
+) -> sqlparser::ast::SelectItem {
     use sqlparser::ast::SelectItem;
     match item {
-        SelectItem::UnnamedExpr(e) => SelectItem::UnnamedExpr(normalize_expr(e)),
+        SelectItem::UnnamedExpr(e) => SelectItem::UnnamedExpr(normalize_expr(e, ctx)),
         SelectItem::ExprWithAlias { expr, alias } => {
-            let normalized_expr = normalize_expr(expr);
+            let normalized_expr = normalize_expr(expr, ctx);
             if is_auto_generated_alias(&normalized_expr, alias) {
                 SelectItem::UnnamedExpr(normalized_expr)
             } else {
@@ -1075,15 +1360,23 @@ fn normalize_select_item(item: &sqlparser::ast::SelectItem) -> sqlparser::ast::S
     }
 }
 
-/// Checks if an alias was auto-generated by PostgreSQL for a scalar subquery.
-/// PostgreSQL adds `AS <function_name>` when the select item is a bare function call.
+/// Checks whether an alias is redundant and was therefore omitted by PostgreSQL's
+/// view deparse, so the aliased and unaliased forms compare equal:
+/// - a bare function call `func()` gets `AS func`, and
+/// - a bare column reference `col` gets `AS col` (which appears once a no-op cast
+///   `CAST(col AS T) AS col` is elided down to `col`).
 fn is_auto_generated_alias(expr: &Expr, alias: &sqlparser::ast::Ident) -> bool {
-    if let Expr::Function(f) = expr {
-        if let Some(sqlparser::ast::ObjectNamePart::Identifier(ident)) = f.name.0.last() {
-            return ident.value.to_lowercase() == alias.value.to_lowercase();
+    match expr {
+        Expr::Function(f) => {
+            if let Some(sqlparser::ast::ObjectNamePart::Identifier(ident)) = f.name.0.last() {
+                ident.value.to_lowercase() == alias.value.to_lowercase()
+            } else {
+                false
+            }
         }
+        Expr::Identifier(ident) => ident.value.to_lowercase() == alias.value.to_lowercase(),
+        _ => false,
     }
-    false
 }
 
 /// Normalizes an expression to canonical form.
@@ -1094,15 +1387,15 @@ fn is_auto_generated_alias(expr: &Expr, alias: &sqlparser::ast::Ident) -> bool {
 /// - Convert <> ALL(ARRAY[...]) to NOT IN (...)
 /// - Strip ::text casts from string literals
 /// - Normalize FILTER clauses on aggregate functions
-fn normalize_expr(expr: &Expr) -> Expr {
+fn normalize_expr(expr: &Expr, ctx: CastCtx) -> Expr {
     match expr {
         // Unwrap nested expressions (parentheses)
-        Expr::Nested(inner) => normalize_expr(inner),
+        Expr::Nested(inner) => normalize_expr(inner, ctx),
 
         // Convert PostgreSQL ~~ operator to LIKE
         Expr::BinaryOp { left, op, right } => {
-            let norm_left = normalize_expr(left);
-            let norm_right = normalize_expr(right);
+            let norm_left = normalize_expr(left, ctx);
+            let norm_right = normalize_expr(right, ctx);
 
             match op {
                 BinaryOperator::PGLikeMatch => Expr::Like {
@@ -1148,7 +1441,11 @@ fn normalize_expr(expr: &Expr) -> Expr {
             format,
             ..
         } => {
-            let norm_inner = normalize_expr(inner);
+            // Capture the column reference before normalization strips its
+            // qualifier, so a no-op cast to the column's own declared type can be
+            // resolved against the FROM clause and elided.
+            let column_ref = column_reference_parts(inner);
+            let norm_inner = normalize_expr(inner, ctx);
             let norm_data_type = normalize_data_type(data_type);
             if matches!(norm_data_type, DataType::Text) {
                 return norm_inner;
@@ -1161,6 +1458,17 @@ fn normalize_expr(expr: &Expr) -> Expr {
                 || is_datetime_type(&norm_data_type))
             {
                 return norm_inner;
+            }
+            // A length-qualified or otherwise explicit cast is only a no-op when
+            // its target equals the referenced column's declared type. Resolve the
+            // column against the FROM clause; elide only on an exact match,
+            // otherwise preserve the cast (it is real, e.g. a truncating cast).
+            if let Some((qualifier, column)) = &column_ref {
+                if let Some(pg_type) = ctx.resolve_column_type(qualifier.as_deref(), column) {
+                    if pg_type_matches_cast(pg_type, &norm_data_type) {
+                        return norm_inner;
+                    }
+                }
             }
             if let Expr::Value(v) = &norm_inner {
                 let should_strip = match &v.value {
@@ -1201,14 +1509,14 @@ fn normalize_expr(expr: &Expr) -> Expr {
         }
 
         Expr::Subquery(q) => {
-            if let Some(simplified) = try_simplify_scalar_subquery(q) {
+            if let Some(simplified) = try_simplify_scalar_subquery(q, ctx) {
                 simplified
             } else {
-                Expr::Subquery(Box::new(normalize_query(q)))
+                Expr::Subquery(Box::new(normalize_query(q, ctx)))
             }
         }
         Expr::Exists { subquery, negated } => Expr::Exists {
-            subquery: Box::new(normalize_query(subquery)),
+            subquery: Box::new(normalize_query(subquery, ctx)),
             negated: *negated,
         },
         Expr::InSubquery {
@@ -1216,8 +1524,8 @@ fn normalize_expr(expr: &Expr) -> Expr {
             subquery,
             negated,
         } => Expr::InSubquery {
-            expr: Box::new(normalize_expr(inner)),
-            subquery: Box::new(normalize_query(subquery)),
+            expr: Box::new(normalize_expr(inner, ctx)),
+            subquery: Box::new(normalize_query(subquery, ctx)),
             negated: *negated,
         },
 
@@ -1230,8 +1538,8 @@ fn normalize_expr(expr: &Expr) -> Expr {
         } => Expr::Like {
             negated: *negated,
             any: *any,
-            expr: Box::new(normalize_expr(inner)),
-            pattern: Box::new(normalize_expr(pattern)),
+            expr: Box::new(normalize_expr(inner, ctx)),
+            pattern: Box::new(normalize_expr(pattern, ctx)),
             escape_char: escape_char.clone(),
         },
         Expr::ILike {
@@ -1243,8 +1551,8 @@ fn normalize_expr(expr: &Expr) -> Expr {
         } => Expr::ILike {
             negated: *negated,
             any: *any,
-            expr: Box::new(normalize_expr(inner)),
-            pattern: Box::new(normalize_expr(pattern)),
+            expr: Box::new(normalize_expr(inner, ctx)),
+            pattern: Box::new(normalize_expr(pattern, ctx)),
             escape_char: escape_char.clone(),
         },
 
@@ -1257,15 +1565,17 @@ fn normalize_expr(expr: &Expr) -> Expr {
         } => Expr::Case {
             case_token: case_token.clone(),
             end_token: end_token.clone(),
-            operand: operand.as_ref().map(|e| Box::new(normalize_expr(e))),
+            operand: operand.as_ref().map(|e| Box::new(normalize_expr(e, ctx))),
             conditions: conditions
                 .iter()
                 .map(|cw| sqlparser::ast::CaseWhen {
-                    condition: normalize_expr(&cw.condition),
-                    result: normalize_expr(&cw.result),
+                    condition: normalize_expr(&cw.condition, ctx),
+                    result: normalize_expr(&cw.result, ctx),
                 })
                 .collect(),
-            else_result: else_result.as_ref().map(|e| Box::new(normalize_expr(e))),
+            else_result: else_result
+                .as_ref()
+                .map(|e| Box::new(normalize_expr(e, ctx))),
         },
 
         Expr::Function(f) => {
@@ -1275,16 +1585,20 @@ fn normalize_expr(expr: &Expr) -> Expr {
                 sqlparser::ast::FunctionArguments::List(args) => {
                     sqlparser::ast::FunctionArguments::List(sqlparser::ast::FunctionArgumentList {
                         duplicate_treatment: args.duplicate_treatment,
-                        args: args.args.iter().map(normalize_function_arg).collect(),
+                        args: args
+                            .args
+                            .iter()
+                            .map(|a| normalize_function_arg(a, ctx))
+                            .collect(),
                         clauses: args.clauses.clone(),
                     })
                 }
                 other => other.clone(),
             };
-            func.filter = f.filter.as_ref().map(|e| Box::new(normalize_expr(e)));
+            func.filter = f.filter.as_ref().map(|e| Box::new(normalize_expr(e, ctx)));
             func.over = f.over.as_ref().map(|w| match w {
                 sqlparser::ast::WindowType::WindowSpec(spec) => {
-                    sqlparser::ast::WindowType::WindowSpec(normalize_window_spec(spec))
+                    sqlparser::ast::WindowType::WindowSpec(normalize_window_spec(spec, ctx))
                 }
                 other => other.clone(),
             });
@@ -1292,7 +1606,7 @@ fn normalize_expr(expr: &Expr) -> Expr {
         }
 
         Expr::UnaryOp { op, expr: inner } => {
-            let norm_inner = normalize_expr(inner);
+            let norm_inner = normalize_expr(inner, ctx);
             // Normalize NOT (EXISTS ...) → EXISTS { negated: true }
             if matches!(op, sqlparser::ast::UnaryOperator::Not) {
                 if let Expr::Exists {
@@ -1317,8 +1631,8 @@ fn normalize_expr(expr: &Expr) -> Expr {
             list,
             negated,
         } => Expr::InList {
-            expr: Box::new(normalize_expr(inner)),
-            list: list.iter().map(normalize_expr).collect(),
+            expr: Box::new(normalize_expr(inner, ctx)),
+            list: list.iter().map(|e| normalize_expr(e, ctx)).collect(),
             negated: *negated,
         },
 
@@ -1328,22 +1642,22 @@ fn normalize_expr(expr: &Expr) -> Expr {
             low,
             high,
         } => Expr::Between {
-            expr: Box::new(normalize_expr(inner)),
+            expr: Box::new(normalize_expr(inner, ctx)),
             negated: *negated,
-            low: Box::new(normalize_expr(low)),
-            high: Box::new(normalize_expr(high)),
+            low: Box::new(normalize_expr(low, ctx)),
+            high: Box::new(normalize_expr(high, ctx)),
         },
 
-        Expr::IsNull(inner) => Expr::IsNull(Box::new(normalize_expr(inner))),
-        Expr::IsNotNull(inner) => Expr::IsNotNull(Box::new(normalize_expr(inner))),
+        Expr::IsNull(inner) => Expr::IsNull(Box::new(normalize_expr(inner, ctx))),
+        Expr::IsNotNull(inner) => Expr::IsNotNull(Box::new(normalize_expr(inner, ctx))),
 
         Expr::IsDistinctFrom(left, right) => Expr::IsDistinctFrom(
-            Box::new(normalize_expr(left)),
-            Box::new(normalize_expr(right)),
+            Box::new(normalize_expr(left, ctx)),
+            Box::new(normalize_expr(right, ctx)),
         ),
         Expr::IsNotDistinctFrom(left, right) => Expr::IsNotDistinctFrom(
-            Box::new(normalize_expr(left)),
-            Box::new(normalize_expr(right)),
+            Box::new(normalize_expr(left, ctx)),
+            Box::new(normalize_expr(right, ctx)),
         ),
 
         // Normalize CompoundIdentifier (lowercase for case-insensitive comparison)
@@ -1387,12 +1701,12 @@ fn normalize_expr(expr: &Expr) -> Expr {
             right,
             ..
         } if *compare_op == BinaryOperator::Eq => {
-            let norm_left = normalize_expr(left);
-            let norm_right = normalize_expr(right);
+            let norm_left = normalize_expr(left, ctx);
+            let norm_right = normalize_expr(right, ctx);
             if let Expr::Array(arr) = &norm_right {
                 Expr::InList {
                     expr: Box::new(norm_left),
-                    list: arr.elem.iter().map(normalize_expr).collect(),
+                    list: arr.elem.iter().map(|e| normalize_expr(e, ctx)).collect(),
                     negated: false,
                 }
             } else {
@@ -1412,12 +1726,12 @@ fn normalize_expr(expr: &Expr) -> Expr {
             compare_op,
             right,
         } if *compare_op == BinaryOperator::NotEq => {
-            let norm_left = normalize_expr(left);
-            let norm_right = normalize_expr(right);
+            let norm_left = normalize_expr(left, ctx);
+            let norm_right = normalize_expr(right, ctx);
             if let Expr::Array(arr) = &norm_right {
                 Expr::InList {
                     expr: Box::new(norm_left),
-                    list: arr.elem.iter().map(normalize_expr).collect(),
+                    list: arr.elem.iter().map(|e| normalize_expr(e, ctx)).collect(),
                     negated: true,
                 }
             } else {
@@ -1431,7 +1745,7 @@ fn normalize_expr(expr: &Expr) -> Expr {
 
         // Normalize Array elements recursively (strips casts inside ARRAY[...])
         Expr::Array(arr) => Expr::Array(sqlparser::ast::Array {
-            elem: arr.elem.iter().map(normalize_expr).collect(),
+            elem: arr.elem.iter().map(|e| normalize_expr(e, ctx)).collect(),
             named: arr.named,
         }),
 
@@ -2621,7 +2935,7 @@ fn try_simplify_scalar_subquery_matches_sqlparser_group_by_variant() {
         panic!("expected Expr::Subquery, got something else");
     };
     assert!(
-        try_simplify_scalar_subquery(&query).is_some(),
+        try_simplify_scalar_subquery(&query, CastCtx::disabled()).is_some(),
         "GROUP BY guard in try_simplify_scalar_subquery did not match sqlparser's AST for: {expr_str}"
     );
 }
@@ -2875,5 +3189,79 @@ fn materialized_view_date_trunc_with_implicit_timestamp_cast() {
     assert!(
         views_semantically_equal(schema_form, db_form),
         "date_trunc with implicit timestamp cast should match source form.\nSchema: {schema_form}\nDB: {db_form}"
+    );
+}
+
+#[cfg(test)]
+fn tables_from_sql(sql: &str) -> std::collections::BTreeMap<String, crate::model::Table> {
+    crate::parser::parse_sql_string(sql)
+        .expect("fixture schema parses")
+        .tables
+}
+
+#[test]
+fn noop_varchar_cast_on_single_table_column_elided() {
+    let tables = tables_from_sql("CREATE TABLE s.t (id bigint, bn varchar(100));");
+    let parsed = "SELECT t1.id, CAST(t1.bn AS varchar(100)) AS bn FROM s.t t1";
+    let introspected = "SELECT t1.id, t1.bn FROM s.t t1";
+    assert!(
+        views_semantically_equal_with_columns(parsed, introspected, &tables, "s"),
+        "A no-op CAST to the column's own declared type should be elided so the view converges"
+    );
+}
+
+#[test]
+fn truncating_varchar_cast_on_single_table_column_preserved() {
+    let tables = tables_from_sql("CREATE TABLE s.t (id bigint, bn varchar(100));");
+    let with_cast = "SELECT t1.id, CAST(t1.bn AS varchar(50)) AS bn FROM s.t t1";
+    let without_cast = "SELECT t1.id, t1.bn FROM s.t t1";
+    assert!(
+        !views_semantically_equal_with_columns(with_cast, without_cast, &tables, "s"),
+        "A truncating cast (target type differs from column type) is real and must be preserved"
+    );
+    assert!(
+        views_semantically_equal_with_columns(with_cast, with_cast, &tables, "s"),
+        "A truncating cast must compare equal to its own form"
+    );
+}
+
+#[test]
+fn join_noop_cast_elided_real_cast_preserved() {
+    let tables = tables_from_sql(
+        "CREATE TABLE s.a (id bigint, name varchar(100));\n\
+         CREATE TABLE s.b (id bigint, code varchar(20));",
+    );
+    let parsed = "SELECT CAST(a.name AS varchar(100)) AS name, CAST(b.code AS varchar(10)) AS code FROM s.a a JOIN s.b b ON a.id = b.id";
+    let introspected =
+        "SELECT a.name, CAST(b.code AS varchar(10)) AS code FROM s.a a JOIN s.b b ON a.id = b.id";
+    assert!(
+        views_semantically_equal_with_columns(parsed, introspected, &tables, "s"),
+        "Across a join, a no-op cast on one column should be elided while a real cast on the other is preserved"
+    );
+}
+
+#[test]
+fn join_ambiguous_bare_column_cast_preserved() {
+    let tables = tables_from_sql(
+        "CREATE TABLE s.a (id bigint, name varchar(100));\n\
+         CREATE TABLE s.b (id bigint, name varchar(100));",
+    );
+    let with_cast =
+        "SELECT CAST(name AS varchar(100)) AS name FROM s.a a JOIN s.b b ON a.id = b.id";
+    let without_cast = "SELECT name FROM s.a a JOIN s.b b ON a.id = b.id";
+    assert!(
+        !views_semantically_equal_with_columns(with_cast, without_cast, &tables, "s"),
+        "A bare column existing in more than one joined table is ambiguous; fail safe and keep the cast"
+    );
+}
+
+#[test]
+fn cast_on_subquery_derived_column_preserved() {
+    let tables = tables_from_sql("CREATE TABLE s.t (id bigint, bn varchar(100));");
+    let with_cast = "SELECT CAST(sub.bn AS varchar(100)) AS bn FROM (SELECT bn FROM s.t) sub";
+    let without_cast = "SELECT sub.bn FROM (SELECT bn FROM s.t) sub";
+    assert!(
+        !views_semantically_equal_with_columns(with_cast, without_cast, &tables, "s"),
+        "A column sourced from a derived table cannot be resolved to a base column; fail safe and keep the cast"
     );
 }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -475,32 +475,36 @@ pub fn normalize_view_query(query: &str) -> String {
 /// available (`tables` is `None`) we never elide a length-qualified cast: keeping
 /// a real cast in place is harmless, while wrongly stripping one causes silent
 /// divergence.
+static EMPTY_SCOPE: ColumnScope = ColumnScope::empty();
+
 #[derive(Clone, Copy)]
-struct CastCtx<'a> {
+struct CastContext<'a> {
     tables: Option<&'a BTreeMap<String, Table>>,
     default_schema: &'a str,
     aliases: &'a ColumnScope,
+    cte_names: &'a [String],
 }
 
-impl CastCtx<'_> {
-    fn disabled() -> CastCtx<'static> {
-        static EMPTY: ColumnScope = ColumnScope::empty();
-        CastCtx {
+impl CastContext<'_> {
+    fn disabled() -> CastContext<'static> {
+        CastContext {
             tables: None,
             default_schema: "public",
-            aliases: &EMPTY,
+            aliases: &EMPTY_SCOPE,
+            cte_names: &[],
         }
     }
 
     /// Replaces the alias scope (used when descending into a SELECT with its own FROM).
-    fn with_scope<'b>(&self, aliases: &'b ColumnScope) -> CastCtx<'b>
+    fn with_scope<'b>(&self, aliases: &'b ColumnScope) -> CastContext<'b>
     where
         Self: 'b,
     {
-        CastCtx {
+        CastContext {
             tables: self.tables,
             default_schema: self.default_schema,
             aliases,
+            cte_names: self.cte_names,
         }
     }
 
@@ -511,12 +515,22 @@ impl CastCtx<'_> {
     fn resolve_column_type(&self, qualifier: Option<&str>, column: &str) -> Option<&PgType> {
         let tables = self.tables?;
         let column = column.to_lowercase();
-        let candidates: Vec<&FromSource> = match qualifier {
-            Some(qual) => self.aliases.matching(qual).into_iter().collect(),
-            None => self.aliases.base_sources(),
+        // A qualifier naming an opaque source (subquery, CTE, nested join) resolves
+        // to no base sources, so the cast is preserved.
+        if let Some(qualifier) = qualifier {
+            if self.aliases.opaque_aliases.iter().any(|a| a == qualifier) {
+                return None;
+            }
+        }
+        let matches_qualifier = |source: &FromSource| match qualifier {
+            None => true,
+            Some(qualifier) => match &source.alias {
+                Some(alias) => alias == qualifier,
+                None => source.table == qualifier,
+            },
         };
         let mut found: Option<&PgType> = None;
-        for source in candidates {
+        for source in self.aliases.base_sources.iter().filter(|s| matches_qualifier(s)) {
             let key = format!("{}.{}", source.schema, source.table);
             let Some(table) = tables.get(&key) else {
                 continue;
@@ -557,34 +571,18 @@ impl ColumnScope {
             opaque_aliases: Vec::new(),
         }
     }
-
-    fn base_sources(&self) -> Vec<&FromSource> {
-        self.base_sources.iter().collect()
-    }
-
-    /// Returns the base sources whose alias (or bare table name when unaliased)
-    /// matches `qualifier`. Empty when the qualifier names an opaque source.
-    fn matching(&self, qualifier: &str) -> Vec<&FromSource> {
-        if self.opaque_aliases.iter().any(|a| a == qualifier) {
-            return Vec::new();
-        }
-        self.base_sources
-            .iter()
-            .filter(|s| match &s.alias {
-                Some(alias) => alias == qualifier,
-                None => s.table == qualifier,
-            })
-            .collect()
-    }
 }
 
-/// Builds the column scope for a SELECT from its FROM clause.
-fn build_column_scope(select: &Select, default_schema: &str) -> ColumnScope {
+/// Builds the column scope for a SELECT from its FROM clause. `cte_names` holds the
+/// lowercased names of every CTE visible in the surrounding query so that a FROM
+/// source naming a CTE is treated as opaque rather than resolved against a base
+/// table of the same name.
+fn build_column_scope(select: &Select, default_schema: &str, cte_names: &[String]) -> ColumnScope {
     let mut scope = ColumnScope::empty();
     for twj in &select.from {
-        collect_table_factor(&twj.relation, default_schema, &mut scope);
+        collect_table_factor(&twj.relation, default_schema, cte_names, &mut scope);
         for join in &twj.joins {
-            collect_table_factor(&join.relation, default_schema, &mut scope);
+            collect_table_factor(&join.relation, default_schema, cte_names, &mut scope);
         }
     }
     scope
@@ -593,6 +591,7 @@ fn build_column_scope(select: &Select, default_schema: &str) -> ColumnScope {
 fn collect_table_factor(
     factor: &sqlparser::ast::TableFactor,
     default_schema: &str,
+    cte_names: &[String],
     scope: &mut ColumnScope,
 ) {
     use sqlparser::ast::TableFactor;
@@ -613,6 +612,17 @@ fn collect_table_factor(
                 [table] => (default_schema.to_lowercase(), table.clone()),
                 _ => return,
             };
+            // An unqualified name matching a CTE references the CTE, whose column
+            // types are unknown. Record it as opaque (keyed by its alias if present,
+            // else the CTE name) so any column off it preserves its cast.
+            if parts.len() == 1 && cte_names.iter().any(|c| c == &table) {
+                let opaque = alias
+                    .as_ref()
+                    .map(|a| a.name.value.to_lowercase())
+                    .unwrap_or(table);
+                scope.opaque_aliases.push(opaque);
+                return;
+            }
             scope.base_sources.push(FromSource {
                 alias: alias.as_ref().map(|a| a.name.value.to_lowercase()),
                 schema,
@@ -629,9 +639,9 @@ fn collect_table_factor(
             table_with_joins,
             alias: None,
         } => {
-            collect_table_factor(&table_with_joins.relation, default_schema, scope);
+            collect_table_factor(&table_with_joins.relation, default_schema, cte_names, scope);
             for join in &table_with_joins.joins {
-                collect_table_factor(&join.relation, default_schema, scope);
+                collect_table_factor(&join.relation, default_schema, cte_names, scope);
             }
         }
         _ => {}
@@ -692,7 +702,7 @@ fn pg_type_matches_cast(pg_type: &PgType, cast_type: &DataType) -> bool {
 /// This is more robust than text normalization because it compares structure, not text.
 /// Falls back to regex-based normalization if parsing fails.
 pub fn views_semantically_equal(query1: &str, query2: &str) -> bool {
-    compare_view_queries(query1, query2, CastCtx::disabled())
+    compare_view_queries(query1, query2, CastContext::disabled())
 }
 
 /// Like [`views_semantically_equal`], but resolves column references against the
@@ -705,16 +715,16 @@ pub fn views_semantically_equal_with_columns(
     tables: &BTreeMap<String, Table>,
     default_schema: &str,
 ) -> bool {
-    static EMPTY: ColumnScope = ColumnScope::empty();
-    let ctx = CastCtx {
+    let cast_context = CastContext {
         tables: Some(tables),
         default_schema,
-        aliases: &EMPTY,
+        aliases: &EMPTY_SCOPE,
+        cte_names: &[],
     };
-    compare_view_queries(query1, query2, ctx)
+    compare_view_queries(query1, query2, cast_context)
 }
 
-fn compare_view_queries(query1: &str, query2: &str, ctx: CastCtx) -> bool {
+fn compare_view_queries(query1: &str, query2: &str, cast_context: CastContext) -> bool {
     let dialect = PostgreSqlDialect {};
 
     let ast1 = Parser::parse_sql(&dialect, query1);
@@ -725,15 +735,78 @@ fn compare_view_queries(query1: &str, query2: &str, ctx: CastCtx) -> bool {
             if stmts1.len() != stmts2.len() {
                 return false;
             }
-            stmts1
-                .into_iter()
-                .zip(stmts2)
-                .all(|(s1, s2)| normalize_statement(&s1, ctx) == normalize_statement(&s2, ctx))
+            stmts1.into_iter().zip(stmts2).all(|(s1, s2)| {
+                let mut cte_names = Vec::new();
+                collect_cte_names_in_statement(&s1, &mut cte_names);
+                collect_cte_names_in_statement(&s2, &mut cte_names);
+                let scoped = CastContext {
+                    cte_names: &cte_names,
+                    ..cast_context
+                };
+                normalize_statement(&s1, scoped) == normalize_statement(&s2, scoped)
+            })
         }
         _ => {
             // Fallback to regex normalization if parsing fails
             normalize_view_query(query1) == normalize_view_query(query2)
         }
+    }
+}
+
+/// Collects every CTE name defined anywhere in a statement (top-level and nested
+/// WITH clauses), lowercased, so FROM sources referencing a CTE can be treated as
+/// opaque rather than resolved against a colliding base table.
+fn collect_cte_names_in_statement(stmt: &Statement, names: &mut Vec<String>) {
+    if let Statement::Query(query) = stmt {
+        collect_cte_names_in_query(query, names);
+    }
+}
+
+fn collect_cte_names_in_query(query: &Query, names: &mut Vec<String>) {
+    if let Some(with) = &query.with {
+        for cte in &with.cte_tables {
+            names.push(cte.alias.name.value.to_lowercase());
+            collect_cte_names_in_query(&cte.query, names);
+        }
+    }
+    collect_cte_names_in_set_expr(&query.body, names);
+}
+
+fn collect_cte_names_in_set_expr(body: &SetExpr, names: &mut Vec<String>) {
+    match body {
+        SetExpr::Select(select) => {
+            for twj in &select.from {
+                collect_cte_names_in_table_factor(&twj.relation, names);
+                for join in &twj.joins {
+                    collect_cte_names_in_table_factor(&join.relation, names);
+                }
+            }
+        }
+        SetExpr::Query(q) => collect_cte_names_in_query(q, names),
+        SetExpr::SetOperation { left, right, .. } => {
+            collect_cte_names_in_set_expr(left, names);
+            collect_cte_names_in_set_expr(right, names);
+        }
+        _ => {}
+    }
+}
+
+fn collect_cte_names_in_table_factor(
+    factor: &sqlparser::ast::TableFactor,
+    names: &mut Vec<String>,
+) {
+    use sqlparser::ast::TableFactor;
+    match factor {
+        TableFactor::Derived { subquery, .. } => collect_cte_names_in_query(subquery, names),
+        TableFactor::NestedJoin {
+            table_with_joins, ..
+        } => {
+            collect_cte_names_in_table_factor(&table_with_joins.relation, names);
+            for join in &table_with_joins.joins {
+                collect_cte_names_in_table_factor(&join.relation, names);
+            }
+        }
+        _ => {}
     }
 }
 
@@ -752,8 +825,8 @@ pub fn expressions_semantically_equal(expr1: &str, expr2: &str) -> bool {
 
     match (parse1, parse2) {
         (Ok(ast1), Ok(ast2)) => {
-            let ctx = CastCtx::disabled();
-            normalize_expr(&ast1, ctx) == normalize_expr(&ast2, ctx)
+            let cast_context = CastContext::disabled();
+            normalize_expr(&ast1, cast_context) == normalize_expr(&ast2, cast_context)
         }
         _ => {
             // Fallback to regex normalization if parsing fails
@@ -773,15 +846,15 @@ pub fn optional_expressions_equal(expr1: &Option<String>, expr2: &Option<String>
 }
 
 /// Normalizes a SQL statement to a canonical form for comparison.
-fn normalize_statement(stmt: &Statement, ctx: CastCtx) -> Statement {
+fn normalize_statement(stmt: &Statement, cast_context: CastContext) -> Statement {
     match stmt {
-        Statement::Query(query) => Statement::Query(Box::new(normalize_query(query, ctx))),
+        Statement::Query(query) => Statement::Query(Box::new(normalize_query(query, cast_context))),
         other => other.clone(),
     }
 }
 
 /// Normalizes a query to canonical form.
-fn normalize_query(query: &Query, ctx: CastCtx) -> Query {
+fn normalize_query(query: &Query, cast_context: CastContext) -> Query {
     Query {
         with: query.with.as_ref().map(|w| sqlparser::ast::With {
             with_token: w.with_token.clone(),
@@ -791,14 +864,14 @@ fn normalize_query(query: &Query, ctx: CastCtx) -> Query {
                 .iter()
                 .map(|cte| sqlparser::ast::Cte {
                     alias: cte.alias.clone(),
-                    query: Box::new(normalize_query(&cte.query, ctx)),
+                    query: Box::new(normalize_query(&cte.query, cast_context)),
                     from: cte.from.clone(),
                     materialized: cte.materialized,
                     closing_paren_token: cte.closing_paren_token.clone(),
                 })
                 .collect(),
         }),
-        body: Box::new(normalize_set_expr(&query.body, ctx)),
+        body: Box::new(normalize_set_expr(&query.body, cast_context)),
         order_by: query.order_by.as_ref().map(normalize_order_by),
         limit_clause: query.limit_clause.clone(),
         fetch: query.fetch.clone(),
@@ -810,10 +883,10 @@ fn normalize_query(query: &Query, ctx: CastCtx) -> Query {
     }
 }
 
-fn normalize_group_by(group_by: &GroupByExpr, ctx: CastCtx) -> GroupByExpr {
+fn normalize_group_by(group_by: &GroupByExpr, cast_context: CastContext) -> GroupByExpr {
     match group_by {
         GroupByExpr::Expressions(exprs, modifiers) => GroupByExpr::Expressions(
-            exprs.iter().map(|e| normalize_expr(e, ctx)).collect(),
+            exprs.iter().map(|e| normalize_expr(e, cast_context)).collect(),
             modifiers.clone(),
         ),
         other => other.clone(),
@@ -821,14 +894,14 @@ fn normalize_group_by(group_by: &GroupByExpr, ctx: CastCtx) -> GroupByExpr {
 }
 
 fn normalize_order_by(order_by: &OrderBy) -> OrderBy {
-    let ctx = CastCtx::disabled();
+    let cast_context = CastContext::disabled();
     OrderBy {
         kind: match &order_by.kind {
             OrderByKind::Expressions(exprs) => OrderByKind::Expressions(
                 exprs
                     .iter()
                     .map(|e| OrderByExpr {
-                        expr: normalize_expr(&e.expr, ctx),
+                        expr: normalize_expr(&e.expr, cast_context),
                         options: normalize_order_by_options(e.options),
                         with_fill: e.with_fill.clone(),
                     })
@@ -864,10 +937,10 @@ fn normalize_order_by_options(opts: OrderByOptions) -> OrderByOptions {
 }
 
 /// Normalizes a set expression (SELECT, UNION, etc).
-fn normalize_set_expr(body: &SetExpr, ctx: CastCtx) -> SetExpr {
+fn normalize_set_expr(body: &SetExpr, cast_context: CastContext) -> SetExpr {
     match body {
-        SetExpr::Select(select) => SetExpr::Select(Box::new(normalize_select(select, ctx))),
-        SetExpr::Query(q) => SetExpr::Query(Box::new(normalize_query(q, ctx))),
+        SetExpr::Select(select) => SetExpr::Select(Box::new(normalize_select(select, cast_context))),
+        SetExpr::Query(q) => SetExpr::Query(Box::new(normalize_query(q, cast_context))),
         SetExpr::SetOperation {
             op,
             set_quantifier,
@@ -876,8 +949,8 @@ fn normalize_set_expr(body: &SetExpr, ctx: CastCtx) -> SetExpr {
         } => SetExpr::SetOperation {
             op: *op,
             set_quantifier: *set_quantifier,
-            left: Box::new(normalize_set_expr(left, ctx)),
-            right: Box::new(normalize_set_expr(right, ctx)),
+            left: Box::new(normalize_set_expr(left, cast_context)),
+            right: Box::new(normalize_set_expr(right, cast_context)),
         },
         other => other.clone(),
     }
@@ -977,11 +1050,11 @@ fn normalize_nextval_args(expr: Expr) -> Expr {
 /// Normalizes a FunctionArgExpr, recursively normalizing contained expressions.
 fn normalize_function_arg_expr(
     arg_expr: &sqlparser::ast::FunctionArgExpr,
-    ctx: CastCtx,
+    cast_context: CastContext,
 ) -> sqlparser::ast::FunctionArgExpr {
     match arg_expr {
         sqlparser::ast::FunctionArgExpr::Expr(e) => {
-            sqlparser::ast::FunctionArgExpr::Expr(normalize_expr(e, ctx))
+            sqlparser::ast::FunctionArgExpr::Expr(normalize_expr(e, cast_context))
         }
         other => other.clone(),
     }
@@ -992,11 +1065,11 @@ fn normalize_function_arg_expr(
 /// including stripping table qualifiers from column references.
 fn normalize_function_arg(
     arg: &sqlparser::ast::FunctionArg,
-    ctx: CastCtx,
+    cast_context: CastContext,
 ) -> sqlparser::ast::FunctionArg {
     match arg {
         sqlparser::ast::FunctionArg::Unnamed(arg_expr) => {
-            sqlparser::ast::FunctionArg::Unnamed(normalize_function_arg_expr(arg_expr, ctx))
+            sqlparser::ast::FunctionArg::Unnamed(normalize_function_arg_expr(arg_expr, cast_context))
         }
         sqlparser::ast::FunctionArg::Named {
             name,
@@ -1004,7 +1077,7 @@ fn normalize_function_arg(
             operator,
         } => sqlparser::ast::FunctionArg::Named {
             name: normalize_ident(name),
-            arg: normalize_function_arg_expr(arg, ctx),
+            arg: normalize_function_arg_expr(arg, cast_context),
             operator: operator.clone(),
         },
         sqlparser::ast::FunctionArg::ExprNamed {
@@ -1012,8 +1085,8 @@ fn normalize_function_arg(
             arg,
             operator,
         } => sqlparser::ast::FunctionArg::ExprNamed {
-            name: normalize_expr(name, ctx),
-            arg: normalize_function_arg_expr(arg, ctx),
+            name: normalize_expr(name, cast_context),
+            arg: normalize_function_arg_expr(arg, cast_context),
             operator: operator.clone(),
         },
     }
@@ -1021,20 +1094,20 @@ fn normalize_function_arg(
 
 fn normalize_window_spec(
     spec: &sqlparser::ast::WindowSpec,
-    ctx: CastCtx,
+    cast_context: CastContext,
 ) -> sqlparser::ast::WindowSpec {
     sqlparser::ast::WindowSpec {
         window_name: spec.window_name.clone(),
         partition_by: spec
             .partition_by
             .iter()
-            .map(|e| normalize_expr(e, ctx))
+            .map(|e| normalize_expr(e, cast_context))
             .collect(),
         order_by: spec
             .order_by
             .iter()
             .map(|e| sqlparser::ast::OrderByExpr {
-                expr: normalize_expr(&e.expr, ctx),
+                expr: normalize_expr(&e.expr, cast_context),
                 options: normalize_order_by_options(e.options),
                 with_fill: e.with_fill.clone(),
             })
@@ -1044,25 +1117,25 @@ fn normalize_window_spec(
             .as_ref()
             .map(|wf| sqlparser::ast::WindowFrame {
                 units: wf.units,
-                start_bound: normalize_window_frame_bound(&wf.start_bound, ctx),
+                start_bound: normalize_window_frame_bound(&wf.start_bound, cast_context),
                 end_bound: wf
                     .end_bound
                     .as_ref()
-                    .map(|b| normalize_window_frame_bound(b, ctx)),
+                    .map(|b| normalize_window_frame_bound(b, cast_context)),
             }),
     }
 }
 
 fn normalize_window_frame_bound(
     bound: &sqlparser::ast::WindowFrameBound,
-    ctx: CastCtx,
+    cast_context: CastContext,
 ) -> sqlparser::ast::WindowFrameBound {
     match bound {
         sqlparser::ast::WindowFrameBound::Preceding(Some(e)) => {
-            sqlparser::ast::WindowFrameBound::Preceding(Some(Box::new(normalize_expr(e, ctx))))
+            sqlparser::ast::WindowFrameBound::Preceding(Some(Box::new(normalize_expr(e, cast_context))))
         }
         sqlparser::ast::WindowFrameBound::Following(Some(e)) => {
-            sqlparser::ast::WindowFrameBound::Following(Some(Box::new(normalize_expr(e, ctx))))
+            sqlparser::ast::WindowFrameBound::Following(Some(Box::new(normalize_expr(e, cast_context))))
         }
         other => other.clone(),
     }
@@ -1071,7 +1144,7 @@ fn normalize_window_frame_bound(
 /// Normalizes a TableFactor (the source in a FROM clause).
 fn normalize_table_factor(
     factor: &sqlparser::ast::TableFactor,
-    ctx: CastCtx,
+    cast_context: CastContext,
 ) -> sqlparser::ast::TableFactor {
     use sqlparser::ast::TableFactor;
     match factor {
@@ -1109,7 +1182,7 @@ fn normalize_table_factor(
             sample,
         } => TableFactor::Derived {
             lateral: *lateral,
-            subquery: Box::new(normalize_query(subquery, ctx)),
+            subquery: Box::new(normalize_query(subquery, cast_context)),
             alias: alias.as_ref().map(|a| sqlparser::ast::TableAlias {
                 name: normalize_ident(&a.name),
                 explicit: a.explicit,
@@ -1124,7 +1197,7 @@ fn normalize_table_factor(
             table_with_joins,
             alias,
         } => {
-            let normalized_twj = normalize_table_with_joins(table_with_joins, ctx);
+            let normalized_twj = normalize_table_with_joins(table_with_joins, cast_context);
             // If there are no joins, just return the relation (unwrap parens)
             if normalized_twj.joins.is_empty() {
                 let mut inner = normalized_twj.relation;
@@ -1163,7 +1236,7 @@ fn normalize_table_factor(
 /// Also unwraps NestedJoin when PostgreSQL wraps entire JOINs in parentheses.
 fn normalize_table_with_joins(
     twj: &sqlparser::ast::TableWithJoins,
-    ctx: CastCtx,
+    cast_context: CastContext,
 ) -> sqlparser::ast::TableWithJoins {
     // If the relation is a NestedJoin without an alias, flatten it by combining joins
     // PostgreSQL stores `((A JOIN B) JOIN C)` as NestedJoin { inner: {A, [B]}, joins: [C] }
@@ -1175,11 +1248,11 @@ fn normalize_table_with_joins(
     {
         if alias.is_none() {
             // Recursively normalize the inner TableWithJoins first
-            let normalized_inner = normalize_table_with_joins(inner_twj, ctx);
+            let normalized_inner = normalize_table_with_joins(inner_twj, cast_context);
 
             // Normalize outer joins
             let normalized_outer_joins: Vec<_> =
-                twj.joins.iter().map(|j| normalize_join(j, ctx)).collect();
+                twj.joins.iter().map(|j| normalize_join(j, cast_context)).collect();
 
             // Combine: inner joins first, then outer joins
             let mut combined_joins = normalized_inner.joins;
@@ -1193,21 +1266,21 @@ fn normalize_table_with_joins(
     }
 
     // Standard case: normalize relation and joins separately
-    let normalized_relation = normalize_table_factor(&twj.relation, ctx);
+    let normalized_relation = normalize_table_factor(&twj.relation, cast_context);
 
     sqlparser::ast::TableWithJoins {
         relation: normalized_relation,
-        joins: twj.joins.iter().map(|j| normalize_join(j, ctx)).collect(),
+        joins: twj.joins.iter().map(|j| normalize_join(j, cast_context)).collect(),
     }
 }
 
 /// Normalizes a single Join.
-fn normalize_join(j: &sqlparser::ast::Join, ctx: CastCtx) -> sqlparser::ast::Join {
+fn normalize_join(j: &sqlparser::ast::Join, cast_context: CastContext) -> sqlparser::ast::Join {
     use sqlparser::ast::{Join, JoinOperator};
     let normalize_constraint =
-        |c: &sqlparser::ast::JoinConstraint| normalize_join_constraint(c, ctx);
+        |c: &sqlparser::ast::JoinConstraint| normalize_join_constraint(c, cast_context);
     Join {
-        relation: normalize_table_factor(&j.relation, ctx),
+        relation: normalize_table_factor(&j.relation, cast_context),
         global: j.global,
         join_operator: match &j.join_operator {
             JoinOperator::Join(c) | JoinOperator::Inner(c) => {
@@ -1228,11 +1301,11 @@ fn normalize_join(j: &sqlparser::ast::Join, ctx: CastCtx) -> sqlparser::ast::Joi
 /// Normalizes a JoinConstraint.
 fn normalize_join_constraint(
     constraint: &sqlparser::ast::JoinConstraint,
-    ctx: CastCtx,
+    cast_context: CastContext,
 ) -> sqlparser::ast::JoinConstraint {
     use sqlparser::ast::JoinConstraint;
     match constraint {
-        JoinConstraint::On(expr) => JoinConstraint::On(normalize_expr(expr, ctx)),
+        JoinConstraint::On(expr) => JoinConstraint::On(normalize_expr(expr, cast_context)),
         JoinConstraint::Using(names) => {
             JoinConstraint::Using(names.iter().map(normalize_object_name).collect())
         }
@@ -1260,7 +1333,7 @@ fn normalize_data_type(data_type: &DataType) -> DataType {
 ///
 /// Detects that pattern and reduces it back to the bare function call so that
 /// both forms compare as equal.
-fn try_simplify_scalar_subquery(query: &Query, ctx: CastCtx) -> Option<Expr> {
+fn try_simplify_scalar_subquery(query: &Query, cast_context: CastContext) -> Option<Expr> {
     if query.with.is_some() || query.order_by.is_some() || query.limit_clause.is_some() {
         return None;
     }
@@ -1291,13 +1364,13 @@ fn try_simplify_scalar_subquery(query: &Query, ctx: CastCtx) -> Option<Expr> {
     if !matches!(expr, Expr::Function(_)) {
         return None;
     }
-    Some(normalize_expr(expr, ctx))
+    Some(normalize_expr(expr, cast_context))
 }
 
 /// Normalizes a SELECT statement.
-fn normalize_select(select: &Select, ctx: CastCtx) -> Select {
-    let scope = build_column_scope(select, ctx.default_schema);
-    let scoped = ctx.with_scope(&scope);
+fn normalize_select(select: &Select, cast_context: CastContext) -> Select {
+    let scope = build_column_scope(select, cast_context.default_schema, cast_context.cte_names);
+    let scoped = cast_context.with_scope(&scope);
     Select {
         select_token: select.select_token.clone(),
         distinct: select.distinct.clone(),
@@ -1313,7 +1386,7 @@ fn normalize_select(select: &Select, ctx: CastCtx) -> Select {
         from: select
             .from
             .iter()
-            .map(|twj| normalize_table_with_joins(twj, ctx))
+            .map(|twj| normalize_table_with_joins(twj, cast_context))
             .collect(),
         lateral_views: select.lateral_views.clone(),
         prewhere: select.prewhere.as_ref().map(|e| normalize_expr(e, scoped)),
@@ -1340,13 +1413,13 @@ fn normalize_select(select: &Select, ctx: CastCtx) -> Select {
 /// adding an alias matching the function name.
 fn normalize_select_item(
     item: &sqlparser::ast::SelectItem,
-    ctx: CastCtx,
+    cast_context: CastContext,
 ) -> sqlparser::ast::SelectItem {
     use sqlparser::ast::SelectItem;
     match item {
-        SelectItem::UnnamedExpr(e) => SelectItem::UnnamedExpr(normalize_expr(e, ctx)),
+        SelectItem::UnnamedExpr(e) => SelectItem::UnnamedExpr(normalize_expr(e, cast_context)),
         SelectItem::ExprWithAlias { expr, alias } => {
-            let normalized_expr = normalize_expr(expr, ctx);
+            let normalized_expr = normalize_expr(expr, cast_context);
             if is_auto_generated_alias(&normalized_expr, alias) {
                 SelectItem::UnnamedExpr(normalized_expr)
             } else {
@@ -1387,15 +1460,15 @@ fn is_auto_generated_alias(expr: &Expr, alias: &sqlparser::ast::Ident) -> bool {
 /// - Convert <> ALL(ARRAY[...]) to NOT IN (...)
 /// - Strip ::text casts from string literals
 /// - Normalize FILTER clauses on aggregate functions
-fn normalize_expr(expr: &Expr, ctx: CastCtx) -> Expr {
+fn normalize_expr(expr: &Expr, cast_context: CastContext) -> Expr {
     match expr {
         // Unwrap nested expressions (parentheses)
-        Expr::Nested(inner) => normalize_expr(inner, ctx),
+        Expr::Nested(inner) => normalize_expr(inner, cast_context),
 
         // Convert PostgreSQL ~~ operator to LIKE
         Expr::BinaryOp { left, op, right } => {
-            let norm_left = normalize_expr(left, ctx);
-            let norm_right = normalize_expr(right, ctx);
+            let norm_left = normalize_expr(left, cast_context);
+            let norm_right = normalize_expr(right, cast_context);
 
             match op {
                 BinaryOperator::PGLikeMatch => Expr::Like {
@@ -1445,7 +1518,7 @@ fn normalize_expr(expr: &Expr, ctx: CastCtx) -> Expr {
             // qualifier, so a no-op cast to the column's own declared type can be
             // resolved against the FROM clause and elided.
             let column_ref = column_reference_parts(inner);
-            let norm_inner = normalize_expr(inner, ctx);
+            let norm_inner = normalize_expr(inner, cast_context);
             let norm_data_type = normalize_data_type(data_type);
             if matches!(norm_data_type, DataType::Text) {
                 return norm_inner;
@@ -1464,7 +1537,7 @@ fn normalize_expr(expr: &Expr, ctx: CastCtx) -> Expr {
             // column against the FROM clause; elide only on an exact match,
             // otherwise preserve the cast (it is real, e.g. a truncating cast).
             if let Some((qualifier, column)) = &column_ref {
-                if let Some(pg_type) = ctx.resolve_column_type(qualifier.as_deref(), column) {
+                if let Some(pg_type) = cast_context.resolve_column_type(qualifier.as_deref(), column) {
                     if pg_type_matches_cast(pg_type, &norm_data_type) {
                         return norm_inner;
                     }
@@ -1509,14 +1582,14 @@ fn normalize_expr(expr: &Expr, ctx: CastCtx) -> Expr {
         }
 
         Expr::Subquery(q) => {
-            if let Some(simplified) = try_simplify_scalar_subquery(q, ctx) {
+            if let Some(simplified) = try_simplify_scalar_subquery(q, cast_context) {
                 simplified
             } else {
-                Expr::Subquery(Box::new(normalize_query(q, ctx)))
+                Expr::Subquery(Box::new(normalize_query(q, cast_context)))
             }
         }
         Expr::Exists { subquery, negated } => Expr::Exists {
-            subquery: Box::new(normalize_query(subquery, ctx)),
+            subquery: Box::new(normalize_query(subquery, cast_context)),
             negated: *negated,
         },
         Expr::InSubquery {
@@ -1524,8 +1597,8 @@ fn normalize_expr(expr: &Expr, ctx: CastCtx) -> Expr {
             subquery,
             negated,
         } => Expr::InSubquery {
-            expr: Box::new(normalize_expr(inner, ctx)),
-            subquery: Box::new(normalize_query(subquery, ctx)),
+            expr: Box::new(normalize_expr(inner, cast_context)),
+            subquery: Box::new(normalize_query(subquery, cast_context)),
             negated: *negated,
         },
 
@@ -1538,8 +1611,8 @@ fn normalize_expr(expr: &Expr, ctx: CastCtx) -> Expr {
         } => Expr::Like {
             negated: *negated,
             any: *any,
-            expr: Box::new(normalize_expr(inner, ctx)),
-            pattern: Box::new(normalize_expr(pattern, ctx)),
+            expr: Box::new(normalize_expr(inner, cast_context)),
+            pattern: Box::new(normalize_expr(pattern, cast_context)),
             escape_char: escape_char.clone(),
         },
         Expr::ILike {
@@ -1551,8 +1624,8 @@ fn normalize_expr(expr: &Expr, ctx: CastCtx) -> Expr {
         } => Expr::ILike {
             negated: *negated,
             any: *any,
-            expr: Box::new(normalize_expr(inner, ctx)),
-            pattern: Box::new(normalize_expr(pattern, ctx)),
+            expr: Box::new(normalize_expr(inner, cast_context)),
+            pattern: Box::new(normalize_expr(pattern, cast_context)),
             escape_char: escape_char.clone(),
         },
 
@@ -1565,17 +1638,17 @@ fn normalize_expr(expr: &Expr, ctx: CastCtx) -> Expr {
         } => Expr::Case {
             case_token: case_token.clone(),
             end_token: end_token.clone(),
-            operand: operand.as_ref().map(|e| Box::new(normalize_expr(e, ctx))),
+            operand: operand.as_ref().map(|e| Box::new(normalize_expr(e, cast_context))),
             conditions: conditions
                 .iter()
                 .map(|cw| sqlparser::ast::CaseWhen {
-                    condition: normalize_expr(&cw.condition, ctx),
-                    result: normalize_expr(&cw.result, ctx),
+                    condition: normalize_expr(&cw.condition, cast_context),
+                    result: normalize_expr(&cw.result, cast_context),
                 })
                 .collect(),
             else_result: else_result
                 .as_ref()
-                .map(|e| Box::new(normalize_expr(e, ctx))),
+                .map(|e| Box::new(normalize_expr(e, cast_context))),
         },
 
         Expr::Function(f) => {
@@ -1588,17 +1661,17 @@ fn normalize_expr(expr: &Expr, ctx: CastCtx) -> Expr {
                         args: args
                             .args
                             .iter()
-                            .map(|a| normalize_function_arg(a, ctx))
+                            .map(|a| normalize_function_arg(a, cast_context))
                             .collect(),
                         clauses: args.clauses.clone(),
                     })
                 }
                 other => other.clone(),
             };
-            func.filter = f.filter.as_ref().map(|e| Box::new(normalize_expr(e, ctx)));
+            func.filter = f.filter.as_ref().map(|e| Box::new(normalize_expr(e, cast_context)));
             func.over = f.over.as_ref().map(|w| match w {
                 sqlparser::ast::WindowType::WindowSpec(spec) => {
-                    sqlparser::ast::WindowType::WindowSpec(normalize_window_spec(spec, ctx))
+                    sqlparser::ast::WindowType::WindowSpec(normalize_window_spec(spec, cast_context))
                 }
                 other => other.clone(),
             });
@@ -1606,7 +1679,7 @@ fn normalize_expr(expr: &Expr, ctx: CastCtx) -> Expr {
         }
 
         Expr::UnaryOp { op, expr: inner } => {
-            let norm_inner = normalize_expr(inner, ctx);
+            let norm_inner = normalize_expr(inner, cast_context);
             // Normalize NOT (EXISTS ...) → EXISTS { negated: true }
             if matches!(op, sqlparser::ast::UnaryOperator::Not) {
                 if let Expr::Exists {
@@ -1631,8 +1704,8 @@ fn normalize_expr(expr: &Expr, ctx: CastCtx) -> Expr {
             list,
             negated,
         } => Expr::InList {
-            expr: Box::new(normalize_expr(inner, ctx)),
-            list: list.iter().map(|e| normalize_expr(e, ctx)).collect(),
+            expr: Box::new(normalize_expr(inner, cast_context)),
+            list: list.iter().map(|e| normalize_expr(e, cast_context)).collect(),
             negated: *negated,
         },
 
@@ -1642,22 +1715,22 @@ fn normalize_expr(expr: &Expr, ctx: CastCtx) -> Expr {
             low,
             high,
         } => Expr::Between {
-            expr: Box::new(normalize_expr(inner, ctx)),
+            expr: Box::new(normalize_expr(inner, cast_context)),
             negated: *negated,
-            low: Box::new(normalize_expr(low, ctx)),
-            high: Box::new(normalize_expr(high, ctx)),
+            low: Box::new(normalize_expr(low, cast_context)),
+            high: Box::new(normalize_expr(high, cast_context)),
         },
 
-        Expr::IsNull(inner) => Expr::IsNull(Box::new(normalize_expr(inner, ctx))),
-        Expr::IsNotNull(inner) => Expr::IsNotNull(Box::new(normalize_expr(inner, ctx))),
+        Expr::IsNull(inner) => Expr::IsNull(Box::new(normalize_expr(inner, cast_context))),
+        Expr::IsNotNull(inner) => Expr::IsNotNull(Box::new(normalize_expr(inner, cast_context))),
 
         Expr::IsDistinctFrom(left, right) => Expr::IsDistinctFrom(
-            Box::new(normalize_expr(left, ctx)),
-            Box::new(normalize_expr(right, ctx)),
+            Box::new(normalize_expr(left, cast_context)),
+            Box::new(normalize_expr(right, cast_context)),
         ),
         Expr::IsNotDistinctFrom(left, right) => Expr::IsNotDistinctFrom(
-            Box::new(normalize_expr(left, ctx)),
-            Box::new(normalize_expr(right, ctx)),
+            Box::new(normalize_expr(left, cast_context)),
+            Box::new(normalize_expr(right, cast_context)),
         ),
 
         // Normalize CompoundIdentifier (lowercase for case-insensitive comparison)
@@ -1701,12 +1774,12 @@ fn normalize_expr(expr: &Expr, ctx: CastCtx) -> Expr {
             right,
             ..
         } if *compare_op == BinaryOperator::Eq => {
-            let norm_left = normalize_expr(left, ctx);
-            let norm_right = normalize_expr(right, ctx);
+            let norm_left = normalize_expr(left, cast_context);
+            let norm_right = normalize_expr(right, cast_context);
             if let Expr::Array(arr) = &norm_right {
                 Expr::InList {
                     expr: Box::new(norm_left),
-                    list: arr.elem.iter().map(|e| normalize_expr(e, ctx)).collect(),
+                    list: arr.elem.iter().map(|e| normalize_expr(e, cast_context)).collect(),
                     negated: false,
                 }
             } else {
@@ -1726,12 +1799,12 @@ fn normalize_expr(expr: &Expr, ctx: CastCtx) -> Expr {
             compare_op,
             right,
         } if *compare_op == BinaryOperator::NotEq => {
-            let norm_left = normalize_expr(left, ctx);
-            let norm_right = normalize_expr(right, ctx);
+            let norm_left = normalize_expr(left, cast_context);
+            let norm_right = normalize_expr(right, cast_context);
             if let Expr::Array(arr) = &norm_right {
                 Expr::InList {
                     expr: Box::new(norm_left),
-                    list: arr.elem.iter().map(|e| normalize_expr(e, ctx)).collect(),
+                    list: arr.elem.iter().map(|e| normalize_expr(e, cast_context)).collect(),
                     negated: true,
                 }
             } else {
@@ -1745,7 +1818,7 @@ fn normalize_expr(expr: &Expr, ctx: CastCtx) -> Expr {
 
         // Normalize Array elements recursively (strips casts inside ARRAY[...])
         Expr::Array(arr) => Expr::Array(sqlparser::ast::Array {
-            elem: arr.elem.iter().map(|e| normalize_expr(e, ctx)).collect(),
+            elem: arr.elem.iter().map(|e| normalize_expr(e, cast_context)).collect(),
             named: arr.named,
         }),
 
@@ -2935,7 +3008,7 @@ fn try_simplify_scalar_subquery_matches_sqlparser_group_by_variant() {
         panic!("expected Expr::Subquery, got something else");
     };
     assert!(
-        try_simplify_scalar_subquery(&query, CastCtx::disabled()).is_some(),
+        try_simplify_scalar_subquery(&query, CastContext::disabled()).is_some(),
         "GROUP BY guard in try_simplify_scalar_subquery did not match sqlparser's AST for: {expr_str}"
     );
 }
@@ -3263,5 +3336,20 @@ fn cast_on_subquery_derived_column_preserved() {
     assert!(
         !views_semantically_equal_with_columns(with_cast, without_cast, &tables, "s"),
         "A column sourced from a derived table cannot be resolved to a base column; fail safe and keep the cast"
+    );
+}
+
+#[test]
+fn cast_on_cte_backed_column_preserved_even_when_colliding_base_table_exists() {
+    // A real base table named `cte` exists in the same schema with a varchar(100)
+    // `bn` column. The CTE shadows it: the CTE's `bn` may have a different type, so
+    // the cast must be preserved rather than resolved against the colliding table.
+    let tables = tables_from_sql("CREATE TABLE s.cte (bn varchar(100));");
+    let with_cast = "WITH cte AS (SELECT bn FROM s.t) SELECT CAST(cte.bn AS varchar(100)) AS bn FROM cte";
+    let without_cast = "WITH cte AS (SELECT bn FROM s.t) SELECT cte.bn FROM cte";
+    assert_eq!(
+        views_semantically_equal_with_columns(with_cast, without_cast, &tables, "s"),
+        false,
+        "A CTE name shadows a colliding base table; its columns are opaque so the cast must be preserved"
     );
 }

--- a/tests/convergence.rs
+++ b/tests/convergence.rs
@@ -1343,3 +1343,45 @@ async fn index_with_64_byte_name_converges() {
     );
     assert_convergence_public(&sql).await;
 }
+
+#[tokio::test]
+async fn view_with_noop_cast_on_column_converges() {
+    assert_convergence_public(
+        r#"
+        CREATE TABLE public.t (
+            id BIGSERIAL PRIMARY KEY,
+            bn VARCHAR(100) NOT NULL
+        );
+
+        CREATE VIEW public.v AS
+            SELECT t1.id, CAST(t1.bn AS VARCHAR(100)) AS bn
+            FROM public.t t1;
+        "#,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn view_with_join_noop_and_real_casts_converges() {
+    assert_convergence_public(
+        r#"
+        CREATE TABLE public.a (
+            id   BIGSERIAL PRIMARY KEY,
+            name VARCHAR(100) NOT NULL
+        );
+
+        CREATE TABLE public.b (
+            id   BIGINT PRIMARY KEY,
+            code VARCHAR(20) NOT NULL
+        );
+
+        CREATE VIEW public.ab AS
+            SELECT
+                CAST(a.name AS VARCHAR(100)) AS name,
+                CAST(b.code AS VARCHAR(10)) AS code
+            FROM public.a a
+            JOIN public.b b ON a.id = b.id;
+        "#,
+    )
+    .await;
+}


### PR DESCRIPTION
Fixes #338

## Root cause

PostgreSQL elides a `CAST(col AS T)` in a stored view definition only when it is a true no-op, meaning `T` equals the referenced column's declared type. pgmold introspected the view as PG deparses it (cast removed) but kept the parsed source verbatim, so the diff saw the two bodies as different and emitted a spurious `CREATE OR REPLACE VIEW` on every plan. A cast to a *different* type (for example a truncating `varchar(50)` on a `varchar(100)` column) is real and PG keeps it, so unconditional cast-stripping would have created the inverse non-convergence.

## Resolver design

The view-body normalizer now resolves each cast's column against the FROM clause:

1. Walk the SELECT's FROM/JOIN to build a per-SELECT scope: a map of base-table source (alias or bare table name) to `(schema, table)`. Derived tables (subqueries) and parenthesized aliased joins are recorded as opaque so nothing resolves through them.
2. For a cast on a column reference, capture the qualifier and column name *before* normalization strips the qualifier.
3. Look up the column's declared `PgType` from the schema being compared (threaded in through the new `View::semantically_equals_with_tables`, called from `diff_views` with the source schema's tables).
4. Elide the cast only when the column's declared type, compared structurally against the cast target type, is an exact no-op match.

## Fail-safe behavior

Resolution returns "preserve the cast" whenever it cannot prove a no-op:

- bare column existing in more than one joined table (ambiguous),
- column sourced from a subquery / derived table,
- table or type not resolvable.

Preserving a real cast is harmless; wrongly stripping one would cause silent divergence, so the conservative default is to keep the cast.

## Tests (failing first, then passing)

Unit tests in `src/util/mod.rs`:
- single-table no-op `varchar(100)` cast elided,
- truncating `varchar(50)` cast preserved,
- join: no-op cast on one column elided, real cast on the other preserved,
- join ambiguity: bare column in both tables keeps the cast,
- derived-table column keeps the cast,
- char(n) no-op elided / truncating char(n) preserved,
- boolean and uuid no-op casts elided,
- CTE-named FROM source keeps the cast even when a real base table of the same qualified name exists (soundness: a CTE shadows the base table; its column types are unknown).

Integration convergence tests in `tests/convergence.rs` (single-table and join variants). The existing length-qualified-cast protective tests still pass.

`cargo test --lib`: 1338 passed, 0 failed.

## Live verification

Against a local Postgres (Docker image pulls are unavailable in this environment, so the testcontainers integration suite was not run locally; CI runs it).

Baseline (released pgmold 0.33.1), after apply + re-plan:
```
Migration plan (1 statements):
CREATE OR REPLACE VIEW "s"."v" AS SELECT t1.id, CAST(t1.bn AS VARCHAR(100)) AS bn FROM s.t t1;
```

This branch, single-table repro after apply + re-plan:
```
No changes required.
```

This branch, join repro (no-op cast on `a.name`, truncating cast on `b.code`) after apply + re-plan:
```
No changes required.
```

PG's stored definition for the join view confirms only the real cast survives:
```
SELECT a.name,
    b.code::character varying(10) AS code
   FROM s.a a
     JOIN s.b b ON a.id = b.id;
```


## Known limitation

Only `varchar(n)` and `char(n)` length-qualified casts (and the bare `boolean`/`uuid` scalar arms) are elided. Other precision-qualified casts, notably `numeric(p,s)`, are stored without precision on `PgType` and stay preserved. Tracked in #340.

<!-- archie:start -->

## Diagram Analysis

### View comparison flow

How a stored view body reaches the cast-elision decision during diffing.

```mermaid
flowchart TD
    A[diff_views] --> B[View::semantically_equals_with_tables]
    B --> C[views_semantically_equal_with_columns]
    C --> D[normalize_select: build FROM-clause scope]
    D --> E[normalize_expr: Cast arm]
    E --> F[resolve_column_type against scope and tables]
    F --> G{Cast target equals column type?}
    G -->|Yes, no-op| H[Elide cast]
    G -->|No, or unresolved| I[Preserve cast]
    H --> J[Bodies compare equal: no migration]
    I --> J
```

### Cast elision decision

When a cast is dropped versus kept, including the fail-safe paths.

```mermaid
flowchart TD
    A[CAST col AS T on a column reference] --> B{Column resolves to one base table?}
    B -->|Ambiguous bare column| K[Preserve cast]
    B -->|From subquery / derived table| K
    B -->|Table or type unresolved| K
    B -->|Exactly one base column| C{T equals declared type?}
    C -->|Equal: true no-op| D[Elide cast]
    C -->|Differs: truncating / real cast| K
```
<!-- archie:end -->

