### PR TITLE
fix(parser): truncate object and column names at NAMEDATALEN-1

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -117,7 +117,8 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
     for statement in statements {
         match statement {
             Statement::CreateTable(ct) => {
-                let (table_schema, table_name) = extract_qualified_name(&ct.name);
+                let (table_schema, raw_table_name) = extract_qualified_name(&ct.name);
+                let table_name = truncate_identifier(&raw_table_name);
 
                 if let Some(ref parent_table) = ct.partition_of {
                     let (parent_schema, parent_name) = extract_qualified_name(parent_table);
@@ -188,7 +189,8 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
                 representation: Some(UserDefinedTypeRepresentation::Enum { labels }),
                 ..
             } => {
-                let (enum_schema, enum_name) = extract_qualified_name(&name);
+                let (enum_schema, raw_enum_name) = extract_qualified_name(&name);
+                let enum_name = truncate_identifier(&raw_enum_name);
                 let enum_type = EnumType {
                     schema: enum_schema.clone(),
                     name: enum_name.clone(),
@@ -455,8 +457,10 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
                             new_column_name,
                         } => {
                             if let Some(table) = schema.tables.get_mut(&tbl_key) {
-                                let old_name = unquote_ident(&old_column_name.value).to_string();
-                                let new_name = unquote_ident(&new_column_name.value).to_string();
+                                let old_name =
+                                    truncate_identifier(unquote_ident(&old_column_name.value));
+                                let new_name =
+                                    truncate_identifier(unquote_ident(&new_column_name.value));
 
                                 if let Some(mut column) = table.columns.remove(&old_name) {
                                     column.name = new_name.clone();
@@ -692,7 +696,8 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
                 set_params,
                 ..
             }) => {
-                let (func_schema, func_name) = extract_qualified_name(&name);
+                let (func_schema, raw_func_name) = extract_qualified_name(&name);
+                let func_name = truncate_identifier(&raw_func_name);
                 let func = parse_create_function(
                     &func_schema,
                     &func_name,
@@ -713,7 +718,8 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
                 materialized,
                 ..
             }) => {
-                let (view_schema, view_name) = extract_qualified_name(&name);
+                let (view_schema, raw_view_name) = extract_qualified_name(&name);
+                let view_name = truncate_identifier(&raw_view_name);
                 let view = View {
                     schema: view_schema.clone(),
                     name: view_name.clone(),
@@ -774,7 +780,8 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
                 default,
                 constraints,
             }) => {
-                let (domain_schema, domain_name) = extract_qualified_name(&name);
+                let (domain_schema, raw_domain_name) = extract_qualified_name(&name);
+                let domain_name = truncate_identifier(&raw_domain_name);
                 let pg_type = parse_data_type(&data_type)?;
 
                 let mut not_null = false;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -425,7 +425,7 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
                             if let Some(table) = schema.tables.get_mut(&tbl_key) {
                                 let names_to_drop: Vec<String> = column_names
                                     .iter()
-                                    .map(|n| unquote_ident(&n.value).to_string())
+                                    .map(|n| truncate_identifier(unquote_ident(&n.value)))
                                     .collect();
                                 table
                                     .columns
@@ -435,13 +435,13 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
                         AlterTableOperation::RenameTable { table_name } => {
                             let new_name = match table_name {
                                 RenameTableNameKind::As(obj) | RenameTableNameKind::To(obj) => {
-                                    let (new_schema, new_tbl) = extract_qualified_name(&obj);
+                                    let (new_schema, raw_new_tbl) = extract_qualified_name(&obj);
                                     let effective_schema = if obj.0.len() == 1 {
                                         tbl_schema.clone()
                                     } else {
                                         new_schema
                                     };
-                                    (effective_schema, new_tbl)
+                                    (effective_schema, truncate_identifier(&raw_new_tbl))
                                 }
                             };
                             let new_key = qualified_name(&new_name.0, &new_name.1);
@@ -457,10 +457,8 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
                             new_column_name,
                         } => {
                             if let Some(table) = schema.tables.get_mut(&tbl_key) {
-                                let old_name =
-                                    truncate_identifier(unquote_ident(&old_column_name.value));
-                                let new_name =
-                                    truncate_identifier(unquote_ident(&new_column_name.value));
+                                let old_name = truncated_ident(&old_column_name);
+                                let new_name = truncated_ident(&new_column_name);
 
                                 if let Some(mut column) = table.columns.remove(&old_name) {
                                     column.name = new_name.clone();

--- a/src/parser/tables.rs
+++ b/src/parser/tables.rs
@@ -16,7 +16,7 @@ use std::collections::BTreeMap;
 
 use super::util::{
     extract_qualified_name, normalize_expr, parse_data_type, truncate_identifier,
-    truncate_to_bytes, unquote_ident, PG_MAX_IDENTIFIER_LENGTH,
+    truncate_to_bytes, truncated_ident, unquote_ident, PG_MAX_IDENTIFIER_LENGTH,
 };
 
 pub(super) struct ParsedTable {
@@ -60,7 +60,7 @@ pub(super) fn parse_create_table(
     }
 
     for col_def in columns {
-        let col_name = truncate_identifier(unquote_ident(&col_def.name.to_string()));
+        let col_name = truncated_ident(&col_def.name);
         for option in &col_def.options {
             let explicit_name = option
                 .name
@@ -363,7 +363,7 @@ pub(super) fn parse_column_with_serial(
         }
     }
 
-    let col_name = truncate_identifier(unquote_ident(&col_def.name.to_string()));
+    let col_name = truncated_ident(&col_def.name);
 
     if generated.is_some() {
         let column = Column {
@@ -462,11 +462,7 @@ pub(super) fn detect_serial_type(dt: &DataType) -> Option<SequenceDataType> {
 /// `ALTER TABLE ... ADD CONSTRAINT ... PRIMARY KEY (...)` — to the given table,
 /// populating `table.primary_key` and flipping the referenced columns to NOT NULL.
 pub(super) fn apply_primary_key(table: &mut Table, pk: &PrimaryKeyConstraint) {
-    let pk_columns: Vec<String> = pk
-        .columns
-        .iter()
-        .map(|c| unquote_ident(&c.to_string()).to_string())
-        .collect();
+    let pk_columns: Vec<String> = pk.columns.iter().map(truncated_ident).collect();
     for pk_col in &pk_columns {
         if let Some(col) = table.columns.get_mut(pk_col) {
             col.nullable = false;

--- a/src/parser/tables.rs
+++ b/src/parser/tables.rs
@@ -60,7 +60,7 @@ pub(super) fn parse_create_table(
     }
 
     for col_def in columns {
-        let col_name = unquote_ident(&col_def.name.to_string()).to_string();
+        let col_name = truncate_identifier(unquote_ident(&col_def.name.to_string()));
         for option in &col_def.options {
             let explicit_name = option
                 .name
@@ -363,7 +363,7 @@ pub(super) fn parse_column_with_serial(
         }
     }
 
-    let col_name = unquote_ident(&col_def.name.to_string()).to_string();
+    let col_name = truncate_identifier(unquote_ident(&col_def.name.to_string()));
 
     if generated.is_some() {
         let column = Column {

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -5655,8 +5655,6 @@ fn create_table_truncates_multibyte_table_name_at_char_boundary() {
     assert_eq!(truncated.len(), 62);
     let table = schema.tables.get(&format!("public.{truncated}")).unwrap();
     assert_eq!(table.name, truncated);
-    assert!(table.name.len() <= 63);
-    assert!(table.name.is_char_boundary(table.name.len()));
 }
 
 #[test]
@@ -5782,4 +5780,75 @@ fn alter_table_rename_column_matches_already_truncated_old_name() {
     assert!(table.columns.contains_key("renamed"));
     assert!(!table.columns.contains_key(&truncated_old));
     assert_eq!(table.columns.get("renamed").unwrap().name, "renamed");
+}
+
+#[test]
+fn drop_column_with_64_byte_name_removes_column() {
+    // A 64-char column name is stored truncated to 63 bytes at creation time. DROP COLUMN
+    // naming the 64-char form must match the stored 63-byte key, so the drop name needs the
+    // same truncation before lookup.
+    let long_col = "c".repeat(64);
+    let sql = format!(
+        r#"
+        CREATE TABLE t (id BIGINT NOT NULL, "{long_col}" TEXT);
+        ALTER TABLE t DROP COLUMN "{long_col}";
+        "#
+    );
+    let schema = parse_sql_string(&sql).unwrap();
+    let truncated = "c".repeat(63);
+    let table = schema.tables.get("public.t").unwrap();
+    assert!(
+        !table.columns.contains_key(&truncated),
+        "DROP COLUMN with overlong name must remove the column; remaining: {:?}",
+        table.columns.keys().collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn inline_table_level_primary_key_on_64_byte_column_resolves_truncated_name() {
+    // A table-level PRIMARY KEY (...) constraint flows through `apply_primary_key`, which must
+    // truncate the column name so it matches the stored 63-byte column key (NOT NULL flip) and
+    // the stored PK column name is the truncated form.
+    let long_col = "c".repeat(64);
+    let sql =
+        format!(r#"CREATE TABLE t ("{long_col}" BIGINT NOT NULL, PRIMARY KEY ("{long_col}"));"#);
+    let schema = parse_sql_string(&sql).unwrap();
+    let truncated = "c".repeat(63);
+    let table = schema.tables.get("public.t").unwrap();
+    let pk = table.primary_key.as_ref().unwrap();
+    assert_eq!(pk.columns, vec![truncated.clone()]);
+    assert!(!table.columns.get(&truncated).unwrap().nullable);
+}
+
+#[test]
+fn alter_table_add_primary_key_on_64_byte_column_resolves_truncated_name() {
+    let long_col = "c".repeat(64);
+    let sql = format!(
+        r#"
+        CREATE TABLE t ("{long_col}" BIGINT NOT NULL);
+        ALTER TABLE t ADD CONSTRAINT t_pkey PRIMARY KEY ("{long_col}");
+        "#
+    );
+    let schema = parse_sql_string(&sql).unwrap();
+    let truncated = "c".repeat(63);
+    let table = schema.tables.get("public.t").unwrap();
+    let pk = table.primary_key.as_ref().unwrap();
+    assert_eq!(pk.columns, vec![truncated.clone()]);
+    assert!(!table.columns.get(&truncated).unwrap().nullable);
+}
+
+#[test]
+fn alter_table_rename_table_truncates_new_name_to_63_bytes() {
+    let long_new = "n".repeat(64);
+    let sql = format!(
+        r#"
+        CREATE TABLE t (id BIGINT NOT NULL);
+        ALTER TABLE t RENAME TO "{long_new}";
+        "#
+    );
+    let schema = parse_sql_string(&sql).unwrap();
+    let truncated = "n".repeat(63);
+    let table = schema.tables.get(&format!("public.{truncated}")).unwrap();
+    assert_eq!(table.name, truncated);
+    assert!(!schema.tables.contains_key("public.t"));
 }

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -5632,3 +5632,154 @@ fn alter_table_rename_constraint_matches_already_truncated_old_name() {
     assert_eq!(table.indexes.len(), 1);
     assert_eq!(table.indexes[0].name, "users_email_index");
 }
+
+#[test]
+fn create_table_truncates_table_name_to_63_bytes() {
+    let long_name = "t".repeat(64);
+    let sql = format!(r#"CREATE TABLE "{long_name}" (id BIGINT NOT NULL);"#);
+    let schema = parse_sql_string(&sql).unwrap();
+    let truncated = "t".repeat(63);
+    let table = schema.tables.get(&format!("public.{truncated}")).unwrap();
+    assert_eq!(table.name, truncated);
+}
+
+#[test]
+fn create_table_truncates_multibyte_table_name_at_char_boundary() {
+    // `À` is a 2-byte UTF-8 char; 32 of them is 64 bytes. PG clips to 63 bytes, which falls
+    // mid-codepoint, so the byte-safe truncation backs off to 31 chars (62 bytes).
+    let long_name = "À".repeat(32);
+    assert_eq!(long_name.len(), 64);
+    let sql = format!(r#"CREATE TABLE "{long_name}" (id BIGINT NOT NULL);"#);
+    let schema = parse_sql_string(&sql).unwrap();
+    let truncated = "À".repeat(31);
+    assert_eq!(truncated.len(), 62);
+    let table = schema.tables.get(&format!("public.{truncated}")).unwrap();
+    assert_eq!(table.name, truncated);
+    assert!(table.name.len() <= 63);
+    assert!(table.name.is_char_boundary(table.name.len()));
+}
+
+#[test]
+fn create_view_truncates_view_name_to_63_bytes() {
+    let long_name = "v".repeat(64);
+    let sql = format!(r#"CREATE VIEW "{long_name}" AS SELECT 1 AS a;"#);
+    let schema = parse_sql_string(&sql).unwrap();
+    let truncated = "v".repeat(63);
+    let view = schema.views.get(&format!("public.{truncated}")).unwrap();
+    assert_eq!(view.name, truncated);
+    assert!(!view.materialized);
+}
+
+#[test]
+fn create_materialized_view_truncates_view_name_to_63_bytes() {
+    let long_name = "m".repeat(64);
+    let sql = format!(r#"CREATE MATERIALIZED VIEW "{long_name}" AS SELECT 1 AS a;"#);
+    let schema = parse_sql_string(&sql).unwrap();
+    let truncated = "m".repeat(63);
+    let view = schema.views.get(&format!("public.{truncated}")).unwrap();
+    assert_eq!(view.name, truncated);
+    assert!(view.materialized);
+}
+
+#[test]
+fn create_enum_type_truncates_type_name_to_63_bytes() {
+    let long_name = "e".repeat(64);
+    let sql = format!(r#"CREATE TYPE "{long_name}" AS ENUM ('a', 'b');"#);
+    let schema = parse_sql_string(&sql).unwrap();
+    let truncated = "e".repeat(63);
+    let enum_type = schema.enums.get(&format!("public.{truncated}")).unwrap();
+    assert_eq!(enum_type.name, truncated);
+}
+
+#[test]
+fn create_domain_truncates_domain_name_to_63_bytes() {
+    let long_name = "d".repeat(64);
+    let sql = format!(r#"CREATE DOMAIN "{long_name}" AS TEXT;"#);
+    let schema = parse_sql_string(&sql).unwrap();
+    let truncated = "d".repeat(63);
+    let domain = schema.domains.get(&format!("public.{truncated}")).unwrap();
+    assert_eq!(domain.name, truncated);
+}
+
+#[test]
+fn create_function_truncates_function_name_to_63_bytes() {
+    let long_name = "f".repeat(64);
+    let sql = format!(
+        r#"CREATE FUNCTION "{long_name}"() RETURNS integer LANGUAGE sql AS $$ SELECT 1 $$;"#
+    );
+    let schema = parse_sql_string(&sql).unwrap();
+    let truncated = "f".repeat(63);
+    let function = schema
+        .functions
+        .values()
+        .find(|f| f.name == truncated)
+        .unwrap();
+    assert_eq!(function.name, truncated);
+    assert!(schema
+        .functions
+        .contains_key(&format!("public.{truncated}()")));
+}
+
+#[test]
+fn create_table_truncates_column_name_to_63_bytes() {
+    let long_col = "c".repeat(64);
+    let sql = format!(r#"CREATE TABLE t (id BIGINT NOT NULL, "{long_col}" TEXT);"#);
+    let schema = parse_sql_string(&sql).unwrap();
+    let truncated = "c".repeat(63);
+    let table = schema.tables.get("public.t").unwrap();
+    assert!(table.columns.contains_key(&truncated));
+    assert_eq!(table.columns.get(&truncated).unwrap().name, truncated);
+}
+
+#[test]
+fn alter_table_add_column_truncates_column_name_to_63_bytes() {
+    let long_col = "c".repeat(64);
+    let sql = format!(
+        r#"
+        CREATE TABLE t (id BIGINT NOT NULL);
+        ALTER TABLE t ADD COLUMN "{long_col}" TEXT;
+        "#
+    );
+    let schema = parse_sql_string(&sql).unwrap();
+    let truncated = "c".repeat(63);
+    let table = schema.tables.get("public.t").unwrap();
+    assert!(table.columns.contains_key(&truncated));
+    assert_eq!(table.columns.get(&truncated).unwrap().name, truncated);
+}
+
+#[test]
+fn alter_table_rename_column_truncates_new_name_to_63_bytes() {
+    let long_new = "n".repeat(64);
+    let sql = format!(
+        r#"
+        CREATE TABLE t (id BIGINT NOT NULL, email TEXT);
+        ALTER TABLE t RENAME COLUMN email TO "{long_new}";
+        "#
+    );
+    let schema = parse_sql_string(&sql).unwrap();
+    let truncated = "n".repeat(63);
+    let table = schema.tables.get("public.t").unwrap();
+    assert!(table.columns.contains_key(&truncated));
+    assert!(!table.columns.contains_key("email"));
+    assert_eq!(table.columns.get(&truncated).unwrap().name, truncated);
+}
+
+#[test]
+fn alter_table_rename_column_matches_already_truncated_old_name() {
+    // A 64-char column name is stored truncated to 63 bytes at creation time. Renaming from
+    // the 64-char form must match the stored 63-byte name, so the old name needs the same
+    // truncation before lookup.
+    let long_old = "o".repeat(64);
+    let sql = format!(
+        r#"
+        CREATE TABLE t (id BIGINT NOT NULL, "{long_old}" TEXT);
+        ALTER TABLE t RENAME COLUMN "{long_old}" TO renamed;
+        "#
+    );
+    let schema = parse_sql_string(&sql).unwrap();
+    let truncated_old = "o".repeat(63);
+    let table = schema.tables.get("public.t").unwrap();
+    assert!(table.columns.contains_key("renamed"));
+    assert!(!table.columns.contains_key(&truncated_old));
+    assert_eq!(table.columns.get("renamed").unwrap().name, "renamed");
+}


### PR DESCRIPTION
Closes #326

Extends the byte-safe identifier truncation from PR #324 (issue #323) to every remaining own-name site in the parser. Also covers the column-rename truncation gap.

## Background

PostgreSQL clips any identifier to 63 bytes (NAMEDATALEN-1) at object-creation time, and introspection always reads back the truncated form. PR #324 wired `truncate_identifier` into the index, constraint, trigger, sequence, and policy paths plus `RenameConstraint`, but object NAMES for tables, views, types, functions, and domains, plus plain column names and `RenameColumn` operands, were still carried verbatim. A 64-byte declared name therefore produced a never-converging DROP+CREATE or drift.

## Sites now covered

- CREATE TABLE name
- CREATE TYPE (enum) name
- CREATE VIEW / CREATE MATERIALIZED VIEW name
- CREATE FUNCTION name (feeds both the model `.name` and the signature-based map key)
- CREATE DOMAIN name
- Column names in `parse_column_with_serial` (covers CREATE TABLE columns and ALTER TABLE ADD COLUMN) and the column-constraint lookup loop in `parse_create_table`
- ALTER TABLE RENAME COLUMN old and new operands (both sides, like `RenameConstraint`) so the lookup matches the already-truncated stored name

Each site reuses the existing `truncate_identifier` / `unquote_ident` helpers; nothing reinvented.

## Out of scope

Composite types: the parser drops every non-enum `CreateType` representation, so there is no model object to truncate. Reference sites (FK `referenced_table`, partition `parent_name`, index column references) that point at >63-byte targets are also not truncated yet; filed as a follow-up (beads pgmold-fgw1).

## Beads

Also closes the column-rename truncation gap tracked as beads pgmold-wxt2.

## Tests (red then green)

Added 11 parser tests, each confirmed failing before the fix and passing after:
- table, view, materialized view, enum type, domain, function names each parse to a 63-byte name
- a multibyte table name (`À` x 32 = 64 bytes) truncates byte-safely to 31 chars / 62 bytes at a char boundary
- column name in CREATE TABLE and in ALTER TABLE ADD COLUMN store 63 bytes
- RENAME COLUMN to a 64-char name stores 63; renaming from an already-truncated 64-char name matches the stored form

The existing #324 truncation tests still pass.

## Verification

- `cargo fmt`, `cargo clippy --all-targets -- -D warnings` clean
- `cargo test --lib`: 1349 passed, 0 failed
- Live convergence (postgres:16-alpine): applied a schema with a 64-char table name and a 64-char view name, re-plan returned "No changes required."
