### PR TITLE
chore: bump pgmold-sqlparser to 0.64.0 (operator-name + dollar-comment fixes)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1612,9 +1612,9 @@ dependencies = [
 
 [[package]]
 name = "pgmold-sqlparser"
-version = "0.63.0"
+version = "0.64.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "149cdc1dd64b7bc0f3918f6b8f72f8ea3a7af8b52df3a87bcabc848bf8d023d2"
+checksum = "6db4cd1a99747af2e421b034022a93032ffa8e57d89c97a77d2dfd80d027123e"
 dependencies = [
  "log",
  "recursive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["command-line-utilities", "database"]
 clap = { version = "4.5", features = ["derive", "env"] }
 tokio = { version = "1.35", features = ["full"] }
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres"] }
-sqlparser = { package = "pgmold-sqlparser", version = "0.63.0", features = ["visitor"] }
+sqlparser = { package = "pgmold-sqlparser", version = "0.64.0", features = ["visitor"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 anyhow = "1.0"
@@ -37,11 +37,11 @@ sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres"] }
 tokio = { version = "1.35", features = ["full"] }
 assert_cmd = "2"
 criterion = { version = "0.5", features = ["html_reports"] }
-sqlparser = { package = "pgmold-sqlparser", version = "0.63.0", features = ["visitor"] }
+sqlparser = { package = "pgmold-sqlparser", version = "0.64.0", features = ["visitor"] }
 
 [[bench]]
 name = "performance"
 harness = false
 
 [build-dependencies]
-sqlparser = { package = "pgmold-sqlparser", version = "0.63.0", features = ["visitor"] }
+sqlparser = { package = "pgmold-sqlparser", version = "0.64.0", features = ["visitor"] }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1364,6 +1364,7 @@ fn parse_sql_string_inner(sql: &str) -> Result<Schema> {
                 table_name,
                 on_domain,
                 comment,
+                comment_dollar_quote: _,
                 if_exists: _,
             } => {
                 apply_comment_statement(


### PR DESCRIPTION
bumps pgmold-sqlparser 0.63.0 to 0.64.0, pulling two PostgreSQL fidelity fixes shipped in fmguerreiro/datafusion-sqlparser-rs#34:

- pgmold-299: parse_operator_name now guards on EOF instead of stuffing literal "EOF"/"IS" tokens into idents on a truncated OPERATOR target.
- pgmold-287: dollar-quoted COMMENT bodies preserve their `$$` delimiter on Display via a new comment_dollar_quote field on Statement::Comment.

the new field is ignored at pgmold's parser match site: pgmold reads the decoded comment string and its sqlgen always single-quotes, so pgmold behavior is unchanged. dollar-quote preservation in pgmold's own emitted SQL was intentionally not added (introspection returns plain text, no drift impact); tracked separately if wanted.

cargo build clean, cargo test --lib 1409 passed 0 failed.
