### PR TITLE
fix(diff): emit drop+add when a foreign key's shape changes

### DIFF
--- a/src/diff/mod.rs
+++ b/src/diff/mod.rs
@@ -985,6 +985,40 @@ mod tests {
     }
 
     #[test]
+    fn detects_changed_foreign_key_as_drop_and_add() {
+        let make = |on_delete: ReferentialAction| ForeignKey {
+            name: "posts_user_id_fkey".to_string(),
+            columns: vec!["user_id".to_string()],
+            referenced_table: "users".to_string(),
+            referenced_schema: "public".to_string(),
+            referenced_columns: vec!["id".to_string()],
+            on_delete,
+            on_update: ReferentialAction::NoAction,
+        };
+
+        let mut from = empty_schema();
+        let mut from_table = simple_table("posts");
+        from_table
+            .foreign_keys
+            .push(make(ReferentialAction::NoAction));
+        from.tables.insert("posts".to_string(), from_table);
+
+        let mut to = empty_schema();
+        let mut to_table = simple_table("posts");
+        to_table.foreign_keys.push(make(ReferentialAction::Cascade));
+        to.tables.insert("posts".to_string(), to_table);
+
+        let ops = compute_diff(&from, &to);
+        assert_eq!(ops.len(), 2);
+        assert!(
+            matches!(&ops[0], MigrationOp::DropForeignKey { table, foreign_key_name } if table == "public.posts" && foreign_key_name == "posts_user_id_fkey")
+        );
+        assert!(
+            matches!(&ops[1], MigrationOp::AddForeignKey { table, foreign_key } if table == "public.posts" && foreign_key.on_delete == ReferentialAction::Cascade)
+        );
+    }
+
+    #[test]
     fn detects_added_function() {
         let from = empty_schema();
         let mut to = empty_schema();

--- a/src/diff/table_elements.rs
+++ b/src/diff/table_elements.rs
@@ -232,6 +232,11 @@ pub(super) fn diff_foreign_keys(from_table: &Table, to_table: &Table) -> Vec<Mig
             Some(from_fk) => {
                 // PostgreSQL has no ALTER for a foreign key's shape, so a changed
                 // target, column list, or referential action is a drop then an add.
+                // Raw equality is safe here (unlike check constraints, which need
+                // semantically_equals): referential actions are the same enum on
+                // both sides, the column lists are plain identifiers with no
+                // expression folding, and referenced_schema defaults to "public"
+                // to match introspection.
                 if from_fk != foreign_key {
                     ops.push(MigrationOp::DropForeignKey {
                         table: qualified_table_name.clone(),

--- a/src/diff/table_elements.rs
+++ b/src/diff/table_elements.rs
@@ -224,15 +224,31 @@ pub(super) fn diff_foreign_keys(from_table: &Table, to_table: &Table) -> Vec<Mig
     let qualified_table_name = QualifiedName::new(&to_table.schema, &to_table.name);
 
     for foreign_key in &to_table.foreign_keys {
-        if !from_table
+        match from_table
             .foreign_keys
             .iter()
-            .any(|fk| fk.name == foreign_key.name)
+            .find(|fk| fk.name == foreign_key.name)
         {
-            ops.push(MigrationOp::AddForeignKey {
-                table: qualified_table_name.clone(),
-                foreign_key: foreign_key.clone(),
-            });
+            Some(from_fk) => {
+                // PostgreSQL has no ALTER for a foreign key's shape, so a changed
+                // target, column list, or referential action is a drop then an add.
+                if from_fk != foreign_key {
+                    ops.push(MigrationOp::DropForeignKey {
+                        table: qualified_table_name.clone(),
+                        foreign_key_name: from_fk.name.clone(),
+                    });
+                    ops.push(MigrationOp::AddForeignKey {
+                        table: qualified_table_name.clone(),
+                        foreign_key: foreign_key.clone(),
+                    });
+                }
+            }
+            None => {
+                ops.push(MigrationOp::AddForeignKey {
+                    table: qualified_table_name.clone(),
+                    foreign_key: foreign_key.clone(),
+                });
+            }
         }
     }
 

--- a/tests/foreign_keys.rs
+++ b/tests/foreign_keys.rs
@@ -655,12 +655,19 @@ async fn changed_foreign_key_action_is_dropped_and_re_added() {
         .unwrap();
     let ops = compute_diff(&current, &target_schema);
 
-    assert!(ops
+    let drop_pos = ops
         .iter()
-        .any(|op| matches!(op, MigrationOp::DropForeignKey { .. })));
-    assert!(ops
+        .position(|op| matches!(op, MigrationOp::DropForeignKey { .. }))
+        .expect("expected a DropForeignKey op");
+    let add_pos = ops
         .iter()
-        .any(|op| matches!(op, MigrationOp::AddForeignKey { .. })));
+        .position(|op| matches!(op, MigrationOp::AddForeignKey { .. }))
+        .expect("expected an AddForeignKey op");
+    assert_eq!(ops.len(), 2, "only the changed FK should diff: {ops:?}");
+    assert!(
+        drop_pos < add_pos,
+        "DropForeignKey must precede AddForeignKey"
+    );
 
     let planned = plan_migration(ops);
     let sql = generate_sql(&planned);

--- a/tests/foreign_keys.rs
+++ b/tests/foreign_keys.rs
@@ -610,3 +610,72 @@ async fn fk_type_change_referenced_column_only() {
         "DropForeignKey (pos {drop_fk_pos}) must come before AlterColumn (pos {alter_pos})"
     );
 }
+
+#[tokio::test]
+async fn changed_foreign_key_action_is_dropped_and_re_added() {
+    let (_container, url) = setup_postgres().await;
+    let connection = PgConnection::new(&url).await.unwrap();
+
+    let initial_sql = r#"
+        CREATE TABLE "public"."parent" (
+            "id" INTEGER NOT NULL,
+            CONSTRAINT "parent_pkey" PRIMARY KEY ("id")
+        );
+        CREATE TABLE "public"."child" (
+            "id" INTEGER NOT NULL,
+            "parent_id" INTEGER NOT NULL,
+            CONSTRAINT "child_pkey" PRIMARY KEY ("id"),
+            CONSTRAINT "child_parent_id_fkey" FOREIGN KEY ("parent_id")
+                REFERENCES "public"."parent"("id") ON DELETE NO ACTION
+        );
+    "#;
+    for stmt in initial_sql.split(';').filter(|s| !s.trim().is_empty()) {
+        sqlx::query(stmt).execute(connection.pool()).await.unwrap();
+    }
+
+    let target_schema = parse_sql_string(
+        r#"
+        CREATE TABLE "public"."parent" (
+            "id" INTEGER NOT NULL,
+            CONSTRAINT "parent_pkey" PRIMARY KEY ("id")
+        );
+        CREATE TABLE "public"."child" (
+            "id" INTEGER NOT NULL,
+            "parent_id" INTEGER NOT NULL,
+            CONSTRAINT "child_pkey" PRIMARY KEY ("id"),
+            CONSTRAINT "child_parent_id_fkey" FOREIGN KEY ("parent_id")
+                REFERENCES "public"."parent"("id") ON DELETE CASCADE
+        );
+        "#,
+    )
+    .unwrap();
+
+    let current = introspect_schema(&connection, &["public".to_string()], false)
+        .await
+        .unwrap();
+    let ops = compute_diff(&current, &target_schema);
+
+    assert!(ops
+        .iter()
+        .any(|op| matches!(op, MigrationOp::DropForeignKey { .. })));
+    assert!(ops
+        .iter()
+        .any(|op| matches!(op, MigrationOp::AddForeignKey { .. })));
+
+    let planned = plan_migration(ops);
+    let sql = generate_sql(&planned);
+    for stmt in &sql {
+        sqlx::query(stmt)
+            .execute(connection.pool())
+            .await
+            .unwrap_or_else(|e| panic!("Failed to execute: {stmt}\nError: {e}"));
+    }
+
+    let after = introspect_schema(&connection, &["public".to_string()], false)
+        .await
+        .unwrap();
+    assert!(
+        compute_diff(&after, &target_schema).is_empty(),
+        "schema should converge after re-adding the changed foreign key"
+    );
+}


### PR DESCRIPTION
## Problem

`diff_foreign_keys` matched foreign keys by name only. A same-named FK whose referenced table, referenced columns, local columns, or `ON DELETE`/`ON UPDATE` action changed produced **no migration** and silently drifted. (This is also what hid the FK reference-truncation fix from convergence in #349.)

## Fix

PostgreSQL has no `ALTER` for a foreign key's shape, so diff it the way check constraints are already diffed: find the matching FK by name, and on any structural difference emit `DropForeignKey` then `AddForeignKey`. Added and removed FKs keep their existing behavior. The planner already orders every `DropForeignKey` before every `AddForeignKey`, so the rebuild applies cleanly.

Raw `PartialEq` is safe here (no `semantically_equals` needed): referential actions are the same enum on both sides, FK column lists are plain identifiers with no expression folding, and `referenced_schema` defaults to `public` to match introspection — documented inline.

## Tests

- Unit test: a same-named FK with a changed action diffs to exactly `[DropForeignKey, AddForeignKey]`.
- End-to-end test: applies a real `ON DELETE NO ACTION` -> `CASCADE` change against PostgreSQL, asserts exactly two correctly-ordered ops, applies the migration, and asserts the re-plan is empty (converges).
- Full convergence suite (51) and foreign_keys integration pass — the deeper comparison surfaces no parser/introspect normalization mismatch.

## Scope

This is the foreign-key half of pgmold-2byz. `diff_partitions` ignoring the partition parent/bound is tracked as a separate follow-up.