### PR TITLE
feat(diff): detach/attach partition on bound or parent change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1591,6 +1591,7 @@ version = "0.34.15"
 dependencies = [
  "anyhow",
  "assert_cmd",
+ "chrono",
  "clap",
  "criterion",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ hex = "0.4"
 regex = "1.10"
 glob = "0.3"
 petgraph = "0.6"
+chrono = { version = "0.4", default-features = false, features = ["std"] }
 
 [dev-dependencies]
 proptest = "1"

--- a/src/diff/dump_planner.rs
+++ b/src/diff/dump_planner.rs
@@ -57,6 +57,8 @@ pub(crate) fn plan_dump(ops: Vec<MigrationOp>) -> Vec<MigrationOp> {
             | MigrationOp::AlterDomain { .. }
             | MigrationOp::DropTable(_)
             | MigrationOp::DropPartition(_)
+            | MigrationOp::DetachPartition(_)
+            | MigrationOp::AttachPartition(_)
             | MigrationOp::AddColumn { .. }
             | MigrationOp::DropColumn { .. }
             | MigrationOp::AlterColumn { .. }

--- a/src/diff/mod.rs
+++ b/src/diff/mod.rs
@@ -4380,7 +4380,11 @@ CREATE TRIGGER "on_user_role_change" AFTER INSERT OR UPDATE OR DELETE ON "public
 
         let ops = compute_diff(&from, &to);
 
-        assert_eq!(ops.len(), 2, "expected exactly Detach then Attach, got {ops:?}");
+        assert_eq!(
+            ops.len(),
+            2,
+            "expected exactly Detach then Attach, got {ops:?}"
+        );
 
         match &ops[0] {
             MigrationOp::DetachPartition(detached) => {
@@ -4451,7 +4455,11 @@ CREATE TRIGGER "on_user_role_change" AFTER INSERT OR UPDATE OR DELETE ON "public
 
         let ops = compute_diff(&from, &to);
 
-        assert_eq!(ops.len(), 2, "expected exactly Detach then Attach, got {ops:?}");
+        assert_eq!(
+            ops.len(),
+            2,
+            "expected exactly Detach then Attach, got {ops:?}"
+        );
 
         match &ops[0] {
             MigrationOp::DetachPartition(detached) => {
@@ -4485,7 +4493,8 @@ CREATE TRIGGER "on_user_role_change" AFTER INSERT OR UPDATE OR DELETE ON "public
         };
 
         let mut from = empty_schema();
-        from.partitions.insert(partition_key.clone(), partition.clone());
+        from.partitions
+            .insert(partition_key.clone(), partition.clone());
         let mut to = empty_schema();
         to.partitions.insert(partition_key, partition);
 

--- a/src/diff/mod.rs
+++ b/src/diff/mod.rs
@@ -4337,6 +4337,163 @@ CREATE TRIGGER "on_user_role_change" AFTER INSERT OR UPDATE OR DELETE ON "public
     }
 
     #[test]
+    fn changed_partition_bound_emits_detach_then_attach_not_drop_recreate() {
+        use crate::model::{Partition, PartitionBound};
+
+        let partition_key = "public.events_2024".to_string();
+
+        let mut from = empty_schema();
+        from.partitions.insert(
+            partition_key.clone(),
+            Partition {
+                name: "events_2024".to_string(),
+                schema: "public".to_string(),
+                parent_schema: "public".to_string(),
+                parent_name: "events".to_string(),
+                bound: PartitionBound::Range {
+                    from: vec!["'2024-01-01'".to_string()],
+                    to: vec!["'2024-07-01'".to_string()],
+                },
+                indexes: Vec::new(),
+                check_constraints: Vec::new(),
+                owner: None,
+            },
+        );
+
+        let mut to = empty_schema();
+        to.partitions.insert(
+            partition_key.clone(),
+            Partition {
+                name: "events_2024".to_string(),
+                schema: "public".to_string(),
+                parent_schema: "public".to_string(),
+                parent_name: "events".to_string(),
+                bound: PartitionBound::Range {
+                    from: vec!["'2024-01-01'".to_string()],
+                    to: vec!["'2025-01-01'".to_string()],
+                },
+                indexes: Vec::new(),
+                check_constraints: Vec::new(),
+                owner: None,
+            },
+        );
+
+        let ops = compute_diff(&from, &to);
+
+        assert_eq!(ops.len(), 2, "expected exactly Detach then Attach, got {ops:?}");
+
+        match &ops[0] {
+            MigrationOp::DetachPartition(detached) => {
+                assert_eq!(detached.name, "events_2024");
+                assert_eq!(detached.parent_name, "events");
+                assert_eq!(
+                    detached.bound,
+                    PartitionBound::Range {
+                        from: vec!["'2024-01-01'".to_string()],
+                        to: vec!["'2024-07-01'".to_string()],
+                    }
+                );
+            }
+            other => panic!("expected DetachPartition first, got {other:?}"),
+        }
+
+        match &ops[1] {
+            MigrationOp::AttachPartition(attached) => {
+                assert_eq!(attached.name, "events_2024");
+                assert_eq!(attached.parent_name, "events");
+                assert_eq!(
+                    attached.bound,
+                    PartitionBound::Range {
+                        from: vec!["'2024-01-01'".to_string()],
+                        to: vec!["'2025-01-01'".to_string()],
+                    }
+                );
+            }
+            other => panic!("expected AttachPartition second, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn changed_partition_parent_emits_detach_from_old_then_attach_to_new() {
+        use crate::model::{Partition, PartitionBound};
+
+        let partition_key = "public.events_2024".to_string();
+
+        let mut from = empty_schema();
+        from.partitions.insert(
+            partition_key.clone(),
+            Partition {
+                name: "events_2024".to_string(),
+                schema: "public".to_string(),
+                parent_schema: "public".to_string(),
+                parent_name: "events_old".to_string(),
+                bound: PartitionBound::Default,
+                indexes: Vec::new(),
+                check_constraints: Vec::new(),
+                owner: None,
+            },
+        );
+
+        let mut to = empty_schema();
+        to.partitions.insert(
+            partition_key.clone(),
+            Partition {
+                name: "events_2024".to_string(),
+                schema: "public".to_string(),
+                parent_schema: "public".to_string(),
+                parent_name: "events_new".to_string(),
+                bound: PartitionBound::Default,
+                indexes: Vec::new(),
+                check_constraints: Vec::new(),
+                owner: None,
+            },
+        );
+
+        let ops = compute_diff(&from, &to);
+
+        assert_eq!(ops.len(), 2, "expected exactly Detach then Attach, got {ops:?}");
+
+        match &ops[0] {
+            MigrationOp::DetachPartition(detached) => {
+                assert_eq!(detached.parent_name, "events_old");
+            }
+            other => panic!("expected DetachPartition first, got {other:?}"),
+        }
+
+        match &ops[1] {
+            MigrationOp::AttachPartition(attached) => {
+                assert_eq!(attached.parent_name, "events_new");
+            }
+            other => panic!("expected AttachPartition second, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unchanged_partition_emits_no_detach_or_attach() {
+        use crate::model::{Partition, PartitionBound};
+
+        let partition_key = "public.events_2024".to_string();
+        let partition = Partition {
+            name: "events_2024".to_string(),
+            schema: "public".to_string(),
+            parent_schema: "public".to_string(),
+            parent_name: "events".to_string(),
+            bound: PartitionBound::Default,
+            indexes: Vec::new(),
+            check_constraints: Vec::new(),
+            owner: None,
+        };
+
+        let mut from = empty_schema();
+        from.partitions.insert(partition_key.clone(), partition.clone());
+        let mut to = empty_schema();
+        to.partitions.insert(partition_key, partition);
+
+        let ops = compute_diff(&from, &to);
+        assert!(ops.is_empty(), "expected no ops, got {ops:?}");
+    }
+
+    #[test]
     fn ignores_partition_owner_change_when_flag_disabled() {
         use crate::model::{Partition, PartitionBound};
 

--- a/src/diff/objects.rs
+++ b/src/diff/objects.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use crate::model::{
     parse_qualified_name, qualified_name, EnumType, Grant, Schema, Sequence, Server, Trigger,
 };
-use crate::util::optional_expressions_equal;
+use crate::util::{optional_expressions_equal, partition_bounds_equal};
 
 use super::grants::{create_grants_for_new_object, diff_grants_for_object};
 use super::{
@@ -388,7 +388,7 @@ pub(super) fn diff_partitions(
             // changed bound/parent becomes a non-destructive DETACH then ATTACH.
             if from_partition.parent_schema != to_partition.parent_schema
                 || from_partition.parent_name != to_partition.parent_name
-                || from_partition.bound != to_partition.bound
+                || !partition_bounds_equal(&from_partition.bound, &to_partition.bound)
             {
                 ops.push(MigrationOp::DetachPartition(from_partition.clone()));
                 ops.push(MigrationOp::AttachPartition(to_partition.clone()));

--- a/src/diff/objects.rs
+++ b/src/diff/objects.rs
@@ -382,7 +382,18 @@ pub(super) fn diff_partitions(
         &from.partitions,
         &to.partitions,
         |_key, partition| MigrationOp::CreatePartition(partition.clone()),
-        |_ops, _key, _from_partition, _to_partition| {},
+        |ops, _key, from_partition, to_partition| {
+            // PostgreSQL cannot ALTER a partition's bound or parent in place, and
+            // drop+recreate would `DROP TABLE` the child (losing its rows), so a
+            // changed bound/parent becomes a non-destructive DETACH then ATTACH.
+            if from_partition.parent_schema != to_partition.parent_schema
+                || from_partition.parent_name != to_partition.parent_name
+                || from_partition.bound != to_partition.bound
+            {
+                ops.push(MigrationOp::DetachPartition(from_partition.clone()));
+                ops.push(MigrationOp::AttachPartition(to_partition.clone()));
+            }
+        },
         |name, _val| MigrationOp::DropPartition(name.clone()),
         qualified_coords,
         None,

--- a/src/diff/op_key.rs
+++ b/src/diff/op_key.rs
@@ -52,6 +52,8 @@ pub(crate) enum OpKey {
     DropTable(String),
     CreatePartition(String),
     DropPartition(String),
+    DetachPartition(String),
+    AttachPartition(String),
     AddColumn {
         table: QualifiedName,
         column: String,
@@ -261,6 +263,12 @@ impl OpKey {
                 OpKey::CreatePartition(qualified_name(&p.schema, &p.name))
             }
             MigrationOp::DropPartition(name) => OpKey::DropPartition(name.clone()),
+            MigrationOp::DetachPartition(p) => {
+                OpKey::DetachPartition(qualified_name(&p.schema, &p.name))
+            }
+            MigrationOp::AttachPartition(p) => {
+                OpKey::AttachPartition(qualified_name(&p.schema, &p.name))
+            }
             MigrationOp::AddColumn { table, column } => OpKey::AddColumn {
                 table: table.clone(),
                 column: column.name.clone(),

--- a/src/diff/planner.rs
+++ b/src/diff/planner.rs
@@ -39,6 +39,8 @@ struct NodeSets {
     drop_aggregates: Vec<NodeIndex>,
     tables: Vec<NodeIndex>,
     partitions: Vec<NodeIndex>,
+    detach_partitions: Vec<NodeIndex>,
+    attach_partitions: Vec<NodeIndex>,
     add_columns: Vec<NodeIndex>,
     add_pks: Vec<NodeIndex>,
     add_indexes: Vec<NodeIndex>,
@@ -97,6 +99,8 @@ impl NodeSets {
             drop_aggregates: graph.nodes_matching(|k| matches!(k, OpKey::DropAggregate { .. })),
             tables: graph.nodes_matching(|k| matches!(k, OpKey::CreateTable(_))),
             partitions: graph.nodes_matching(|k| matches!(k, OpKey::CreatePartition(_))),
+            detach_partitions: graph.nodes_matching(|k| matches!(k, OpKey::DetachPartition(_))),
+            attach_partitions: graph.nodes_matching(|k| matches!(k, OpKey::AttachPartition(_))),
             add_columns: graph.nodes_matching(|k| matches!(k, OpKey::AddColumn { .. })),
             add_pks: graph.nodes_matching(|k| matches!(k, OpKey::AddPrimaryKey { .. })),
             add_indexes: graph.nodes_matching(|k| matches!(k, OpKey::AddIndex { .. })),
@@ -353,6 +357,14 @@ impl MigrationGraph {
     fn add_table_and_partition_edges(&mut self, ns: &NodeSets) {
         self.edges_all_to_all(&ns.tables, &ns.partitions);
 
+        // A changed bound/parent is DETACH then re-ATTACH. The child must be
+        // detached from its old parent before it can be attached to the new one,
+        // and the (possibly newly created) parent table must exist before ATTACH.
+        self.edges_all_to_all(&ns.detach_partitions, &ns.attach_partitions);
+        self.edges_all_to_all(&ns.tables, &ns.detach_partitions);
+        self.edges_all_to_all(&ns.tables, &ns.attach_partitions);
+        self.edges_all_to_all(&ns.add_columns, &ns.attach_partitions);
+
         self.edges_all_to_all(&ns.tables, &ns.add_columns);
         self.edges_all_to_all(&ns.tables, &ns.add_pks);
         self.edges_all_to_all(&ns.tables, &ns.add_indexes);
@@ -494,6 +506,8 @@ impl MigrationGraph {
             &ns.functions,
             &ns.tables,
             &ns.partitions,
+            &ns.detach_partitions,
+            &ns.attach_partitions,
             &ns.add_columns,
             &ns.add_pks,
             &ns.add_indexes,

--- a/src/diff/types.rs
+++ b/src/diff/types.rs
@@ -94,6 +94,15 @@ pub enum MigrationOp {
     DropTable(String),
     CreatePartition(Partition),
     DropPartition(String),
+    /// Detaches an existing child from its current parent. Carries the `from`
+    /// partition (old parent and bound) so the SQL names the right parent.
+    /// PostgreSQL has no in-place ALTER for a partition's bound or parent, so a
+    /// changed bound/parent is a non-destructive DETACH + ATTACH (drop+recreate
+    /// would `DROP TABLE` the child and lose its rows).
+    DetachPartition(Partition),
+    /// Re-attaches an existing child to a parent with the given bound. Carries
+    /// the `to` partition (new parent and bound).
+    AttachPartition(Partition),
     AddColumn {
         table: QualifiedName,
         column: Column,

--- a/src/lint/mod.rs
+++ b/src/lint/mod.rs
@@ -261,6 +261,8 @@ fn lint_op(op: &MigrationOp, options: &LintOptions) -> Vec<LintResult> {
         | MigrationOp::CreateTable(_)
         | MigrationOp::CreatePartition(_)
         | MigrationOp::DropPartition(_)
+        | MigrationOp::DetachPartition(_)
+        | MigrationOp::AttachPartition(_)
         | MigrationOp::AddColumn { .. }
         | MigrationOp::AddPrimaryKey { .. }
         | MigrationOp::DropPrimaryKey { .. }

--- a/src/pg/sqlgen.rs
+++ b/src/pg/sqlgen.rs
@@ -133,6 +133,23 @@ fn generate_op_sql(op: &MigrationOp) -> Vec<String> {
             )]
         }
 
+        MigrationOp::DetachPartition(partition) => {
+            vec![format!(
+                "ALTER TABLE {} DETACH PARTITION {};",
+                quote_qualified(&partition.parent_schema, &partition.parent_name),
+                quote_qualified(&partition.schema, &partition.name),
+            )]
+        }
+
+        MigrationOp::AttachPartition(partition) => {
+            vec![format!(
+                "ALTER TABLE {} ATTACH PARTITION {} {};",
+                quote_qualified(&partition.parent_schema, &partition.parent_name),
+                quote_qualified(&partition.schema, &partition.name),
+                format_partition_bound(&partition.bound),
+            )]
+        }
+
         MigrationOp::AddColumn { table, column } => {
             vec![format!(
                 "ALTER TABLE {} ADD COLUMN {};",
@@ -800,11 +817,8 @@ fn generate_create_table(table: &Table) -> Vec<String> {
     statements
 }
 
-fn generate_create_partition(partition: &Partition) -> String {
-    let partition_name = quote_qualified(&partition.schema, &partition.name);
-    let parent_name = quote_qualified(&partition.parent_schema, &partition.parent_name);
-
-    let bound_clause = match &partition.bound {
+fn format_partition_bound(bound: &PartitionBound) -> String {
+    match bound {
         PartitionBound::Range { from, to } => {
             format!(
                 "FOR VALUES FROM ({}) TO ({})",
@@ -819,7 +833,13 @@ fn generate_create_partition(partition: &Partition) -> String {
             format!("FOR VALUES WITH (MODULUS {modulus}, REMAINDER {remainder})")
         }
         PartitionBound::Default => "DEFAULT".to_string(),
-    };
+    }
+}
+
+fn generate_create_partition(partition: &Partition) -> String {
+    let partition_name = quote_qualified(&partition.schema, &partition.name);
+    let parent_name = quote_qualified(&partition.parent_schema, &partition.parent_name);
+    let bound_clause = format_partition_bound(&partition.bound);
 
     format!("CREATE TABLE {partition_name} PARTITION OF {parent_name} {bound_clause};")
 }
@@ -4438,6 +4458,81 @@ mod tests {
         assert_eq!(
             sql[0],
             "ALTER TABLE \"public\".\"orders_2024\" OWNER TO analytics_user;"
+        );
+    }
+
+    #[test]
+    fn detach_partition_generates_alter_table_detach_sql() {
+        use crate::model::{Partition, PartitionBound};
+
+        let ops = vec![MigrationOp::DetachPartition(Partition {
+            name: "events_2024".to_string(),
+            schema: "public".to_string(),
+            parent_schema: "public".to_string(),
+            parent_name: "events".to_string(),
+            bound: PartitionBound::Range {
+                from: vec!["'2024-01-01'".to_string()],
+                to: vec!["'2024-07-01'".to_string()],
+            },
+            indexes: Vec::new(),
+            check_constraints: Vec::new(),
+            owner: None,
+        })];
+
+        let sql = generate_sql(&ops);
+        assert_eq!(sql.len(), 1);
+        assert_eq!(
+            sql[0],
+            "ALTER TABLE \"public\".\"events\" DETACH PARTITION \"public\".\"events_2024\";"
+        );
+    }
+
+    #[test]
+    fn attach_partition_generates_alter_table_attach_for_values_sql() {
+        use crate::model::{Partition, PartitionBound};
+
+        let ops = vec![MigrationOp::AttachPartition(Partition {
+            name: "events_2024".to_string(),
+            schema: "public".to_string(),
+            parent_schema: "public".to_string(),
+            parent_name: "events".to_string(),
+            bound: PartitionBound::Range {
+                from: vec!["'2024-01-01'".to_string()],
+                to: vec!["'2025-01-01'".to_string()],
+            },
+            indexes: Vec::new(),
+            check_constraints: Vec::new(),
+            owner: None,
+        })];
+
+        let sql = generate_sql(&ops);
+        assert_eq!(sql.len(), 1);
+        assert_eq!(
+            sql[0],
+            "ALTER TABLE \"public\".\"events\" ATTACH PARTITION \"public\".\"events_2024\" FOR VALUES FROM ('2024-01-01') TO ('2025-01-01');"
+        );
+    }
+
+    #[test]
+    fn attach_default_partition_generates_alter_table_attach_default_sql() {
+        use crate::model::{Partition, PartitionBound};
+
+        let ops = vec![MigrationOp::AttachPartition(Partition {
+            name: "events_other".to_string(),
+            schema: "public".to_string(),
+            parent_schema: "public".to_string(),
+            parent_name: "events".to_string(),
+            bound: PartitionBound::Default,
+            indexes: Vec::new(),
+            check_constraints: Vec::new(),
+            owner: None,
+        })];
+
+        let sql = generate_sql(&ops);
+        assert_eq!(sql.len(), 1);
+        assert_eq!(
+            sql[0],
+            "ALTER TABLE \"public\".\"events\" ATTACH PARTITION \"public\".\"events_other\" DEFAULT;"
         );
     }
 

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -10,7 +10,7 @@ use sqlparser::dialect::PostgreSqlDialect;
 use sqlparser::parser::Parser;
 use thiserror::Error;
 
-use crate::model::{PgType, Table};
+use crate::model::{PartitionBound, PgType, Table};
 
 /// Decodes a parsed `numeric`/`decimal` type's [`ExactNumberInfo`] into the
 /// canonical `(precision, scale)` pair. `numeric(p)` normalizes to scale 0 to
@@ -885,6 +885,94 @@ pub fn optional_expressions_equal(expr1: &Option<String>, expr2: &Option<String>
         (Some(e1), Some(e2)) => expressions_semantically_equal(e1, e2),
         _ => false,
     }
+}
+
+/// Compares two partition bounds for semantic equality.
+///
+/// PostgreSQL stores a partition's bound expressions in its own canonical form,
+/// so a `date` literal written as `'2024-01-01'` is introspected back as the
+/// `timestamptz` form `'2024-01-01 00:00:00+00'`, and a bound entered in a
+/// non-UTC offset (`'2022-04-01 01:00:00+01'`) is stored as the equivalent UTC
+/// instant (`'2022-04-01 00:00:00+00'`). A raw string comparison flags these as
+/// drift and emits a perpetual DETACH/ATTACH that never converges. Temporal bound
+/// values are therefore canonicalized to a single UTC instant before comparison;
+/// non-temporal values fall back to the shared SQL expression comparison.
+pub fn partition_bounds_equal(from: &PartitionBound, to: &PartitionBound) -> bool {
+    match (from, to) {
+        (
+            PartitionBound::Range {
+                from: from_lower,
+                to: from_upper,
+            },
+            PartitionBound::Range {
+                from: to_lower,
+                to: to_upper,
+            },
+        ) => bound_values_equal(from_lower, to_lower) && bound_values_equal(from_upper, to_upper),
+        (
+            PartitionBound::List {
+                values: from_values,
+            },
+            PartitionBound::List { values: to_values },
+        ) => bound_values_equal(from_values, to_values),
+        _ => from == to,
+    }
+}
+
+/// Compares two ordered lists of partition bound value expressions element-wise.
+fn bound_values_equal(from: &[String], to: &[String]) -> bool {
+    from.len() == to.len()
+        && from
+            .iter()
+            .zip(to.iter())
+            .all(|(left, right)| bound_value_equal(left, right))
+}
+
+/// Compares a single partition bound value expression. Temporal literals are
+/// canonicalized to a UTC instant; everything else uses the shared SQL
+/// expression comparison so casts and spacing differences still converge.
+fn bound_value_equal(from: &str, to: &str) -> bool {
+    match (parse_temporal_instant(from), parse_temporal_instant(to)) {
+        (Some(left), Some(right)) => left == right,
+        _ => expressions_semantically_equal(from, to),
+    }
+}
+
+/// Parses a temporal bound value expression into a UTC instant in nanoseconds.
+///
+/// Accepts date literals (`'2024-01-01'`), timestamps without offset (assumed to
+/// be UTC, matching the corpus session's `UTC` timezone), and timestamps with an
+/// explicit offset (`'2022-04-01 01:00:00+01'`). Returns `None` for any value
+/// that is not a recognized temporal literal so the caller can fall back to
+/// expression comparison.
+fn parse_temporal_instant(value: &str) -> Option<i64> {
+    use chrono::{DateTime, NaiveDate, NaiveDateTime};
+
+    let trimmed = value.trim();
+    let inner = trimmed
+        .strip_prefix('\'')
+        .and_then(|rest| rest.strip_suffix('\''))?
+        .trim();
+
+    if let Ok(parsed) = DateTime::parse_from_str(inner, "%Y-%m-%d %H:%M:%S%#z") {
+        return parsed.timestamp_nanos_opt();
+    }
+
+    for format in [
+        "%Y-%m-%d %H:%M:%S%.f",
+        "%Y-%m-%d %H:%M:%S",
+        "%Y-%m-%dT%H:%M:%S",
+    ] {
+        if let Ok(parsed) = NaiveDateTime::parse_from_str(inner, format) {
+            return parsed.and_utc().timestamp_nanos_opt();
+        }
+    }
+
+    if let Ok(date) = NaiveDate::parse_from_str(inner, "%Y-%m-%d") {
+        return date.and_hms_opt(0, 0, 0)?.and_utc().timestamp_nanos_opt();
+    }
+
+    None
 }
 
 /// Normalizes a SQL statement to a canonical form for comparison.
@@ -3107,6 +3195,81 @@ fn expressions_equal_interval_literal_vs_cast() {
         expressions_semantically_equal(schema_form, db_form),
         "interval literal and cast syntax should be equal.\nSchema: {schema_form}\nDB: {db_form}"
     );
+}
+
+#[test]
+fn partition_bound_date_literal_equals_timestamptz_midnight() {
+    let parsed = PartitionBound::Range {
+        from: vec!["'2024-01-01'".to_string()],
+        to: vec!["'2024-04-01'".to_string()],
+    };
+    let introspected = PartitionBound::Range {
+        from: vec!["'2024-01-01 00:00:00+00'".to_string()],
+        to: vec!["'2024-04-01 00:00:00+00'".to_string()],
+    };
+    assert!(
+        partition_bounds_equal(&parsed, &introspected),
+        "date literal and timestamptz midnight describe the same instant"
+    );
+}
+
+#[test]
+fn partition_bound_same_instant_different_offset_equal() {
+    let introspected = PartitionBound::Range {
+        from: vec!["'2022-04-01 00:00:00+00'".to_string()],
+        to: vec!["'2022-05-01 00:00:00+00'".to_string()],
+    };
+    let desired = PartitionBound::Range {
+        from: vec!["'2022-04-01 01:00:00+01'".to_string()],
+        to: vec!["'2022-05-01 01:00:00+01'".to_string()],
+    };
+    assert!(
+        partition_bounds_equal(&introspected, &desired),
+        "+01 offset bound is the same UTC instant as the +00 form"
+    );
+}
+
+#[test]
+fn partition_bound_genuine_change_not_equal() {
+    let narrow = PartitionBound::Range {
+        from: vec!["'2024-01-01'".to_string()],
+        to: vec!["'2024-07-01'".to_string()],
+    };
+    let widened = PartitionBound::Range {
+        from: vec!["'2024-01-01'".to_string()],
+        to: vec!["'2025-01-01'".to_string()],
+    };
+    assert!(
+        !partition_bounds_equal(&narrow, &widened),
+        "a genuine bound widening must remain unequal"
+    );
+}
+
+#[test]
+fn partition_bound_adjacent_dates_not_equal() {
+    let day_one = PartitionBound::Range {
+        from: vec!["'2024-01-01'".to_string()],
+        to: vec!["'2024-01-02'".to_string()],
+    };
+    let day_two = PartitionBound::Range {
+        from: vec!["'2024-01-02'".to_string()],
+        to: vec!["'2024-01-03'".to_string()],
+    };
+    assert!(
+        !partition_bounds_equal(&day_one, &day_two),
+        "adjacent single-day partitions are distinct instants"
+    );
+}
+
+#[test]
+fn partition_bound_list_integers_equal() {
+    let parsed = PartitionBound::List {
+        values: vec!["1".to_string(), "2".to_string()],
+    };
+    let introspected = PartitionBound::List {
+        values: vec!["1".to_string(), "2".to_string()],
+    };
+    assert!(partition_bounds_equal(&parsed, &introspected));
 }
 
 #[test]

--- a/tests/partitions.rs
+++ b/tests/partitions.rs
@@ -467,7 +467,11 @@ async fn changed_partition_bound_detaches_and_reattaches_without_data_loss() {
 
     // A bound change must be DETACH then ATTACH, never DROP/CREATE the child
     // (which would lose the row).
-    assert_eq!(ops.len(), 2, "expected exactly Detach then Attach, got {ops:?}");
+    assert_eq!(
+        ops.len(),
+        2,
+        "expected exactly Detach then Attach, got {ops:?}"
+    );
     assert!(
         matches!(&ops[0], MigrationOp::DetachPartition(p) if p.name == "events_2024"),
         "first op must be DetachPartition, got {:?}",
@@ -504,11 +508,12 @@ async fn changed_partition_bound_detaches_and_reattaches_without_data_loss() {
             .unwrap_or_else(|_| panic!("Failed to execute: {stmt}"));
     }
 
-    let surviving_row_count: i64 =
-        sqlx::query_scalar("SELECT count(*) FROM events WHERE id = 1 AND occurred_at = '2024-03-15'")
-            .fetch_one(connection.pool())
-            .await
-            .unwrap();
+    let surviving_row_count: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM events WHERE id = 1 AND occurred_at = '2024-03-15'",
+    )
+    .fetch_one(connection.pool())
+    .await
+    .unwrap();
     assert_eq!(surviving_row_count, 1, "row must survive DETACH/ATTACH");
 
     let after_schema = introspect_schema(&connection, &["public".to_string()], false)

--- a/tests/partitions.rs
+++ b/tests/partitions.rs
@@ -413,3 +413,123 @@ async fn partition_remove_partition() {
     let final_ops = compute_diff(&after_schema, &desired_schema);
     assert!(final_ops.is_empty(), "Diff should be empty after migration");
 }
+
+#[tokio::test]
+async fn changed_partition_bound_detaches_and_reattaches_without_data_loss() {
+    let (_container, url) = setup_postgres().await;
+    let connection = PgConnection::new(&url).await.unwrap();
+
+    sqlx::query(
+        r#"
+        CREATE TABLE events (
+            id INT NOT NULL,
+            occurred_at DATE NOT NULL
+        ) PARTITION BY RANGE (occurred_at)
+        "#,
+    )
+    .execute(connection.pool())
+    .await
+    .unwrap();
+
+    sqlx::query(
+        r#"
+        CREATE TABLE events_2024 PARTITION OF events
+            FOR VALUES FROM ('2024-01-01') TO ('2024-07-01')
+        "#,
+    )
+    .execute(connection.pool())
+    .await
+    .unwrap();
+
+    sqlx::query("INSERT INTO events (id, occurred_at) VALUES (1, '2024-03-15')")
+        .execute(connection.pool())
+        .await
+        .unwrap();
+
+    let desired_schema = parse_sql_string(
+        r#"
+        CREATE TABLE events (
+            id INT NOT NULL,
+            occurred_at DATE NOT NULL
+        ) PARTITION BY RANGE (occurred_at);
+
+        CREATE TABLE events_2024 PARTITION OF events
+            FOR VALUES FROM ('2024-01-01') TO ('2025-01-01');
+        "#,
+    )
+    .unwrap();
+
+    let current_schema = introspect_schema(&connection, &["public".to_string()], false)
+        .await
+        .unwrap();
+
+    let ops = compute_diff(&current_schema, &desired_schema);
+
+    // A bound change must be DETACH then ATTACH, never DROP/CREATE the child
+    // (which would lose the row).
+    assert_eq!(ops.len(), 2, "expected exactly Detach then Attach, got {ops:?}");
+    assert!(
+        matches!(&ops[0], MigrationOp::DetachPartition(p) if p.name == "events_2024"),
+        "first op must be DetachPartition, got {:?}",
+        ops[0]
+    );
+    assert!(
+        matches!(&ops[1], MigrationOp::AttachPartition(p) if p.name == "events_2024"),
+        "second op must be AttachPartition, got {:?}",
+        ops[1]
+    );
+    assert!(
+        !ops.iter().any(|op| matches!(
+            op,
+            MigrationOp::DropPartition(_) | MigrationOp::CreatePartition(_)
+        )),
+        "must not drop or recreate the partition"
+    );
+
+    let sql = generate_sql(&ops);
+    assert_eq!(
+        sql,
+        vec![
+            "ALTER TABLE \"public\".\"events\" DETACH PARTITION \"public\".\"events_2024\";"
+                .to_string(),
+            "ALTER TABLE \"public\".\"events\" ATTACH PARTITION \"public\".\"events_2024\" FOR VALUES FROM ('2024-01-01') TO ('2025-01-01');"
+                .to_string(),
+        ]
+    );
+
+    for stmt in &sql {
+        sqlx::query(stmt)
+            .execute(connection.pool())
+            .await
+            .unwrap_or_else(|_| panic!("Failed to execute: {stmt}"));
+    }
+
+    let surviving_row_count: i64 =
+        sqlx::query_scalar("SELECT count(*) FROM events WHERE id = 1 AND occurred_at = '2024-03-15'")
+            .fetch_one(connection.pool())
+            .await
+            .unwrap();
+    assert_eq!(surviving_row_count, 1, "row must survive DETACH/ATTACH");
+
+    let after_schema = introspect_schema(&connection, &["public".to_string()], false)
+        .await
+        .unwrap();
+
+    let partition = after_schema
+        .partitions
+        .get("public.events_2024")
+        .expect("partition should still exist after reattach");
+    match &partition.bound {
+        PartitionBound::Range { from, to } => {
+            assert!(from[0].contains("2024-01-01"));
+            assert!(to[0].contains("2025-01-01"));
+        }
+        other => panic!("expected widened Range bound, got {other:?}"),
+    }
+
+    let final_ops = compute_diff(&after_schema, &desired_schema);
+    assert!(
+        final_ops.is_empty(),
+        "re-plan must converge to empty. Got: {final_ops:?}"
+    );
+}


### PR DESCRIPTION
diff_partitions had an empty modify callback, so a partition whose parent or FOR VALUES bound changed (same name on both sides) produced no migration.

drop+recreate is unsafe here: DropPartition emits DROP TABLE and loses the partition's data. instead this adds two non-destructive ops:

- DetachPartition: ALTER TABLE parent DETACH PARTITION child
- AttachPartition: ALTER TABLE parent ATTACH PARTITION child FOR VALUES ...

on a bound or parent change the diff emits Detach(old) then Attach(new); the child table already exists so no CREATE or DROP TABLE. the planner orders detach before attach and both after the parent table. mirrors the FK-shape-change fix in #352.

tests: a bound change yields exactly [DetachPartition, AttachPartition] with exact SQL assertions, plus a live-postgres convergence test.

follow-ups, out of scope: partition index/check-constraint diffing still uses the empty-callback pattern; a lock-hazard lint for detach/attach.


<!-- archie:start -->

## Diagram Analysis

### partition bound/parent change flow

how diff_partitions handles a same-named partition whose bound or parent differs, and how the planner orders the resulting ops.

```mermaid
flowchart TD
    A[partition present on both sides] --> B{bound or parent changed?}
    B -- no --> C[no migration]
    B -- yes --> D[DetachPartition old parent]
    D --> E[AttachPartition new parent FOR VALUES]
    E --> F[child table data preserved]
    G[parent table exists] --> D
    G --> E
```
<!-- archie:end -->
