### PR TITLE
fix(parser): truncate policy and trigger target-table references

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -216,7 +216,7 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
                 with_check,
                 ..
             }) => {
-                let (tbl_schema, tbl_name) = extract_qualified_name(&table_name);
+                let (tbl_schema, tbl_name) = extract_qualified_name_truncated(&table_name);
                 let policy = Policy {
                     name: truncated_ident(&name),
                     table_schema: tbl_schema,
@@ -839,7 +839,7 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
                 characteristics,
                 ..
             }) => {
-                let (tbl_schema, tbl_name) = extract_qualified_name(&table_name);
+                let (tbl_schema, tbl_name) = extract_qualified_name_truncated(&table_name);
                 let trigger_name = truncated_ident(&name);
                 let exec = exec_body.as_ref().ok_or_else(|| {
                     SchemaError::ParseError(format!(

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1109,7 +1109,7 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
                 table_name: Some(ref tbl),
                 ..
             }) => {
-                let (tbl_schema, tbl_name) = extract_qualified_name(tbl);
+                let (tbl_schema, tbl_name) = extract_qualified_name_truncated(tbl);
                 let trigger_key = make_trigger_key(
                     &tbl_schema,
                     &tbl_name,
@@ -1121,7 +1121,7 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
             Statement::DropPolicy(sqlparser::ast::DropPolicy {
                 name, table_name, ..
             }) => {
-                let (tbl_schema, tbl_name) = extract_qualified_name(&table_name);
+                let (tbl_schema, tbl_name) = extract_qualified_name_truncated(&table_name);
                 let tbl_key = qualified_name(&tbl_schema, &tbl_name);
                 let policy_name = truncated_ident(&name);
 

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -1492,6 +1492,42 @@ fn alter_table_add_foreign_key_truncates_references() {
 }
 
 #[test]
+fn policy_on_overlong_table_truncates_table_reference() {
+    let table = "p".repeat(64);
+    let sql = format!(
+        "CREATE TABLE {table} (id INT NOT NULL); \
+         CREATE POLICY my_policy ON {table} FOR SELECT USING (true);"
+    );
+    let schema = parse_sql_string(&sql).unwrap();
+    let parsed = schema
+        .tables
+        .get(&format!("public.{}", "p".repeat(63)))
+        .unwrap();
+    assert!(
+        parsed.policies.iter().any(|p| p.name == "my_policy"),
+        "policy should attach to the truncated table, not orphan in pending_policies"
+    );
+    assert_eq!(parsed.policies[0].table, "p".repeat(63));
+}
+
+#[test]
+fn trigger_on_overlong_table_truncates_table_reference() {
+    let table = "g".repeat(64);
+    let sql = format!(
+        "CREATE TABLE {table} (id INT NOT NULL); \
+         CREATE TRIGGER my_trigger BEFORE INSERT ON {table} \
+            FOR EACH ROW EXECUTE FUNCTION my_fn();"
+    );
+    let schema = parse_sql_string(&sql).unwrap();
+    let trigger = schema
+        .triggers
+        .values()
+        .find(|t| t.name == "my_trigger")
+        .unwrap();
+    assert_eq!(trigger.target_name, "g".repeat(63));
+}
+
+#[test]
 fn index_on_overlong_column_truncates_plain_reference_but_leaves_expressions() {
     let column = "z".repeat(64);
     let sql = format!(

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -1503,10 +1503,12 @@ fn policy_on_overlong_table_truncates_table_reference() {
         .tables
         .get(&format!("public.{}", "p".repeat(63)))
         .unwrap();
-    assert!(
-        parsed.policies.iter().any(|p| p.name == "my_policy"),
+    assert_eq!(
+        parsed.policies.len(),
+        1,
         "policy should attach to the truncated table, not orphan in pending_policies"
     );
+    assert_eq!(parsed.policies[0].name, "my_policy");
     assert_eq!(parsed.policies[0].table, "p".repeat(63));
 }
 
@@ -1525,6 +1527,31 @@ fn trigger_on_overlong_table_truncates_table_reference() {
         .find(|t| t.name == "my_trigger")
         .unwrap();
     assert_eq!(trigger.target_name, "g".repeat(63));
+}
+
+#[test]
+fn drop_trigger_and_policy_on_overlong_table_match_truncated_targets() {
+    let table = "d".repeat(64);
+    let sql = format!(
+        "CREATE TABLE {table} (id INT NOT NULL); \
+         CREATE TRIGGER trg BEFORE INSERT ON {table} FOR EACH ROW EXECUTE FUNCTION fn(); \
+         CREATE POLICY pol ON {table} FOR SELECT USING (true); \
+         DROP TRIGGER trg ON {table}; \
+         DROP POLICY pol ON {table};"
+    );
+    let schema = parse_sql_string(&sql).unwrap();
+    assert!(
+        schema.triggers.is_empty(),
+        "DROP TRIGGER on the truncated table should remove the trigger"
+    );
+    let parsed = schema
+        .tables
+        .get(&format!("public.{}", "d".repeat(63)))
+        .unwrap();
+    assert!(
+        parsed.policies.is_empty(),
+        "DROP POLICY on the truncated table should remove the policy"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Problem

`CREATE POLICY`, `CREATE TRIGGER`, `DROP POLICY`, and `DROP TRIGGER` resolved their target table name via `extract_qualified_name` (untruncated). For a table whose name exceeds NAMEDATALEN-1 (63 bytes), the stored/looked-up reference held a name PostgreSQL never has:

- A trigger's `target_name` (and its key) drifted from the truncated table.
- A policy never matched its truncated table during `finalize_partial`, so it was silently orphaned in `pending_policies` instead of attaching.
- `DROP TRIGGER`/`DROP POLICY ON <64-byte-table>` built a key that missed the one written at definition time, so the drop silently no-op'd.

## Fix

Route all four sites through `extract_qualified_name_truncated` (extract + non-recording truncate on the name, schema untruncated), mirroring the other reference/lookup sites.

## Tests

Parser unit tests: a policy attaches to the truncated table (not orphaned), a trigger's `target_name` is truncated, and a create-then-`DROP` round trip on a 64-byte table removes both the trigger and the policy.

## Out of scope (already tracked)

- The trigger's `EXECUTE FUNCTION` name reference is not truncated (rare).
- `diff_partitions`, expression-index inner identifiers.