### PR TITLE
chore: bump version to 0.34.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1587,7 +1587,7 @@ dependencies = [
 
 [[package]]
 name = "pgmold"
-version = "0.34.14"
+version = "0.34.15"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "pgmold"
-version = "0.34.14"
+version = "0.34.15"
 edition = "2021"
 exclude = [".auto-claude/", ".auto-claude-security.json", ".claude_settings.json"]
 description = "PostgreSQL schema-as-code management tool"


### PR DESCRIPTION
release 0.34.15.

changes since 0.34.14:
- fix(parser): extend NAMEDATALEN-1 identifier truncation to table/view/type/function/domain/column CREATE paths, column drops, primary keys, and table/column renames (#343, closes #326)
- feat(lint): warn when a declared identifier exceeds NAMEDATALEN-1 (63 bytes) (#344, closes #325)
- fix(diff): add numeric precision/scale to the type model; elide no-op numeric(p,s) casts in view bodies and detect real numeric type changes, including negative scale (#345, fixes #340 and #342)