### PR TITLE
fix(parser): truncate table-lookup keys at NAMEDATALEN-1

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -164,7 +164,8 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
                     .as_ref()
                     .map(truncated_ident)
                     .ok_or_else(|| SchemaError::ParseError("Index must have name".into()))?;
-                let (tbl_schema, tbl_name) = extract_qualified_name(&ci.table_name);
+                let (tbl_schema, raw_tbl_name) = extract_qualified_name(&ci.table_name);
+                let tbl_name = truncate_referenced_identifier(&raw_tbl_name);
                 let tbl_key = qualified_name(&tbl_schema, &tbl_name);
 
                 if let Some(table) = schema.tables.get_mut(&tbl_key) {
@@ -244,7 +245,8 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
             Statement::AlterTable(AlterTable {
                 name, operations, ..
             }) => {
-                let (tbl_schema, tbl_name) = extract_qualified_name(&name);
+                let (tbl_schema, raw_tbl_name) = extract_qualified_name(&name);
+                let tbl_name = truncate_referenced_identifier(&raw_tbl_name);
                 let tbl_key = qualified_name(&tbl_schema, &tbl_name);
                 for op in operations {
                     match op {
@@ -494,8 +496,9 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
                             partition_name,
                             partition_bound,
                         } => {
-                            let (child_schema, child_name) =
+                            let (child_schema, raw_child_name) =
                                 extract_qualified_name(&partition_name);
+                            let child_name = truncate_referenced_identifier(&raw_child_name);
                             let child_key = qualified_name(&child_schema, &child_name);
                             let bound = parse_for_values_required(&partition_bound)?;
                             let owner = schema.tables.remove(&child_key).and_then(|t| t.owner);
@@ -503,7 +506,7 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
                                 schema: child_schema,
                                 name: child_name,
                                 parent_schema: tbl_schema.clone(),
-                                parent_name: truncate_referenced_identifier(&tbl_name),
+                                parent_name: tbl_name.clone(),
                                 bound,
                                 indexes: Vec::new(),
                                 check_constraints: Vec::new(),
@@ -516,8 +519,9 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
                             concurrently: _,
                             finalize: _,
                         } => {
-                            let (child_schema, child_name) =
+                            let (child_schema, raw_child_name) =
                                 extract_qualified_name(&partition_name);
+                            let child_name = truncate_referenced_identifier(&raw_child_name);
                             let child_key = qualified_name(&child_schema, &child_name);
                             // TODO: PostgreSQL promotes a detached partition to a standalone
                             // table; re-insert into schema.tables to model that.

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -60,8 +60,8 @@ use tables::{
     parse_referential_action,
 };
 use util::{
-    extract_qualified_name, normalize_expr, parse_data_type, parse_for_values,
-    parse_for_values_required, parse_policy_command, take_overlong_identifiers,
+    extract_qualified_name, extract_qualified_name_truncated, normalize_expr, parse_data_type,
+    parse_for_values, parse_for_values_required, parse_policy_command, take_overlong_identifiers,
     truncate_identifier, truncate_index_column, truncate_referenced_columns,
     truncate_referenced_identifier, truncated_ident, unquote_ident,
 };
@@ -164,8 +164,7 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
                     .as_ref()
                     .map(truncated_ident)
                     .ok_or_else(|| SchemaError::ParseError("Index must have name".into()))?;
-                let (tbl_schema, raw_tbl_name) = extract_qualified_name(&ci.table_name);
-                let tbl_name = truncate_referenced_identifier(&raw_tbl_name);
+                let (tbl_schema, tbl_name) = extract_qualified_name_truncated(&ci.table_name);
                 let tbl_key = qualified_name(&tbl_schema, &tbl_name);
 
                 if let Some(table) = schema.tables.get_mut(&tbl_key) {
@@ -245,8 +244,7 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
             Statement::AlterTable(AlterTable {
                 name, operations, ..
             }) => {
-                let (tbl_schema, raw_tbl_name) = extract_qualified_name(&name);
-                let tbl_name = truncate_referenced_identifier(&raw_tbl_name);
+                let (tbl_schema, tbl_name) = extract_qualified_name_truncated(&name);
                 let tbl_key = qualified_name(&tbl_schema, &tbl_name);
                 for op in operations {
                     match op {
@@ -496,9 +494,8 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
                             partition_name,
                             partition_bound,
                         } => {
-                            let (child_schema, raw_child_name) =
-                                extract_qualified_name(&partition_name);
-                            let child_name = truncate_referenced_identifier(&raw_child_name);
+                            let (child_schema, child_name) =
+                                extract_qualified_name_truncated(&partition_name);
                             let child_key = qualified_name(&child_schema, &child_name);
                             let bound = parse_for_values_required(&partition_bound)?;
                             let owner = schema.tables.remove(&child_key).and_then(|t| t.owner);
@@ -519,9 +516,8 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
                             concurrently: _,
                             finalize: _,
                         } => {
-                            let (child_schema, raw_child_name) =
-                                extract_qualified_name(&partition_name);
-                            let child_name = truncate_referenced_identifier(&raw_child_name);
+                            let (child_schema, child_name) =
+                                extract_qualified_name_truncated(&partition_name);
                             let child_key = qualified_name(&child_schema, &child_name);
                             // TODO: PostgreSQL promotes a detached partition to a standalone
                             // table; re-insert into schema.tables to model that.

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -126,8 +126,8 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
                 let table_name = truncate_identifier(&raw_table_name);
 
                 if let Some(ref parent_table) = ct.partition_of {
-                    let (parent_schema, raw_parent_name) = extract_qualified_name(parent_table);
-                    let parent_name = truncate_referenced_identifier(&raw_parent_name);
+                    let (parent_schema, parent_name) =
+                        extract_qualified_name_truncated(parent_table);
                     let bound = parse_for_values(&ct.for_values)?;
                     let partition = Partition {
                         schema: table_schema.clone(),

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -1531,6 +1531,7 @@ fn create_index_on_overlong_table_name_is_not_dropped() {
         .unwrap();
     assert_eq!(parsed.indexes.len(), 1);
     assert_eq!(parsed.indexes[0].name, "overlong_tbl_idx");
+    assert_eq!(parsed.indexes[0].columns, vec!["val".to_string()]);
 }
 
 #[test]
@@ -1545,7 +1546,9 @@ fn alter_table_on_overlong_table_name_is_not_dropped() {
         .tables
         .get(&format!("public.{}", "t".repeat(63)))
         .unwrap();
-    assert!(parsed.columns.contains_key("extra"));
+    let column = parsed.columns.get("extra").unwrap();
+    assert_eq!(column.data_type, PgType::Text);
+    assert!(column.nullable);
 }
 
 #[test]

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -1518,6 +1518,56 @@ fn index_on_overlong_column_truncates_plain_reference_but_leaves_expressions() {
 }
 
 #[test]
+fn create_index_on_overlong_table_name_is_not_dropped() {
+    let table = "t".repeat(64);
+    let sql = format!(
+        "CREATE TABLE {table} (id INT NOT NULL, val INT); \
+         CREATE INDEX overlong_tbl_idx ON {table} (val);"
+    );
+    let schema = parse_sql_string(&sql).unwrap();
+    let parsed = schema
+        .tables
+        .get(&format!("public.{}", "t".repeat(63)))
+        .unwrap();
+    assert_eq!(parsed.indexes.len(), 1);
+    assert_eq!(parsed.indexes[0].name, "overlong_tbl_idx");
+}
+
+#[test]
+fn alter_table_on_overlong_table_name_is_not_dropped() {
+    let table = "t".repeat(64);
+    let sql = format!(
+        "CREATE TABLE {table} (id INT NOT NULL); \
+         ALTER TABLE {table} ADD COLUMN extra TEXT;"
+    );
+    let schema = parse_sql_string(&sql).unwrap();
+    let parsed = schema
+        .tables
+        .get(&format!("public.{}", "t".repeat(63)))
+        .unwrap();
+    assert!(parsed.columns.contains_key("extra"));
+}
+
+#[test]
+fn attach_partition_with_overlong_child_name_truncates_key_and_name() {
+    let child = "c".repeat(64);
+    let sql = format!(
+        "CREATE TABLE parent_tbl (id INT NOT NULL, logdate DATE NOT NULL) \
+         PARTITION BY RANGE (logdate); \
+         CREATE TABLE {child} (id INT NOT NULL, logdate DATE NOT NULL); \
+         ALTER TABLE parent_tbl ATTACH PARTITION {child} \
+         FOR VALUES FROM ('2024-01-01') TO ('2025-01-01');"
+    );
+    let schema = parse_sql_string(&sql).unwrap();
+    let partition = schema
+        .partitions
+        .get(&format!("public.{}", "c".repeat(63)))
+        .unwrap();
+    assert_eq!(partition.name, "c".repeat(63));
+    assert_eq!(partition.parent_name, "parent_tbl");
+}
+
+#[test]
 fn parses_list_partition() {
     let sql = r#"
 CREATE TABLE customers (

--- a/src/parser/util.rs
+++ b/src/parser/util.rs
@@ -124,6 +124,15 @@ pub(super) fn extract_qualified_name(name: &ObjectName) -> (String, String) {
     }
 }
 
+/// Like [`extract_qualified_name`], but truncates the name part to the form the
+/// catalog holds, for use at sites that *reference* or *look up* an object
+/// declared elsewhere (see [`truncate_referenced_identifier`]). The schema part
+/// is left untruncated, matching declaration sites.
+pub(super) fn extract_qualified_name_truncated(name: &ObjectName) -> (String, String) {
+    let (schema, object_name) = extract_qualified_name(name);
+    (schema, truncate_referenced_identifier(&object_name))
+}
+
 pub(super) fn parse_policy_command(cmd: &Option<CreatePolicyCommand>) -> PolicyCommand {
     match cmd {
         Some(CreatePolicyCommand::All) => PolicyCommand::All,


### PR DESCRIPTION
## Problem

`CREATE INDEX`, `ALTER TABLE`, and `ATTACH`/`DETACH PARTITION` built their `schema.tables` / `schema.partitions` lookup keys from the raw object name returned by `extract_qualified_name`. A table declared with a >63-byte name is stored under its truncated (NAMEDATALEN-1) key, so the lookup missed and the operation was **silently discarded**:

- `CREATE INDEX ... ON <64-byte-table>` — the index was dropped from the model entirely.
- `ALTER TABLE <64-byte-table> ADD COLUMN ...` (and every other ALTER op) — silently no-op'd.
- `ATTACH PARTITION <64-byte-child>` — stored under a key/name PG never has, and the owner transfer missed.

A silent drop is invisible to convergence (both sides lack the object), so this only surfaced under direct inspection.

## Fix

Add `extract_qualified_name_truncated` (extract + non-recording `truncate_referenced_identifier` on the name, schema left raw, consistent with declaration sites) and use it at every lookup/reference-lookup site. The ATTACH `parent_name` no longer needs its own truncate call now that the ALTER target name is truncated at binding.

## Tests

Parser unit tests assert the index/column/partition is present under the truncated key after parsing a >63-byte table name (a convergence test cannot catch a silent drop).

## Out of scope (follow-up filed)

- `Policy.table` and `Trigger.table` store the target table reference untruncated (drift, not silent drop) — same pattern, separate object types.