### PR TITLE
fix(parser): truncate COMMENT ON targets, trigger/aggregate names at NAMEDATALEN-1

### DIFF
--- a/src/parser/comments.rs
+++ b/src/parser/comments.rs
@@ -22,7 +22,10 @@ use crate::model::{
 };
 use crate::util::{Result, SchemaError};
 
-use super::util::{extract_qualified_name, unquote_ident};
+use super::util::{
+    extract_qualified_name, extract_qualified_name_truncated, truncate_referenced_identifier,
+    unquote_ident,
+};
 
 /// Parameters captured from `Statement::Comment` and forwarded to the
 /// pending-comment queue. Mirrors the fields of the AST variant so callers
@@ -57,7 +60,7 @@ pub(super) fn apply_comment_statement(
 
     match object_type {
         CommentObject::Table => {
-            let (obj_schema, obj_name) = extract_qualified_name(object_name);
+            let (obj_schema, obj_name) = extract_qualified_name_truncated(object_name);
             push(
                 schema,
                 PendingCommentObjectType::Table,
@@ -67,11 +70,13 @@ pub(super) fn apply_comment_statement(
         }
         CommentObject::Column => {
             let (table_schema, table_name, column_name) = extract_three_part_name(object_name)?;
+            let table_name = truncate_referenced_identifier(&table_name);
+            let column_name = truncate_referenced_identifier(&column_name);
             let key = format!("{table_schema}.{table_name}.{column_name}");
             push(schema, PendingCommentObjectType::Column, key, comment);
         }
         CommentObject::View => {
-            let (obj_schema, obj_name) = extract_qualified_name(object_name);
+            let (obj_schema, obj_name) = extract_qualified_name_truncated(object_name);
             push(
                 schema,
                 PendingCommentObjectType::View,
@@ -80,7 +85,7 @@ pub(super) fn apply_comment_statement(
             );
         }
         CommentObject::MaterializedView => {
-            let (obj_schema, obj_name) = extract_qualified_name(object_name);
+            let (obj_schema, obj_name) = extract_qualified_name_truncated(object_name);
             push(
                 schema,
                 PendingCommentObjectType::MaterializedView,
@@ -89,7 +94,7 @@ pub(super) fn apply_comment_statement(
             );
         }
         CommentObject::Type => {
-            let (obj_schema, obj_name) = extract_qualified_name(object_name);
+            let (obj_schema, obj_name) = extract_qualified_name_truncated(object_name);
             push(
                 schema,
                 PendingCommentObjectType::Type,
@@ -98,7 +103,7 @@ pub(super) fn apply_comment_statement(
             );
         }
         CommentObject::Domain => {
-            let (obj_schema, obj_name) = extract_qualified_name(object_name);
+            let (obj_schema, obj_name) = extract_qualified_name_truncated(object_name);
             push(
                 schema,
                 PendingCommentObjectType::Domain,
@@ -113,7 +118,7 @@ pub(super) fn apply_comment_statement(
             push(schema, PendingCommentObjectType::Schema, key, comment);
         }
         CommentObject::Sequence => {
-            let (obj_schema, obj_name) = extract_qualified_name(object_name);
+            let (obj_schema, obj_name) = extract_qualified_name_truncated(object_name);
             push(
                 schema,
                 PendingCommentObjectType::Sequence,
@@ -122,7 +127,7 @@ pub(super) fn apply_comment_statement(
             );
         }
         CommentObject::Function => {
-            let (func_schema, func_name) = extract_qualified_name(object_name);
+            let (func_schema, func_name) = extract_qualified_name_truncated(object_name);
             let args_canonical = canonical_args(arguments);
             let key = format!("{func_schema}.{func_name}({args_canonical})");
             push(schema, PendingCommentObjectType::Function, key, comment);
@@ -136,7 +141,7 @@ pub(super) fn apply_comment_statement(
                     "COMMENT ON AGGREGATE {object_name}: argument list is required"
                 )));
             };
-            let (agg_schema, agg_name) = extract_qualified_name(object_name);
+            let (agg_schema, agg_name) = extract_qualified_name_truncated(object_name);
             let args_canonical = canonical_args(Some(args));
             let key = format!("{agg_schema}.{agg_name}({args_canonical})");
             push(schema, PendingCommentObjectType::Aggregate, key, comment);
@@ -148,13 +153,14 @@ pub(super) fn apply_comment_statement(
                     "COMMENT ON TRIGGER expects an unqualified trigger name, got {object_name}"
                 )));
             }
-            let trigger_name = trigger_parts.into_iter().next().unwrap();
+            let trigger_name =
+                truncate_referenced_identifier(&trigger_parts.into_iter().next().unwrap());
             let Some(partner_table) = partner_table else {
                 return Err(SchemaError::ParseError(
                     "COMMENT ON TRIGGER missing ON <table> tail".into(),
                 ));
             };
-            let (table_schema, table_name) = extract_qualified_name(partner_table);
+            let (table_schema, table_name) = extract_qualified_name_truncated(partner_table);
             let key = format!("{table_schema}.{table_name}.{trigger_name}");
             push(schema, PendingCommentObjectType::Trigger, key, comment);
         }
@@ -169,13 +175,14 @@ pub(super) fn apply_comment_statement(
                     "COMMENT ON CONSTRAINT expects an unqualified constraint name, got {object_name}"
                 )));
             }
-            let constraint_name = constraint_parts.into_iter().next().unwrap();
+            let constraint_name =
+                truncate_referenced_identifier(&constraint_parts.into_iter().next().unwrap());
             let Some(partner_relation) = partner_table else {
                 return Err(SchemaError::ParseError(
                     "COMMENT ON CONSTRAINT missing ON [DOMAIN] <relation> tail".into(),
                 ));
             };
-            let (parent_schema, parent_name) = extract_qualified_name(partner_relation);
+            let (parent_schema, parent_name) = extract_qualified_name_truncated(partner_relation);
             let key = format!("{parent_schema}.{parent_name}.{constraint_name}");
             schema.pending_comments.push(PendingComment {
                 object_type: PendingCommentObjectType::Constraint,
@@ -208,13 +215,14 @@ pub(super) fn apply_comment_statement(
                     "COMMENT ON POLICY expects an unqualified policy name, got {object_name}"
                 )));
             }
-            let policy_name = policy_parts.into_iter().next().unwrap();
+            let policy_name =
+                truncate_referenced_identifier(&policy_parts.into_iter().next().unwrap());
             let Some(partner_table) = partner_table else {
                 return Err(SchemaError::ParseError(
                     "COMMENT ON POLICY missing ON <table> tail".into(),
                 ));
             };
-            let (table_schema, table_name) = extract_qualified_name(partner_table);
+            let (table_schema, table_name) = extract_qualified_name_truncated(partner_table);
             let key = format!("{table_schema}.{table_name}.{policy_name}");
             push(schema, PendingCommentObjectType::Policy, key, comment);
         }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -847,7 +847,7 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
                     ))
                 })?;
                 let func_unqualified = exec.func_name.0.len() == 1;
-                let (func_schema, func_name) = extract_qualified_name(&exec.func_name);
+                let (func_schema, func_name) = extract_qualified_name_truncated(&exec.func_name);
                 let func_schema = if func_unqualified && is_pg_catalog_trigger_function(&func_name)
                 {
                     "pg_catalog".to_string()

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1511,7 +1511,8 @@ fn is_pg_catalog_trigger_function(name: &str) -> bool {
 }
 
 fn parse_create_aggregate(stmt: CreateAggregate, schema: &mut Schema) -> Result<()> {
-    let (agg_schema, agg_name) = extract_qualified_name(&stmt.name);
+    let (agg_schema, raw_agg_name) = extract_qualified_name(&stmt.name);
+    let agg_name = truncate_identifier(&raw_agg_name);
     let args: Vec<String> = stmt
         .args
         .iter()

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -2817,6 +2817,7 @@ fn comment_on_overlong_trigger_name_attaches() {
         .find(|t| t.name == "g".repeat(63))
         .expect("trigger should parse under its truncated name");
     assert_eq!(parsed.comment.as_deref(), Some("hi"));
+    assert!(schema.pending_comments.is_empty());
 }
 
 #[test]
@@ -2835,6 +2836,7 @@ fn comment_on_overlong_policy_name_attaches() {
         .find(|p| p.name == "y".repeat(63))
         .expect("policy should attach under its truncated name");
     assert_eq!(parsed.comment.as_deref(), Some("hi"));
+    assert!(schema.pending_comments.is_empty());
 }
 
 #[test]
@@ -2848,6 +2850,13 @@ fn comment_on_overlong_constraint_name_attaches() {
     assert!(
         schema.pending_comments.is_empty(),
         "constraint comment should attach to the truncated constraint, not stay pending"
+    );
+    assert_eq!(
+        schema
+            .table_constraint_comments
+            .get(&format!("public.tbl.{}", "k".repeat(63)))
+            .map(String::as_str),
+        Some("hi")
     );
 }
 
@@ -2864,6 +2873,7 @@ fn comment_on_overlong_aggregate_name_attaches() {
         .get(&format!("public.{}(integer)", "a".repeat(63)))
         .expect("aggregate should be stored under its truncated name");
     assert_eq!(parsed.comment.as_deref(), Some("hi"));
+    assert!(schema.pending_comments.is_empty());
 }
 
 #[test]

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -2693,6 +2693,53 @@ fn comment_on_column_accepts_e_string_literal() {
 }
 
 #[test]
+fn comment_on_overlong_table_attaches_to_truncated_table() {
+    let table = "t".repeat(64);
+    let sql = format!(
+        "CREATE TABLE {table} (id integer PRIMARY KEY); \
+         COMMENT ON TABLE {table} IS 'hello';"
+    );
+    let schema = parse_sql_string(&sql).unwrap();
+    let parsed = schema
+        .tables
+        .get(&format!("public.{}", "t".repeat(63)))
+        .expect("table should parse");
+    assert_eq!(parsed.comment.as_deref(), Some("hello"));
+}
+
+#[test]
+fn comment_on_overlong_column_attaches_to_truncated_column() {
+    let column = "c".repeat(64);
+    let sql = format!(
+        "CREATE TABLE orders (id integer PRIMARY KEY, {column} numeric); \
+         COMMENT ON COLUMN orders.{column} IS 'amount';"
+    );
+    let schema = parse_sql_string(&sql).unwrap();
+    let table = schema.tables.get("public.orders").unwrap();
+    let col = table
+        .columns
+        .get(&"c".repeat(63))
+        .expect("column should exist");
+    assert_eq!(col.comment.as_deref(), Some("amount"));
+}
+
+#[test]
+fn trigger_execute_function_name_is_truncated() {
+    let func = "f".repeat(64);
+    let sql = format!(
+        "CREATE TRIGGER trg BEFORE INSERT ON some_table \
+         FOR EACH ROW EXECUTE FUNCTION {func}();"
+    );
+    let schema = parse_sql_string(&sql).unwrap();
+    let trigger = schema
+        .triggers
+        .values()
+        .find(|t| t.name == "trg")
+        .expect("trigger should parse");
+    assert_eq!(trigger.function_name, "f".repeat(63));
+}
+
+#[test]
 fn comment_on_table_accepts_dollar_quoted_literal() {
     let sql = r#"
         CREATE TABLE t (id integer PRIMARY KEY);

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -2803,6 +2803,70 @@ fn trigger_execute_function_name_is_truncated() {
 }
 
 #[test]
+fn comment_on_overlong_trigger_name_attaches() {
+    let trigger = "g".repeat(64);
+    let sql = format!(
+        "CREATE TABLE tbl (id integer PRIMARY KEY); \
+         CREATE TRIGGER {trigger} BEFORE INSERT ON tbl FOR EACH ROW EXECUTE FUNCTION fn(); \
+         COMMENT ON TRIGGER {trigger} ON tbl IS 'hi';"
+    );
+    let schema = parse_sql_string(&sql).unwrap();
+    let parsed = schema
+        .triggers
+        .values()
+        .find(|t| t.name == "g".repeat(63))
+        .expect("trigger should parse under its truncated name");
+    assert_eq!(parsed.comment.as_deref(), Some("hi"));
+}
+
+#[test]
+fn comment_on_overlong_policy_name_attaches() {
+    let policy = "y".repeat(64);
+    let sql = format!(
+        "CREATE TABLE tbl (id integer PRIMARY KEY); \
+         CREATE POLICY {policy} ON tbl FOR SELECT USING (true); \
+         COMMENT ON POLICY {policy} ON tbl IS 'hi';"
+    );
+    let schema = parse_sql_string(&sql).unwrap();
+    let table = schema.tables.get("public.tbl").unwrap();
+    let parsed = table
+        .policies
+        .iter()
+        .find(|p| p.name == "y".repeat(63))
+        .expect("policy should attach under its truncated name");
+    assert_eq!(parsed.comment.as_deref(), Some("hi"));
+}
+
+#[test]
+fn comment_on_overlong_constraint_name_attaches() {
+    let constraint = "k".repeat(64);
+    let sql = format!(
+        "CREATE TABLE tbl (id integer, CONSTRAINT {constraint} CHECK (id > 0)); \
+         COMMENT ON CONSTRAINT {constraint} ON tbl IS 'hi';"
+    );
+    let schema = parse_sql_string(&sql).unwrap();
+    assert!(
+        schema.pending_comments.is_empty(),
+        "constraint comment should attach to the truncated constraint, not stay pending"
+    );
+}
+
+#[test]
+fn comment_on_overlong_aggregate_name_attaches() {
+    let aggregate = "a".repeat(64);
+    let sql = format!(
+        "CREATE AGGREGATE {aggregate}(integer) (SFUNC = int4pl, STYPE = integer); \
+         COMMENT ON AGGREGATE {aggregate}(integer) IS 'hi';"
+    );
+    let schema = parse_sql_string(&sql).unwrap();
+    let parsed = schema
+        .aggregates
+        .get(&format!("public.{}(integer)", "a".repeat(63)))
+        .expect("aggregate should be stored under its truncated name");
+    assert_eq!(parsed.comment.as_deref(), Some("hi"));
+}
+
+#[test]
 fn comment_on_table_accepts_dollar_quoted_literal() {
     let sql = r#"
         CREATE TABLE t (id integer PRIMARY KEY);


### PR DESCRIPTION
## Problem

Several reference/declaration sites stored or looked up identifiers untruncated, so for objects whose names exceed NAMEDATALEN-1 (63 bytes):

- `COMMENT ON <object>` built its pending-comment key from the raw target name, so a comment on a >63-byte object never matched the object's truncated key during finalize and was silently dropped. Affected every comment kind: table, view, materialized view, type, domain, sequence, function, aggregate, column, trigger, constraint, policy.
- `CREATE TRIGGER` stored the `EXECUTE FUNCTION` name untruncated, drifting from introspection.
- `CREATE AGGREGATE` stored the aggregate under an untruncated key (unlike `CREATE FUNCTION`), so a >63-byte aggregate drifted and its comment couldn't attach.

## Fix

Route comment-target identifiers and the trigger function name through the existing non-recording truncation helpers (`extract_qualified_name_truncated` / `truncate_referenced_identifier`), and truncate the aggregate name at declaration with `truncate_identifier` (matching functions). Truncation is a no-op for ≤63-byte names, so normal schemas are unaffected.

## Tests

Parser unit tests assert that a comment on a >63-byte table, column, trigger, policy, constraint, and aggregate attaches to the truncated object (and that nothing is left pending), that the trigger function name is truncated, and that the aggregate is stored under its truncated key.

## Out of scope (tracked)

- `diff_partitions` (needs non-destructive Detach/Attach ops), expression-index inner identifiers, `#287` corpus.