### PR TITLE
fix(introspect): carry numeric/varchar typmod through domain base types

### DIFF
--- a/src/pg/introspect.rs
+++ b/src/pg/introspect.rs
@@ -443,12 +443,7 @@ async fn introspect_domains(
                 "json" => PgType::Json,
                 "jsonb" => PgType::Jsonb,
                 "character varying" | "varchar" => {
-                    let length = if base_typmod > 0 {
-                        Some((base_typmod - 4) as u32)
-                    } else {
-                        None
-                    };
-                    PgType::Varchar(length)
+                    PgType::Varchar(decode_varchar_typmod(base_typmod))
                 }
                 _ => {
                     let qualified = format!("public.{base_type}");
@@ -922,6 +917,17 @@ fn decode_numeric_typmod(atttypmod: i32) -> PgType {
     }
 }
 
+/// Decodes a `varchar` column's `atttypmod` into a declared length. PostgreSQL
+/// stores `length + VARHDRSZ` (4) for a bounded `varchar(n)` and -1 for the
+/// unbounded `varchar`.
+fn decode_varchar_typmod(atttypmod: i32) -> Option<u32> {
+    if atttypmod > 0 {
+        Some((atttypmod - 4) as u32)
+    } else {
+        None
+    }
+}
+
 fn map_udt_name_to_pg_type(udt_name: &str, udt_schema: &str, atttypmod: Option<i32>) -> PgType {
     match udt_name {
         "bool" => PgType::Boolean,
@@ -931,10 +937,7 @@ fn map_udt_name_to_pg_type(udt_name: &str, udt_schema: &str, atttypmod: Option<i
         "float4" => PgType::Real,
         "float8" => PgType::DoublePrecision,
         "text" => PgType::Text,
-        "varchar" => {
-            let length = atttypmod.and_then(|m| if m > 0 { Some((m - 4) as u32) } else { None });
-            PgType::Varchar(length)
-        }
+        "varchar" => PgType::Varchar(atttypmod.and_then(decode_varchar_typmod)),
         "uuid" => PgType::Uuid,
         "timestamptz" => PgType::TimestampTz,
         "timestamp" => PgType::Timestamp,

--- a/src/pg/introspect.rs
+++ b/src/pg/introspect.rs
@@ -442,7 +442,14 @@ async fn introspect_domains(
                 "uuid" => PgType::Uuid,
                 "json" => PgType::Json,
                 "jsonb" => PgType::Jsonb,
-                "character varying" | "varchar" => PgType::Varchar(None),
+                "character varying" | "varchar" => {
+                    let length = if base_typmod > 0 {
+                        Some((base_typmod - 4) as u32)
+                    } else {
+                        None
+                    };
+                    PgType::Varchar(length)
+                }
                 _ => {
                     let qualified = format!("public.{base_type}");
                     if base_type.contains('.') {

--- a/src/pg/introspect.rs
+++ b/src/pg/introspect.rs
@@ -917,9 +917,10 @@ fn decode_numeric_typmod(atttypmod: i32) -> PgType {
     }
 }
 
-/// Decodes a `varchar` column's `atttypmod` into a declared length. PostgreSQL
-/// stores `length + VARHDRSZ` (4) for a bounded `varchar(n)` and -1 for the
-/// unbounded `varchar`.
+/// Decodes a `varchar` typmod into a declared length. PostgreSQL stores
+/// `length + VARHDRSZ` (4) for a bounded `varchar(n)` and -1 for the unbounded
+/// `varchar`. The same encoding applies to table columns (`atttypmod`) and
+/// domain base types (`typtypmod`).
 fn decode_varchar_typmod(atttypmod: i32) -> Option<u32> {
     if atttypmod > 0 {
         Some((atttypmod - 4) as u32)

--- a/src/pg/introspect.rs
+++ b/src/pg/introspect.rs
@@ -372,6 +372,7 @@ async fn introspect_domains(
             t.typname AS domain_name,
             bt.typname AS base_type,
             bt.typcategory::text AS base_category,
+            t.typtypmod AS base_typmod,
             t.typnotnull AS not_null,
             pg_get_expr(t.typdefaultbin, 0) AS default_expr,
             r.rolname AS owner,
@@ -409,6 +410,7 @@ async fn introspect_domains(
         let name: String = row.get("domain_name");
         let base_type: String = row.get("base_type");
         let base_category: String = row.get("base_category");
+        let base_typmod: i32 = row.get("base_typmod");
         let not_null: bool = row.get("not_null");
         let default_expr: Option<String> = row
             .get::<Option<String>, &str>("default_expr")
@@ -431,10 +433,7 @@ async fn introspect_domains(
                 "smallint" | "int2" => PgType::SmallInt,
                 "real" | "float4" => PgType::Real,
                 "double precision" | "float8" => PgType::DoublePrecision,
-                "numeric" => PgType::Numeric {
-                    precision: None,
-                    scale: None,
-                },
+                "numeric" => decode_numeric_typmod(base_typmod),
                 "text" => PgType::Text,
                 "boolean" | "bool" => PgType::Boolean,
                 "timestamp" => PgType::Timestamp,

--- a/tests/baseline.rs
+++ b/tests/baseline.rs
@@ -394,6 +394,37 @@ async fn baseline_captures_domain() {
 }
 
 #[tokio::test]
+async fn baseline_preserves_domain_numeric_precision_and_scale() {
+    let (_container, url) = setup_postgres().await;
+    let connection = PgConnection::new(&url).await.unwrap();
+
+    sqlx::raw_sql("CREATE DOMAIN money_amount AS NUMERIC(10, 2);")
+        .execute(connection.pool())
+        .await
+        .unwrap();
+
+    let temp_dir = TempDir::new().unwrap();
+    let output_path = temp_dir.path().join("schema.sql");
+
+    let result = run_baseline(
+        &connection,
+        &url,
+        &["public".to_string()],
+        output_path.to_str().unwrap(),
+    )
+    .await
+    .unwrap();
+
+    assert!(result.report.round_trip_ok);
+    assert!(result.report.zero_diff_ok);
+    assert!(
+        result.sql_dump.contains("NUMERIC(10,2)"),
+        "domain base type lost precision/scale; dump was:\n{}",
+        result.sql_dump
+    );
+}
+
+#[tokio::test]
 async fn baseline_detects_inherited_table() {
     let (_container, url) = setup_postgres().await;
     let connection = PgConnection::new(&url).await.unwrap();

--- a/tests/baseline.rs
+++ b/tests/baseline.rs
@@ -394,33 +394,44 @@ async fn baseline_captures_domain() {
 }
 
 #[tokio::test]
-async fn baseline_preserves_domain_numeric_precision_and_scale() {
+async fn introspect_carries_typmod_through_domain_base_types() {
+    use pgmold::model::PgType;
+
     let (_container, url) = setup_postgres().await;
     let connection = PgConnection::new(&url).await.unwrap();
 
-    sqlx::raw_sql("CREATE DOMAIN money_amount AS NUMERIC(10, 2);")
-        .execute(connection.pool())
-        .await
-        .unwrap();
-
-    let temp_dir = TempDir::new().unwrap();
-    let output_path = temp_dir.path().join("schema.sql");
-
-    let result = run_baseline(
-        &connection,
-        &url,
-        &["public".to_string()],
-        output_path.to_str().unwrap(),
+    sqlx::raw_sql(
+        r#"
+        CREATE DOMAIN money_amount AS NUMERIC(10, 2);
+        CREATE DOMAIN unbounded_amount AS NUMERIC;
+        CREATE DOMAIN short_name AS VARCHAR(50);
+        "#,
     )
+    .execute(connection.pool())
     .await
     .unwrap();
 
-    assert!(result.report.round_trip_ok);
-    assert!(result.report.zero_diff_ok);
-    assert!(
-        result.sql_dump.contains("NUMERIC(10,2)"),
-        "domain base type lost precision/scale; dump was:\n{}",
-        result.sql_dump
+    let schema = introspect_schema(&connection, &["public".to_string()], false)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        schema.domains["public.money_amount"].data_type,
+        PgType::Numeric {
+            precision: Some(10),
+            scale: Some(2)
+        }
+    );
+    assert_eq!(
+        schema.domains["public.unbounded_amount"].data_type,
+        PgType::Numeric {
+            precision: None,
+            scale: None
+        }
+    );
+    assert_eq!(
+        schema.domains["public.short_name"].data_type,
+        PgType::Varchar(Some(50))
     );
 }
 

--- a/tests/convergence.rs
+++ b/tests/convergence.rs
@@ -390,17 +390,6 @@ async fn domain() {
 }
 
 #[tokio::test]
-async fn domain_over_numeric_with_precision_and_scale() {
-    assert_convergence_public(
-        r#"
-        CREATE DOMAIN public.money_amount AS NUMERIC(10, 2)
-            CONSTRAINT money_amount_check CHECK (VALUE >= 0);
-        "#,
-    )
-    .await;
-}
-
-#[tokio::test]
 async fn partition() {
     assert_convergence_public(
         r#"

--- a/tests/convergence.rs
+++ b/tests/convergence.rs
@@ -390,6 +390,17 @@ async fn domain() {
 }
 
 #[tokio::test]
+async fn domain_over_numeric_with_precision_and_scale() {
+    assert_convergence_public(
+        r#"
+        CREATE DOMAIN public.money_amount AS NUMERIC(10, 2)
+            CONSTRAINT money_amount_check CHECK (VALUE >= 0);
+        "#,
+    )
+    .await;
+}
+
+#[tokio::test]
 async fn partition() {
     assert_convergence_public(
         r#"


### PR DESCRIPTION
## Problem

Domain introspection selected the base type name without its typmod, so a domain over a parameterized scalar lost its modifier:

- `CREATE DOMAIN money_amount AS NUMERIC(10, 2)` introspected as unconstrained `NUMERIC` and dumped as bare `NUMERIC`.
- `CREATE DOMAIN short_name AS VARCHAR(50)` introspected as unbounded `VARCHAR`.

This silently dropped declared precision/scale/length on `dump` and `baseline`.

## Fix

- Plumb `t.typtypmod` through the domain introspection query.
- Decode it for the `numeric` branch via the existing `decode_numeric_typmod` helper, mirroring table-column introspection.
- Decode `varchar` length from the same typmod; extract a shared `decode_varchar_typmod` helper so the domain branch and `map_udt_name_to_pg_type` no longer duplicate the formula.

## Tests

`introspect_carries_typmod_through_domain_base_types` (tests/baseline.rs) asserts the introspected `data_type` exactly for `numeric(10,2)`, bare `numeric` (typmod -1), and `varchar(50)`.

## Out of scope (follow-ups filed)

- Domain over `char(n)` introspects as `UserDefined` (wrong type entirely); the base-type match also carries dead arms keyed on display names. Consolidate by delegating to `map_udt_name_to_pg_type`.
- `diff_domains` never compares `data_type`, so a domain base-type change produces no migration.