### PR TITLE
fix(model): structured pending-comment keys for dotted identifiers

### DIFF
--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -100,7 +100,18 @@ pub enum PendingCommentObjectType {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PendingComment {
     pub object_type: PendingCommentObjectType,
+    /// For top-level kinds (Table, View, Function, ...) this is the object's
+    /// qualified key (`schema.name`) or function signature. For the nested
+    /// kinds (Column, Trigger, Policy, Constraint) this is the *parent's*
+    /// qualified key (`schema.table` / `schema.domain`); the child's own name
+    /// lives in `child_name`. The two fields are never concatenated, so a
+    /// schema, table, or child name containing a literal dot (legal via a
+    /// quoted identifier) routes correctly.
     pub object_key: String,
+    /// `Some(child)` only for the nested kinds Column, Trigger, Policy, and
+    /// Constraint, carrying the column / trigger / policy / constraint name.
+    /// `None` for every top-level kind.
+    pub child_name: Option<String>,
     pub comment: Option<String>,
     /// Only meaningful for `PendingCommentObjectType::Constraint`. `true`
     /// when the source statement used the `ON DOMAIN <domain>` tail rather
@@ -1494,12 +1505,14 @@ impl Schema {
                 }
             }
             PendingCommentObjectType::Column => {
-                if let Some((table_key, col_name)) = pc.object_key.rsplit_once('.') {
-                    if let Some(table) = self.tables.get_mut(table_key) {
-                        if let Some(column) = table.columns.get_mut(col_name) {
-                            column.comment = pc.comment.clone();
-                            return true;
-                        }
+                let column_name = pc
+                    .child_name
+                    .as_deref()
+                    .expect("Column pending comment must carry child_name");
+                if let Some(table) = self.tables.get_mut(&pc.object_key) {
+                    if let Some(column) = table.columns.get_mut(column_name) {
+                        column.comment = pc.comment.clone();
+                        return true;
                     }
                 }
                 false
@@ -1561,7 +1574,16 @@ impl Schema {
                 }
             }
             PendingCommentObjectType::Trigger => {
-                if let Some(trigger) = self.triggers.get_mut(&pc.object_key) {
+                let trigger_name = pc
+                    .child_name
+                    .as_deref()
+                    .expect("Trigger pending comment must carry child_name");
+                // The trigger map is keyed by the parent table key with the
+                // trigger name appended, matching `make_trigger_key`. Rebuild
+                // that exact key from the structured parts instead of splitting
+                // a flat string, so a dotted schema/table/trigger name routes.
+                let trigger_key = format!("{}.{}", pc.object_key, trigger_name);
+                if let Some(trigger) = self.triggers.get_mut(&trigger_key) {
                     trigger.comment = pc.comment.clone();
                     true
                 } else {
@@ -1577,49 +1599,54 @@ impl Schema {
                 }
             }
             PendingCommentObjectType::Policy => {
-                // Key encodes schema.table.policy_name. Split off the policy
-                // name (last segment) and resolve the table from the prefix.
-                if let Some((table_key, policy_name)) = pc.object_key.rsplit_once('.') {
-                    if let Some(table) = self.tables.get_mut(table_key) {
-                        if let Some(policy) =
-                            table.policies.iter_mut().find(|p| p.name == policy_name)
-                        {
-                            policy.comment = pc.comment.clone();
-                            return true;
-                        }
+                let policy_name = pc
+                    .child_name
+                    .as_deref()
+                    .expect("Policy pending comment must carry child_name");
+                if let Some(table) = self.tables.get_mut(&pc.object_key) {
+                    if let Some(policy) =
+                        table.policies.iter_mut().find(|p| p.name == policy_name)
+                    {
+                        policy.comment = pc.comment.clone();
+                        return true;
                     }
                 }
                 false
             }
             PendingCommentObjectType::Constraint => {
-                // Key encodes schema.parent.constraint_name where parent is
-                // either a table, a partition child, or a domain (when
-                // on_domain). Routed through the matching Schema-level
-                // sidecar map so we do not have to mutate every constraint
-                // variant struct. Partition children share the table sidecar
-                // because PostgreSQL stores constraint comments on the child
-                // relation, and the diff/emit path is parent-kind agnostic.
-                let Some((parent_key, _)) = pc.object_key.rsplit_once('.') else {
-                    return false;
-                };
+                // `object_key` is the parent's qualified key (`schema.parent`)
+                // and `child_name` the constraint name. The parent is either a
+                // table, a partition child, or a domain (when `on_domain`).
+                // Routed through the matching Schema-level sidecar map so we do
+                // not have to mutate every constraint variant struct. Partition
+                // children share the table sidecar because PostgreSQL stores
+                // constraint comments on the child relation, and the diff/emit
+                // path is parent-kind agnostic. The sidecar map key keeps the
+                // flat `parent.constraint` form because introspection populates
+                // the same maps with that shape.
+                let constraint_name = pc
+                    .child_name
+                    .as_deref()
+                    .expect("Constraint pending comment must carry child_name");
+                let sidecar_key = format!("{}.{}", pc.object_key, constraint_name);
                 if pc.on_domain {
-                    if !self.domains.contains_key(parent_key) {
+                    if !self.domains.contains_key(&pc.object_key) {
                         return false;
                     }
                     update_constraint_comment(
                         &mut self.domain_constraint_comments,
-                        &pc.object_key,
+                        &sidecar_key,
                         pc.comment.as_ref(),
                     );
                 } else {
-                    if !self.tables.contains_key(parent_key)
-                        && !self.partitions.contains_key(parent_key)
+                    if !self.tables.contains_key(&pc.object_key)
+                        && !self.partitions.contains_key(&pc.object_key)
                     {
                         return false;
                     }
                     update_constraint_comment(
                         &mut self.table_constraint_comments,
-                        &pc.object_key,
+                        &sidecar_key,
                         pc.comment.as_ref(),
                     );
                 }

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1604,8 +1604,7 @@ impl Schema {
                     .as_deref()
                     .expect("Policy pending comment must carry child_name");
                 if let Some(table) = self.tables.get_mut(&pc.object_key) {
-                    if let Some(policy) =
-                        table.policies.iter_mut().find(|p| p.name == policy_name)
+                    if let Some(policy) = table.policies.iter_mut().find(|p| p.name == policy_name)
                     {
                         policy.comment = pc.comment.clone();
                         return true;

--- a/src/parser/comments.rs
+++ b/src/parser/comments.rs
@@ -72,8 +72,13 @@ pub(super) fn apply_comment_statement(
             let (table_schema, table_name, column_name) = extract_three_part_name(object_name)?;
             let table_name = truncate_referenced_identifier(&table_name);
             let column_name = truncate_referenced_identifier(&column_name);
-            let key = format!("{table_schema}.{table_name}.{column_name}");
-            push(schema, PendingCommentObjectType::Column, key, comment);
+            push_nested(
+                schema,
+                PendingCommentObjectType::Column,
+                qualified_name(&table_schema, &table_name),
+                column_name,
+                comment,
+            );
         }
         CommentObject::View => {
             let (obj_schema, obj_name) = extract_qualified_name_truncated(object_name);
@@ -161,8 +166,13 @@ pub(super) fn apply_comment_statement(
                 ));
             };
             let (table_schema, table_name) = extract_qualified_name_truncated(partner_table);
-            let key = format!("{table_schema}.{table_name}.{trigger_name}");
-            push(schema, PendingCommentObjectType::Trigger, key, comment);
+            push_nested(
+                schema,
+                PendingCommentObjectType::Trigger,
+                qualified_name(&table_schema, &table_name),
+                trigger_name,
+                comment,
+            );
         }
         // Object kinds pgmold does not model. Surface a warning so the
         // statement is not silently lost; `unrecognized.rs` will also flag
@@ -183,10 +193,10 @@ pub(super) fn apply_comment_statement(
                 ));
             };
             let (parent_schema, parent_name) = extract_qualified_name_truncated(partner_relation);
-            let key = format!("{parent_schema}.{parent_name}.{constraint_name}");
             schema.pending_comments.push(PendingComment {
                 object_type: PendingCommentObjectType::Constraint,
-                object_key: key,
+                object_key: qualified_name(&parent_schema, &parent_name),
+                child_name: Some(constraint_name),
                 comment,
                 on_domain,
             });
@@ -223,8 +233,13 @@ pub(super) fn apply_comment_statement(
                 ));
             };
             let (table_schema, table_name) = extract_qualified_name_truncated(partner_table);
-            let key = format!("{table_schema}.{table_name}.{policy_name}");
-            push(schema, PendingCommentObjectType::Policy, key, comment);
+            push_nested(
+                schema,
+                PendingCommentObjectType::Policy,
+                qualified_name(&table_schema, &table_name),
+                policy_name,
+                comment,
+            );
         }
         CommentObject::Index => {
             eprintln!(
@@ -273,6 +288,27 @@ fn push(
     schema.pending_comments.push(PendingComment {
         object_type,
         object_key,
+        child_name: None,
+        comment,
+        on_domain: false,
+    });
+}
+
+/// Queues a pending comment for a nested kind (Column, Trigger, Policy) whose
+/// target is identified by a parent key plus a child name. The two names stay
+/// separate so a dotted schema, table, or child identifier routes correctly at
+/// resolution time.
+fn push_nested(
+    schema: &mut Schema,
+    object_type: PendingCommentObjectType,
+    parent_key: String,
+    child_name: String,
+    comment: Option<String>,
+) {
+    schema.pending_comments.push(PendingComment {
+        object_type,
+        object_key: parent_key,
+        child_name: Some(child_name),
         comment,
         on_domain: false,
     });

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -2756,6 +2756,63 @@ fn comment_on_column_accepts_e_string_literal() {
 }
 
 #[test]
+fn comment_on_column_with_dotted_name_attaches_to_right_column() {
+    let sql = r#"
+        CREATE TABLE mrv.orders (id integer PRIMARY KEY, "a.b" numeric);
+        COMMENT ON COLUMN mrv.orders."a.b" IS 'dotted';
+    "#;
+    let schema = parse_sql_string(sql).unwrap();
+    let table = schema.tables.get("mrv.orders").expect("table should parse");
+    let column = table
+        .columns
+        .get("a.b")
+        .expect("dotted column should exist");
+    assert_eq!(column.comment.as_deref(), Some("dotted"));
+    assert!(
+        schema.pending_comments.is_empty(),
+        "comment on dotted column should not stay pending"
+    );
+}
+
+#[test]
+fn comment_on_policy_with_dotted_table_attaches() {
+    let sql = r#"
+        CREATE TABLE mrv."a.b" (id integer PRIMARY KEY);
+        CREATE POLICY "p.q" ON mrv."a.b" FOR SELECT USING (true);
+        COMMENT ON POLICY "p.q" ON mrv."a.b" IS 'dotted-table';
+    "#;
+    let schema = parse_sql_string(sql).unwrap();
+    let table = schema
+        .tables
+        .get("mrv.a.b")
+        .expect("dotted table should parse");
+    let policy = table
+        .policies
+        .iter()
+        .find(|p| p.name == "p.q")
+        .expect("policy should exist");
+    assert_eq!(policy.comment.as_deref(), Some("dotted-table"));
+    assert!(schema.pending_comments.is_empty());
+}
+
+#[test]
+fn comment_on_trigger_with_dotted_name_attaches() {
+    let sql = r#"
+        CREATE TABLE mrv."t.u" (id integer PRIMARY KEY);
+        CREATE TRIGGER "g.h" BEFORE INSERT ON mrv."t.u" FOR EACH ROW EXECUTE FUNCTION fn();
+        COMMENT ON TRIGGER "g.h" ON mrv."t.u" IS 'dotted-trigger';
+    "#;
+    let schema = parse_sql_string(sql).unwrap();
+    let trigger = schema
+        .triggers
+        .values()
+        .find(|t| t.name == "g.h")
+        .expect("dotted trigger should parse");
+    assert_eq!(trigger.comment.as_deref(), Some("dotted-trigger"));
+    assert!(schema.pending_comments.is_empty());
+}
+
+#[test]
 fn comment_on_overlong_table_attaches_to_truncated_table() {
     let table = "t".repeat(64);
     let sql = format!(


### PR DESCRIPTION
PendingComment.object_key was a flat dot-joined string (schema.table.child) that apply_single_comment split with rsplit_once. a column, trigger, or policy name containing a literal dot (legal via quoted identifiers) misrouted and the comment was silently dropped.

nested kinds now carry the parent key and child_name as separate fields instead of concatenating them, so routing is dot-agnostic.

tests: comment_on_column_with_dotted_name_attaches_to_right_column, comment_on_policy_with_dotted_table_attaches, plus a trigger guard.

follow-up: constraint comment sidecar maps still use a flat key, out of scope here.
