### PR TITLE
fix(introspect): map domain base types through map_udt_name_to_pg_type

### DIFF
--- a/src/pg/introspect.rs
+++ b/src/pg/introspect.rs
@@ -371,6 +371,7 @@ async fn introspect_domains(
             n.nspname AS schema_name,
             t.typname AS domain_name,
             bt.typname AS base_type,
+            bn.nspname AS base_schema,
             bt.typcategory::text AS base_category,
             t.typtypmod AS base_typmod,
             t.typnotnull AS not_null,
@@ -380,6 +381,7 @@ async fn introspect_domains(
         FROM pg_type t
         JOIN pg_namespace n ON t.typnamespace = n.oid
         JOIN pg_type bt ON t.typbasetype = bt.oid
+        JOIN pg_namespace bn ON bt.typnamespace = bn.oid
         JOIN pg_roles r ON t.typowner = r.oid
         WHERE t.typtype = 'd'
             AND n.nspname = ANY($1::text[])
@@ -409,6 +411,7 @@ async fn introspect_domains(
         let schema: String = row.get("schema_name");
         let name: String = row.get("domain_name");
         let base_type: String = row.get("base_type");
+        let base_schema: String = row.get("base_schema");
         let base_category: String = row.get("base_category");
         let base_typmod: i32 = row.get("base_typmod");
         let not_null: bool = row.get("not_null");
@@ -427,33 +430,10 @@ async fn introspect_domains(
             let element_type = map_domain_element_type(base_udt, &schema);
             PgType::Array(Box::new(element_type))
         } else {
-            match base_type.as_str() {
-                "integer" | "int4" => PgType::Integer,
-                "bigint" | "int8" => PgType::BigInt,
-                "smallint" | "int2" => PgType::SmallInt,
-                "real" | "float4" => PgType::Real,
-                "double precision" | "float8" => PgType::DoublePrecision,
-                "numeric" => decode_numeric_typmod(base_typmod),
-                "text" => PgType::Text,
-                "boolean" | "bool" => PgType::Boolean,
-                "timestamp" => PgType::Timestamp,
-                "timestamp with time zone" | "timestamptz" => PgType::TimestampTz,
-                "date" => PgType::Date,
-                "uuid" => PgType::Uuid,
-                "json" => PgType::Json,
-                "jsonb" => PgType::Jsonb,
-                "character varying" | "varchar" => {
-                    PgType::Varchar(decode_varchar_typmod(base_typmod))
-                }
-                _ => {
-                    let qualified = format!("public.{base_type}");
-                    if base_type.contains('.') {
-                        PgType::UserDefined(base_type)
-                    } else {
-                        PgType::UserDefined(qualified)
-                    }
-                }
-            }
+            // pg_type.typname is the internal name (int4, varchar, bpchar, ...), so
+            // route the base type through the same mapper table-column introspection
+            // uses, passing the domain's stored typmod for parameterized types.
+            map_udt_name_to_pg_type(&base_type, &base_schema, Some(base_typmod))
         };
 
         let domain = Domain {

--- a/src/pg/introspect.rs
+++ b/src/pg/introspect.rs
@@ -427,7 +427,7 @@ async fn introspect_domains(
                     "expected array base_type to start with '_', got: {base_type}"
                 ))
             })?;
-            let element_type = map_domain_element_type(base_udt, &schema);
+            let element_type = map_udt_name_to_pg_type(base_udt, &base_schema, None);
             PgType::Array(Box::new(element_type))
         } else {
             // pg_type.typname is the internal name (int4, varchar, bpchar, ...), so
@@ -909,6 +909,17 @@ fn decode_varchar_typmod(atttypmod: i32) -> Option<u32> {
     }
 }
 
+/// Decodes a `bpchar` (`char(n)`) typmod into a declared length. Same
+/// `length + VARHDRSZ` (4) encoding as `varchar`; PostgreSQL forbids `char(0)`,
+/// so the smallest bounded typmod is 5.
+fn decode_bpchar_typmod(atttypmod: i32) -> Option<u32> {
+    if atttypmod > 4 {
+        Some((atttypmod - 4) as u32)
+    } else {
+        None
+    }
+}
+
 fn map_udt_name_to_pg_type(udt_name: &str, udt_schema: &str, atttypmod: Option<i32>) -> PgType {
     match udt_name {
         "bool" => PgType::Boolean,
@@ -934,10 +945,7 @@ fn map_udt_name_to_pg_type(udt_name: &str, udt_schema: &str, atttypmod: Option<i
         "cidr" => PgType::Cidr,
         "macaddr" => PgType::Macaddr,
         "macaddr8" => PgType::Macaddr8,
-        "bpchar" => {
-            let length = atttypmod.and_then(|m| if m > 4 { Some((m - 4) as u32) } else { None });
-            PgType::Char(length)
-        }
+        "bpchar" => PgType::Char(atttypmod.and_then(decode_bpchar_typmod)),
         "point" => PgType::Point,
         "xml" => PgType::Xml,
         "int4range" | "int8range" | "numrange" | "tsrange" | "tstzrange" | "daterange"
@@ -1029,10 +1037,6 @@ fn map_pg_type(
             "unsupported column type from database: {other} (udt_name: {udt_name})"
         ))),
     }
-}
-
-fn map_domain_element_type(base_udt: &str, domain_schema: &str) -> PgType {
-    map_udt_name_to_pg_type(base_udt, domain_schema, None)
 }
 
 /// Parse Postgres' `format_type(atttypid, atttypmod)` output for PostGIS

--- a/tests/baseline.rs
+++ b/tests/baseline.rs
@@ -436,6 +436,38 @@ async fn introspect_carries_typmod_through_domain_base_types() {
 }
 
 #[tokio::test]
+async fn introspect_maps_domain_over_char_and_user_defined_base_types() {
+    use pgmold::model::PgType;
+
+    let (_container, url) = setup_postgres().await;
+    let connection = PgConnection::new(&url).await.unwrap();
+
+    sqlx::raw_sql(
+        r#"
+        CREATE DOMAIN fixed_code AS CHAR(10);
+        CREATE TYPE mood AS ENUM ('happy', 'sad');
+        CREATE DOMAIN mood_domain AS mood;
+        "#,
+    )
+    .execute(connection.pool())
+    .await
+    .unwrap();
+
+    let schema = introspect_schema(&connection, &["public".to_string()], false)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        schema.domains["public.fixed_code"].data_type,
+        PgType::Char(Some(10))
+    );
+    assert_eq!(
+        schema.domains["public.mood_domain"].data_type,
+        PgType::UserDefined("public.mood".to_string())
+    );
+}
+
+#[tokio::test]
 async fn baseline_detects_inherited_table() {
     let (_container, url) = setup_postgres().await;
     let connection = PgConnection::new(&url).await.unwrap();

--- a/tests/baseline.rs
+++ b/tests/baseline.rs
@@ -447,6 +447,7 @@ async fn introspect_maps_domain_over_char_and_user_defined_base_types() {
         CREATE DOMAIN fixed_code AS CHAR(10);
         CREATE TYPE mood AS ENUM ('happy', 'sad');
         CREATE DOMAIN mood_domain AS mood;
+        CREATE DOMAIN mood_list AS mood[];
         "#,
     )
     .execute(connection.pool())
@@ -464,6 +465,10 @@ async fn introspect_maps_domain_over_char_and_user_defined_base_types() {
     assert_eq!(
         schema.domains["public.mood_domain"].data_type,
         PgType::UserDefined("public.mood".to_string())
+    );
+    assert_eq!(
+        schema.domains["public.mood_list"].data_type,
+        PgType::Array(Box::new(PgType::UserDefined("public.mood".to_string())))
     );
 }
 


### PR DESCRIPTION
## Problem

The non-array branch of domain introspection hand-rolled a `match` on `bt.typname`. Since `typname` is PostgreSQL's internal name (`int4`, `varchar`, `bpchar`, `float8`, `bool`, ...), the match's display-name arms (`"integer"`, `"character varying"`, `"double precision"`, `"boolean"`) were dead, and there was no `bpchar` arm at all: a domain over `char(n)` fell through to `UserDefined("public.bpchar")`, losing both the type and the length.

## Fix

Delegate to `map_udt_name_to_pg_type` — the same mapper table-column introspection uses — passing the domain's `typtypmod`. This:

- Fixes `char(n)` domains (now `Char(Some(n))`).
- Removes the dead display-name arms.
- Resolves user-defined base types under their actual schema, via a new `base_schema` join, instead of a hardcoded `"public"`.
- Routes array-domain element types through `base_schema` too.

`decode_bpchar_typmod` is extracted to mirror `decode_varchar_typmod`.

## Tests

Introspection test asserting `char(10)` -> `Char(Some(10))`, a domain over an enum -> `UserDefined("public.mood")`, and a domain over `mood[]` -> `Array(UserDefined("public.mood"))`.

## Out of scope (follow-ups already filed)

- Array-domain element typmod is still dropped (e.g. `numeric(10,2)[]`).
- `diff_domains` does not compare `data_type`.