### PR TITLE
chore: bump version to 0.34.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1587,7 +1587,7 @@ dependencies = [
 
 [[package]]
 name = "pgmold"
-version = "0.34.13"
+version = "0.34.14"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "pgmold"
-version = "0.34.13"
+version = "0.34.14"
 edition = "2021"
 exclude = [".auto-claude/", ".auto-claude-security.json", ".claude_settings.json"]
 description = "PostgreSQL schema-as-code management tool"


### PR DESCRIPTION
release 0.34.14.

changes since 0.34.13:
- fix(diff): elide no-op column casts in view bodies via FROM-clause type resolution, so a view like `CAST(col AS varchar(100))` on a varchar(100) column converges instead of emitting a spurious CREATE OR REPLACE VIEW (#339, fixes #338). resolves casts across joins and fails safe (preserves the cast) on ambiguous or derived columns.

known limitation tracked in #340: no-op numeric(p,s) casts are not yet elided.