### PR TITLE
fix(parser): truncate identifiers inside expression indexes

### DIFF
--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -1581,6 +1581,25 @@ fn index_on_overlong_column_truncates_plain_reference_but_leaves_expressions() {
 }
 
 #[test]
+fn expression_index_truncates_overlong_inner_identifier() {
+    let column = "z".repeat(64);
+    let truncated = "z".repeat(63);
+    let sql = format!(
+        "CREATE TABLE t (id INT NOT NULL, {column} TEXT); \
+         CREATE INDEX t_expr_idx ON t (lower({column}));"
+    );
+    let schema = parse_sql_string(&sql).unwrap();
+    let table = schema.tables.get("public.t").unwrap();
+
+    let expr = table
+        .indexes
+        .iter()
+        .find(|i| i.name == "t_expr_idx")
+        .unwrap();
+    assert_eq!(expr.columns, vec![format!("lower({truncated})")]);
+}
+
+#[test]
 fn create_index_on_overlong_table_name_is_not_dropped() {
     let table = "t".repeat(64);
     let sql = format!(

--- a/src/parser/util.rs
+++ b/src/parser/util.rs
@@ -6,11 +6,12 @@
 use crate::model::*;
 use crate::util::{normalize_type_casts, numeric_typmod_parts, Result, SchemaError};
 use sqlparser::ast::{
-    ArrayElemTypeDef, CharacterLength, CreatePolicyCommand, DataType, Expr, ForValues, Ident,
-    IndexColumn, ObjectName, PartitionBoundValue, TimezoneInfo,
+    visit_expressions_mut, ArrayElemTypeDef, CharacterLength, CreatePolicyCommand, DataType, Expr,
+    ForValues, Ident, IndexColumn, ObjectName, PartitionBoundValue, TimezoneInfo,
 };
 
 use std::cell::RefCell;
+use std::ops::ControlFlow;
 
 /// PostgreSQL's NAMEDATALEN is 64, so identifiers are truncated to 63 bytes.
 pub(crate) const PG_MAX_IDENTIFIER_LENGTH: usize = 63;
@@ -64,9 +65,38 @@ pub(super) fn truncate_referenced_columns(columns: &[Ident]) -> Vec<String> {
 /// `pg_get_indexdef`, not `attname`.
 pub(super) fn truncate_index_column(column: &IndexColumn) -> String {
     if let Expr::Identifier(ident) = &column.column.expr {
-        truncate_referenced_identifier(&ident.value)
-    } else {
-        unquote_ident(&column.column.expr.to_string()).to_string()
+        return truncate_referenced_identifier(&ident.value);
+    }
+    let mut expr = column.column.expr.clone();
+    truncate_identifiers_in_expression(&mut expr);
+    unquote_ident(&expr.to_string()).to_string()
+}
+
+/// Truncate every identifier *reference* inside an index expression (e.g. the
+/// `x` in `lower(x)`) to PG's NAMEDATALEN-1. PostgreSQL truncates the column at
+/// declaration, and `pg_get_indexdef` renders the expression with the truncated
+/// name; a parsed expression over a >63-byte column must match that truncated
+/// form or it drifts forever (perpetual DROP + CREATE INDEX). Only identifier
+/// components are touched; the rest of the expression is left as written.
+fn truncate_identifiers_in_expression(expr: &mut Expr) {
+    let _: ControlFlow<()> = visit_expressions_mut(expr, |node| {
+        match node {
+            Expr::Identifier(ident) => truncate_ident_in_place(ident),
+            Expr::CompoundIdentifier(idents) => {
+                for ident in idents.iter_mut() {
+                    truncate_ident_in_place(ident);
+                }
+            }
+            _ => {}
+        }
+        ControlFlow::Continue(())
+    });
+}
+
+fn truncate_ident_in_place(ident: &mut Ident) {
+    let truncated = truncate_referenced_identifier(&ident.value);
+    if truncated.len() != ident.value.len() {
+        ident.value = truncated;
     }
 }
 


### PR DESCRIPTION
index-column parsing truncated only the bare-identifier case to 63 bytes. an expression index like lower(<64-byte-column>) kept the inner identifier at 64 bytes while pg_get_indexdef returns the 63-byte truncated name, so plan emitted a perpetual DROP + CREATE INDEX.

expression-index columns now walk the AST and truncate every identifier component to 63 bytes, matching what postgres stores. sibling of pgmold-fgw1.

test: expression_index_truncates_overlong_inner_identifier.
