### PR TITLE
fix(parser): truncate referenced identifiers at NAMEDATALEN-1

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -36,7 +36,7 @@ use sqlparser::ast::{
     AlterSchemaOperation, AlterTable, AlterTableOperation, AlterType, AlterTypeAddValue,
     AlterTypeAddValuePosition, AlterTypeOperation, CreateAggregate, CreateAggregateOption,
     CreateDomain, CreateExtension, CreateFunction, CreateServerStatement, CreateTrigger,
-    CreateView, DeferrableInitial, DropDomain, DropExtension, DropFunction, DropTrigger, Expr,
+    CreateView, DeferrableInitial, DropDomain, DropExtension, DropFunction, DropTrigger,
     FunctionParallel, Grantee, GranteeName, GranteesType, ObjectType, Owner, Privileges,
     RenameTableNameKind, SchemaName, Statement, TableConstraint, TriggerEvent as SqlTriggerEvent,
     TriggerPeriod, TriggerReferencingType, UserDefinedTypeRepresentation,
@@ -62,7 +62,8 @@ use tables::{
 use util::{
     extract_qualified_name, normalize_expr, parse_data_type, parse_for_values,
     parse_for_values_required, parse_policy_command, take_overlong_identifiers,
-    truncate_identifier, truncate_referenced_identifier, truncated_ident, unquote_ident,
+    truncate_identifier, truncate_index_column, truncate_referenced_columns,
+    truncate_referenced_identifier, truncated_ident, unquote_ident,
 };
 
 pub fn parse_sql_file(path: &str) -> Result<Schema> {
@@ -176,20 +177,7 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
                     };
                     table.indexes.push(Index {
                         name: idx_name,
-                        columns: ci
-                            .columns
-                            .iter()
-                            .map(|c| {
-                                // A bare-column index entry references a column PG truncates
-                                // at declaration; truncate the reference to match. Expression
-                                // entries (e.g. lower(x)) are kept verbatim.
-                                if let Expr::Identifier(ident) = &c.column.expr {
-                                    truncate_referenced_identifier(&ident.value)
-                                } else {
-                                    unquote_ident(&c.column.expr.to_string()).to_string()
-                                }
-                            })
-                            .collect(),
+                        columns: ci.columns.iter().map(truncate_index_column).collect(),
                         unique: ci.unique,
                         index_type,
                         predicate: ci.predicate.as_ref().map(|p| p.to_string()),
@@ -326,28 +314,14 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
                                             extract_qualified_name(&fk.foreign_table);
                                         table.foreign_keys.push(ForeignKey {
                                             name: truncate_identifier(&fk_name),
-                                            columns: fk
-                                                .columns
-                                                .iter()
-                                                .map(|c| {
-                                                    truncate_referenced_identifier(unquote_ident(
-                                                        &c.to_string(),
-                                                    ))
-                                                })
-                                                .collect(),
+                                            columns: truncate_referenced_columns(&fk.columns),
                                             referenced_schema: ref_schema,
                                             referenced_table: truncate_referenced_identifier(
                                                 &raw_ref_table,
                                             ),
-                                            referenced_columns: fk
-                                                .referred_columns
-                                                .iter()
-                                                .map(|c| {
-                                                    truncate_referenced_identifier(unquote_ident(
-                                                        &c.to_string(),
-                                                    ))
-                                                })
-                                                .collect(),
+                                            referenced_columns: truncate_referenced_columns(
+                                                &fk.referred_columns,
+                                            ),
                                             on_delete: parse_referential_action(&fk.on_delete),
                                             on_update: parse_referential_action(&fk.on_update),
                                         });

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -36,7 +36,7 @@ use sqlparser::ast::{
     AlterSchemaOperation, AlterTable, AlterTableOperation, AlterType, AlterTypeAddValue,
     AlterTypeAddValuePosition, AlterTypeOperation, CreateAggregate, CreateAggregateOption,
     CreateDomain, CreateExtension, CreateFunction, CreateServerStatement, CreateTrigger,
-    CreateView, DeferrableInitial, DropDomain, DropExtension, DropFunction, DropTrigger,
+    CreateView, DeferrableInitial, DropDomain, DropExtension, DropFunction, DropTrigger, Expr,
     FunctionParallel, Grantee, GranteeName, GranteesType, ObjectType, Owner, Privileges,
     RenameTableNameKind, SchemaName, Statement, TableConstraint, TriggerEvent as SqlTriggerEvent,
     TriggerPeriod, TriggerReferencingType, UserDefinedTypeRepresentation,
@@ -62,7 +62,7 @@ use tables::{
 use util::{
     extract_qualified_name, normalize_expr, parse_data_type, parse_for_values,
     parse_for_values_required, parse_policy_command, take_overlong_identifiers,
-    truncate_identifier, truncated_ident, unquote_ident,
+    truncate_identifier, truncate_referenced_identifier, truncated_ident, unquote_ident,
 };
 
 pub fn parse_sql_file(path: &str) -> Result<Schema> {
@@ -125,7 +125,8 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
                 let table_name = truncate_identifier(&raw_table_name);
 
                 if let Some(ref parent_table) = ct.partition_of {
-                    let (parent_schema, parent_name) = extract_qualified_name(parent_table);
+                    let (parent_schema, raw_parent_name) = extract_qualified_name(parent_table);
+                    let parent_name = truncate_referenced_identifier(&raw_parent_name);
                     let bound = parse_for_values(&ct.for_values)?;
                     let partition = Partition {
                         schema: table_schema.clone(),
@@ -178,7 +179,16 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
                         columns: ci
                             .columns
                             .iter()
-                            .map(|c| unquote_ident(&c.column.expr.to_string()).to_string())
+                            .map(|c| {
+                                // A bare-column index entry references a column PG truncates
+                                // at declaration; truncate the reference to match. Expression
+                                // entries (e.g. lower(x)) are kept verbatim.
+                                if let Expr::Identifier(ident) = &c.column.expr {
+                                    truncate_referenced_identifier(&ident.value)
+                                } else {
+                                    unquote_ident(&c.column.expr.to_string()).to_string()
+                                }
+                            })
                             .collect(),
                         unique: ci.unique,
                         index_type,
@@ -312,21 +322,31 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
                                                     unquote_ident(&fk.columns[0].to_string())
                                                 )
                                             });
-                                        let (ref_schema, ref_table) =
+                                        let (ref_schema, raw_ref_table) =
                                             extract_qualified_name(&fk.foreign_table);
                                         table.foreign_keys.push(ForeignKey {
                                             name: truncate_identifier(&fk_name),
                                             columns: fk
                                                 .columns
                                                 .iter()
-                                                .map(|c| unquote_ident(&c.to_string()).to_string())
+                                                .map(|c| {
+                                                    truncate_referenced_identifier(unquote_ident(
+                                                        &c.to_string(),
+                                                    ))
+                                                })
                                                 .collect(),
                                             referenced_schema: ref_schema,
-                                            referenced_table: ref_table,
+                                            referenced_table: truncate_referenced_identifier(
+                                                &raw_ref_table,
+                                            ),
                                             referenced_columns: fk
                                                 .referred_columns
                                                 .iter()
-                                                .map(|c| unquote_ident(&c.to_string()).to_string())
+                                                .map(|c| {
+                                                    truncate_referenced_identifier(unquote_ident(
+                                                        &c.to_string(),
+                                                    ))
+                                                })
                                                 .collect(),
                                             on_delete: parse_referential_action(&fk.on_delete),
                                             on_update: parse_referential_action(&fk.on_update),
@@ -509,7 +529,7 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
                                 schema: child_schema,
                                 name: child_name,
                                 parent_schema: tbl_schema.clone(),
-                                parent_name: tbl_name.clone(),
+                                parent_name: truncate_referenced_identifier(&tbl_name),
                                 bound,
                                 indexes: Vec::new(),
                                 check_constraints: Vec::new(),

--- a/src/parser/tables.rs
+++ b/src/parser/tables.rs
@@ -16,7 +16,8 @@ use std::collections::BTreeMap;
 
 use super::util::{
     extract_qualified_name, normalize_expr, parse_data_type, truncate_identifier,
-    truncate_to_bytes_raw, truncated_ident, unquote_ident, PG_MAX_IDENTIFIER_LENGTH,
+    truncate_referenced_identifier, truncate_to_bytes_raw, truncated_ident, unquote_ident,
+    PG_MAX_IDENTIFIER_LENGTH,
 };
 
 pub(super) struct ParsedTable {
@@ -92,7 +93,8 @@ pub(super) fn parse_create_table(
                     let constraint_name = explicit_name
                         .clone()
                         .unwrap_or_else(|| format!("{}_{}_fkey", table.name, col_name));
-                    let (ref_schema, ref_table) = extract_qualified_name(&fk.foreign_table);
+                    let (ref_schema, raw_ref_table) = extract_qualified_name(&fk.foreign_table);
+                    let ref_table = truncate_referenced_identifier(&raw_ref_table);
                     if fk.referred_columns.is_empty() {
                         return Err(crate::util::SchemaError::ParseError(format!(
                             "Inline REFERENCES on column \"{}\".\"{}\".\"{}\" must specify \
@@ -108,7 +110,7 @@ pub(super) fn parse_create_table(
                     let referenced_columns: Vec<String> = fk
                         .referred_columns
                         .iter()
-                        .map(|c| unquote_ident(&c.to_string()).to_string())
+                        .map(|c| truncate_referenced_identifier(unquote_ident(&c.to_string())))
                         .collect();
                     table.foreign_keys.push(ForeignKey {
                         name: truncate_identifier(&constraint_name),
@@ -167,7 +169,7 @@ pub(super) fn parse_create_table(
                 let fk_columns: Vec<String> = fk
                     .columns
                     .iter()
-                    .map(|c| unquote_ident(&c.to_string()).to_string())
+                    .map(|c| truncate_referenced_identifier(unquote_ident(&c.to_string())))
                     .collect();
                 let fk_name = fk
                     .name
@@ -178,16 +180,16 @@ pub(super) fn parse_create_table(
                         format!("{}_{}_fkey", table.name, fk_columns.join("_"))
                     });
 
-                let (ref_schema, ref_table) = extract_qualified_name(&fk.foreign_table);
+                let (ref_schema, raw_ref_table) = extract_qualified_name(&fk.foreign_table);
                 table.foreign_keys.push(ForeignKey {
                     name: truncate_identifier(&fk_name),
                     columns: fk_columns,
                     referenced_schema: ref_schema,
-                    referenced_table: ref_table,
+                    referenced_table: truncate_referenced_identifier(&raw_ref_table),
                     referenced_columns: fk
                         .referred_columns
                         .iter()
-                        .map(|c| unquote_ident(&c.to_string()).to_string())
+                        .map(|c| truncate_referenced_identifier(unquote_ident(&c.to_string())))
                         .collect(),
                     on_delete: parse_referential_action(&fk.on_delete),
                     on_update: parse_referential_action(&fk.on_update),

--- a/src/parser/tables.rs
+++ b/src/parser/tables.rs
@@ -16,8 +16,8 @@ use std::collections::BTreeMap;
 
 use super::util::{
     extract_qualified_name, normalize_expr, parse_data_type, truncate_identifier,
-    truncate_referenced_identifier, truncate_to_bytes_raw, truncated_ident, unquote_ident,
-    PG_MAX_IDENTIFIER_LENGTH,
+    truncate_referenced_columns, truncate_referenced_identifier, truncate_to_bytes_raw,
+    truncated_ident, unquote_ident, PG_MAX_IDENTIFIER_LENGTH,
 };
 
 pub(super) struct ParsedTable {
@@ -107,11 +107,7 @@ pub(super) fn parse_create_table(
                             schema, name, col_name, ref_table
                         )));
                     }
-                    let referenced_columns: Vec<String> = fk
-                        .referred_columns
-                        .iter()
-                        .map(|c| truncate_referenced_identifier(unquote_ident(&c.to_string())))
-                        .collect();
+                    let referenced_columns = truncate_referenced_columns(&fk.referred_columns);
                     table.foreign_keys.push(ForeignKey {
                         name: truncate_identifier(&constraint_name),
                         columns: vec![col_name.clone()],
@@ -166,11 +162,7 @@ pub(super) fn parse_create_table(
         match constraint {
             TableConstraint::PrimaryKey(pk) => apply_primary_key(&mut table, pk),
             TableConstraint::ForeignKey(fk) => {
-                let fk_columns: Vec<String> = fk
-                    .columns
-                    .iter()
-                    .map(|c| truncate_referenced_identifier(unquote_ident(&c.to_string())))
-                    .collect();
+                let fk_columns = truncate_referenced_columns(&fk.columns);
                 let fk_name = fk
                     .name
                     .as_ref()
@@ -186,11 +178,7 @@ pub(super) fn parse_create_table(
                     columns: fk_columns,
                     referenced_schema: ref_schema,
                     referenced_table: truncate_referenced_identifier(&raw_ref_table),
-                    referenced_columns: fk
-                        .referred_columns
-                        .iter()
-                        .map(|c| truncate_referenced_identifier(unquote_ident(&c.to_string())))
-                        .collect(),
+                    referenced_columns: truncate_referenced_columns(&fk.referred_columns),
                     on_delete: parse_referential_action(&fk.on_delete),
                     on_update: parse_referential_action(&fk.on_update),
                 });

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -1367,6 +1367,84 @@ FOR VALUES FROM ('2024-01-01') TO ('2025-01-01');
 }
 
 #[test]
+fn partition_of_overlong_parent_truncates_parent_name() {
+    let parent = "p".repeat(64);
+    let sql = format!(
+        "CREATE TABLE {parent} (id INT NOT NULL, logdate DATE NOT NULL) \
+         PARTITION BY RANGE (logdate); \
+         CREATE TABLE child_part PARTITION OF {parent} \
+         FOR VALUES FROM ('2024-01-01') TO ('2025-01-01');"
+    );
+    let schema = parse_sql_string(&sql).unwrap();
+    let partition = schema.partitions.get("public.child_part").unwrap();
+    assert_eq!(partition.parent_name, "p".repeat(63));
+}
+
+#[test]
+fn foreign_key_to_overlong_table_truncates_referenced_table() {
+    let parent = "r".repeat(64);
+    let sql = format!(
+        "CREATE TABLE {parent} (id INT NOT NULL, PRIMARY KEY (id)); \
+         CREATE TABLE child ( \
+            id INT NOT NULL, \
+            parent_id INT NOT NULL, \
+            PRIMARY KEY (id), \
+            CONSTRAINT child_parent_fkey FOREIGN KEY (parent_id) REFERENCES {parent} (id) \
+         );"
+    );
+    let schema = parse_sql_string(&sql).unwrap();
+    let child = schema.tables.get("public.child").unwrap();
+    assert_eq!(child.foreign_keys.len(), 1);
+    assert_eq!(child.foreign_keys[0].referenced_table, "r".repeat(63));
+}
+
+#[test]
+fn foreign_key_to_overlong_column_truncates_referenced_column() {
+    let column = "c".repeat(64);
+    let sql = format!(
+        "CREATE TABLE parent_tbl ({column} INT NOT NULL, PRIMARY KEY ({column})); \
+         CREATE TABLE child ( \
+            id INT NOT NULL, \
+            parent_ref INT NOT NULL REFERENCES parent_tbl ({column}) \
+         );"
+    );
+    let schema = parse_sql_string(&sql).unwrap();
+    let child = schema.tables.get("public.child").unwrap();
+    assert_eq!(child.foreign_keys.len(), 1);
+    assert_eq!(child.foreign_keys[0].referenced_table, "parent_tbl");
+    assert_eq!(
+        child.foreign_keys[0].referenced_columns,
+        vec!["c".repeat(63)]
+    );
+}
+
+#[test]
+fn index_on_overlong_column_truncates_plain_reference_but_leaves_expressions() {
+    let column = "z".repeat(64);
+    let sql = format!(
+        "CREATE TABLE t (id INT NOT NULL, {column} INT, name TEXT); \
+         CREATE INDEX t_plain_idx ON t ({column}); \
+         CREATE INDEX t_expr_idx ON t (lower(name));"
+    );
+    let schema = parse_sql_string(&sql).unwrap();
+    let table = schema.tables.get("public.t").unwrap();
+
+    let plain = table
+        .indexes
+        .iter()
+        .find(|i| i.name == "t_plain_idx")
+        .unwrap();
+    assert_eq!(plain.columns, vec!["z".repeat(63)]);
+
+    let expr = table
+        .indexes
+        .iter()
+        .find(|i| i.name == "t_expr_idx")
+        .unwrap();
+    assert_eq!(expr.columns, vec!["lower(name)".to_string()]);
+}
+
+#[test]
 fn parses_list_partition() {
     let sql = r#"
 CREATE TABLE customers (

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -1419,6 +1419,62 @@ fn foreign_key_to_overlong_column_truncates_referenced_column() {
 }
 
 #[test]
+fn inline_foreign_key_to_overlong_table_truncates_referenced_table() {
+    let parent = "r".repeat(64);
+    let sql = format!(
+        "CREATE TABLE {parent} (id INT NOT NULL, PRIMARY KEY (id)); \
+         CREATE TABLE child ( \
+            id INT NOT NULL, \
+            parent_id INT NOT NULL REFERENCES {parent} (id) \
+         );"
+    );
+    let schema = parse_sql_string(&sql).unwrap();
+    let child = schema.tables.get("public.child").unwrap();
+    assert_eq!(child.foreign_keys.len(), 1);
+    assert_eq!(child.foreign_keys[0].referenced_table, "r".repeat(63));
+}
+
+#[test]
+fn table_constraint_foreign_key_truncates_referenced_column() {
+    let column = "c".repeat(64);
+    let sql = format!(
+        "CREATE TABLE parent_tbl ({column} INT NOT NULL, PRIMARY KEY ({column})); \
+         CREATE TABLE child ( \
+            id INT NOT NULL, \
+            parent_ref INT NOT NULL, \
+            CONSTRAINT child_parent_fkey FOREIGN KEY (parent_ref) REFERENCES parent_tbl ({column}) \
+         );"
+    );
+    let schema = parse_sql_string(&sql).unwrap();
+    let child = schema.tables.get("public.child").unwrap();
+    assert_eq!(child.foreign_keys.len(), 1);
+    assert_eq!(
+        child.foreign_keys[0].referenced_columns,
+        vec!["c".repeat(63)]
+    );
+}
+
+#[test]
+fn alter_table_add_foreign_key_truncates_references() {
+    let parent = "r".repeat(64);
+    let column = "c".repeat(64);
+    let sql = format!(
+        "CREATE TABLE {parent} ({column} INT NOT NULL, PRIMARY KEY ({column})); \
+         CREATE TABLE child (id INT NOT NULL, parent_ref INT NOT NULL, PRIMARY KEY (id)); \
+         ALTER TABLE child ADD CONSTRAINT child_parent_fkey \
+            FOREIGN KEY (parent_ref) REFERENCES {parent} ({column});"
+    );
+    let schema = parse_sql_string(&sql).unwrap();
+    let child = schema.tables.get("public.child").unwrap();
+    assert_eq!(child.foreign_keys.len(), 1);
+    assert_eq!(child.foreign_keys[0].referenced_table, "r".repeat(63));
+    assert_eq!(
+        child.foreign_keys[0].referenced_columns,
+        vec!["c".repeat(63)]
+    );
+}
+
+#[test]
 fn index_on_overlong_column_truncates_plain_reference_but_leaves_expressions() {
     let column = "z".repeat(64);
     let sql = format!(

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -1455,6 +1455,23 @@ fn table_constraint_foreign_key_truncates_referenced_column() {
 }
 
 #[test]
+fn foreign_key_truncates_local_columns() {
+    let local = "l".repeat(64);
+    let sql = format!(
+        "CREATE TABLE parent_tbl (id INT NOT NULL, PRIMARY KEY (id)); \
+         CREATE TABLE child ( \
+            id INT NOT NULL, \
+            {local} INT NOT NULL, \
+            CONSTRAINT child_fkey FOREIGN KEY ({local}) REFERENCES parent_tbl (id) \
+         );"
+    );
+    let schema = parse_sql_string(&sql).unwrap();
+    let child = schema.tables.get("public.child").unwrap();
+    assert_eq!(child.foreign_keys.len(), 1);
+    assert_eq!(child.foreign_keys[0].columns, vec!["l".repeat(63)]);
+}
+
+#[test]
 fn alter_table_add_foreign_key_truncates_references() {
     let parent = "r".repeat(64);
     let column = "c".repeat(64);

--- a/src/parser/util.rs
+++ b/src/parser/util.rs
@@ -6,8 +6,8 @@
 use crate::model::*;
 use crate::util::{normalize_type_casts, numeric_typmod_parts, Result, SchemaError};
 use sqlparser::ast::{
-    ArrayElemTypeDef, CharacterLength, CreatePolicyCommand, DataType, ForValues, ObjectName,
-    PartitionBoundValue, TimezoneInfo,
+    ArrayElemTypeDef, CharacterLength, CreatePolicyCommand, DataType, Expr, ForValues, Ident,
+    IndexColumn, ObjectName, PartitionBoundValue, TimezoneInfo,
 };
 
 use std::cell::RefCell;
@@ -45,6 +45,29 @@ pub(super) fn truncate_identifier(s: &str) -> String {
 /// at every place it is referenced.
 pub(super) fn truncate_referenced_identifier(s: &str) -> String {
     truncate_to_bytes_raw(s, PG_MAX_IDENTIFIER_LENGTH).to_string()
+}
+
+/// Truncate a list of referenced column identifiers (FK local or referenced
+/// columns) to the PG-truncated form the catalog holds. See
+/// [`truncate_referenced_identifier`].
+pub(super) fn truncate_referenced_columns(columns: &[Ident]) -> Vec<String> {
+    columns
+        .iter()
+        .map(|column| truncate_referenced_identifier(unquote_ident(&column.to_string())))
+        .collect()
+}
+
+/// Resolve an index column entry to its stored form. A bare-column entry
+/// references a column PG truncates at declaration, so the reference is
+/// truncated to match (see [`truncate_referenced_identifier`]). Expression
+/// entries (e.g. `lower(x)`) are kept verbatim: introspection renders those via
+/// `pg_get_indexdef`, not `attname`.
+pub(super) fn truncate_index_column(column: &IndexColumn) -> String {
+    if let Expr::Identifier(ident) = &column.column.expr {
+        truncate_referenced_identifier(&ident.value)
+    } else {
+        unquote_ident(&column.column.expr.to_string()).to_string()
+    }
 }
 
 /// Truncate `s` to at most `max_bytes` bytes, backing off to the nearest UTF-8 char

--- a/src/parser/util.rs
+++ b/src/parser/util.rs
@@ -53,7 +53,7 @@ pub(super) fn truncate_referenced_identifier(s: &str) -> String {
 pub(super) fn truncate_referenced_columns(columns: &[Ident]) -> Vec<String> {
     columns
         .iter()
-        .map(|column| truncate_referenced_identifier(unquote_ident(&column.to_string())))
+        .map(|column| truncate_referenced_identifier(&column.value))
         .collect()
 }
 

--- a/src/parser/util.rs
+++ b/src/parser/util.rs
@@ -35,6 +35,18 @@ pub(super) fn truncate_identifier(s: &str) -> String {
     truncate_to_bytes(s, PG_MAX_IDENTIFIER_LENGTH).to_string()
 }
 
+/// Truncate an identifier that *references* an object or column declared
+/// elsewhere (a foreign-key target, a partition parent, an index column) to
+/// PG's NAMEDATALEN-1. PostgreSQL truncates these the same as the declaration,
+/// so a reference to a >63-byte name must match the truncated form the catalog
+/// actually holds; otherwise it points at a name PG never has, reintroducing
+/// drift. Unlike `truncate_identifier`, this does NOT feed the
+/// overlong-identifier lint: the name is reported at its declaration site, not
+/// at every place it is referenced.
+pub(super) fn truncate_referenced_identifier(s: &str) -> String {
+    truncate_to_bytes_raw(s, PG_MAX_IDENTIFIER_LENGTH).to_string()
+}
+
 /// Truncate `s` to at most `max_bytes` bytes, backing off to the nearest UTF-8 char
 /// boundary at or below the cap. Mirrors PG's `pg_mbcliplen`: never split a codepoint.
 ///

--- a/tests/convergence.rs
+++ b/tests/convergence.rs
@@ -390,6 +390,23 @@ async fn domain() {
 }
 
 #[tokio::test]
+async fn index_on_overlong_column_name_converges() {
+    let column = "z".repeat(64);
+    assert_convergence_public(&format!(
+        r#"
+        CREATE TABLE public.measurements (
+            id        BIGINT NOT NULL,
+            {column}  INTEGER,
+            PRIMARY KEY (id)
+        );
+
+        CREATE INDEX measurements_long_col_idx ON public.measurements ({column});
+        "#
+    ))
+    .await;
+}
+
+#[tokio::test]
 async fn partition() {
     assert_convergence_public(
         r#"


### PR DESCRIPTION
## Problem

Object and column *declarations* are truncated to PostgreSQL's 63-byte identifier limit, but *references* to >63-byte targets were stored raw. Since PostgreSQL stores the target under its truncated name, these references held a name the catalog never has, reintroducing drift (and dumping a name PG would silently truncate).

Affected reference sites:
- `ForeignKey.referenced_table`, `referenced_columns`, and local `columns`
- `Partition.parent_name` (both `CREATE TABLE ... PARTITION OF` and `ALTER TABLE ... ATTACH PARTITION`)
- bare-column index references

## Fix

Add `truncate_referenced_identifier`, a non-recording counterpart to `truncate_identifier` (a reference is not a declaration, so it must not feed the overlong-identifier lint, which fires at the declaration site). Apply it at every reference site, via two small helpers: `truncate_referenced_columns` (FK column lists) and `truncate_index_column`.

Index *expression* entries (e.g. `lower(x)`) are left verbatim, matching introspection, which renders plain columns via `attname` (truncated) and expressions via `pg_get_indexdef`.

Schema names are intentionally left untruncated, consistent with the existing declaration sites.

## Tests

Parser unit tests cover each reference field across every FK form (inline `REFERENCES`, table constraint, `ALTER TABLE ADD CONSTRAINT`), partition parent, and the plain-vs-expression index distinction. A convergence test exercises the index-column round-trip against real PostgreSQL.

## Out of scope (follow-ups filed)

- The parser also uses untruncated `extract_qualified_name` results as `schema.tables` lookup keys at `CREATE INDEX` / `ALTER TABLE` / `ATTACH PARTITION`, silently dropping the operation when the *table* name exceeds 63 bytes.
- Expression indexes over a >63-byte column don't truncate the inner identifier.
- `diff_foreign_keys` compares FKs by name only and `diff_partitions` ignores the parent, which masks reference changes at the diff layer (only `dump` surfaces them today).