### PR TITLE
fix(model): structured constraint-comment sidecar keys for dotted identifiers

### DIFF
--- a/src/diff/mod.rs
+++ b/src/diff/mod.rs
@@ -483,16 +483,17 @@ fn diff_comments(from: &Schema, to: &Schema) -> Vec<MigrationOp> {
 /// diff applies, including clears via `IS NULL` when the source drops a
 /// previously-set comment.
 ///
-/// Keys are `"schema.parent.constraint_name"` where `parent` is a table or
-/// domain. The parent name is split off here and passed through `target`,
-/// while `name` carries the constraint identifier.
+/// The key carries the parent's qualified key and the constraint name as
+/// separate fields. The parent splits into `schema` / `target` here, while
+/// `name` carries the constraint identifier.
 fn diff_constraint_comments(
-    from: &std::collections::BTreeMap<String, String>,
-    to: &std::collections::BTreeMap<String, String>,
+    from: &std::collections::BTreeMap<crate::model::ConstraintCommentKey, String>,
+    to: &std::collections::BTreeMap<crate::model::ConstraintCommentKey, String>,
     on_domain: bool,
     ops: &mut Vec<MigrationOp>,
 ) {
-    let mut keys: std::collections::BTreeSet<&String> = from.keys().collect();
+    let mut keys: std::collections::BTreeSet<&crate::model::ConstraintCommentKey> =
+        from.keys().collect();
     keys.extend(to.keys());
 
     for key in keys {
@@ -501,14 +502,11 @@ fn diff_constraint_comments(
         if from_text == to_text {
             continue;
         }
-        let (parent_key, constraint_name) = key.rsplit_once('.').unwrap_or_else(|| {
-            panic!("constraint comment key {key:?} must encode schema.parent.constraint_name")
-        });
-        let (parent_schema, parent_name) = crate::model::parse_qualified_name(parent_key);
+        let (parent_schema, parent_name) = crate::model::parse_qualified_name(&key.parent_key);
         ops.push(MigrationOp::SetComment {
             object_type: CommentObjectType::Constraint,
             schema: parent_schema,
-            name: constraint_name.to_string(),
+            name: key.constraint_name.clone(),
             arguments: None,
             column: None,
             target: Some(parent_name),
@@ -2264,9 +2262,10 @@ mod tests {
             .tables
             .insert("public.users".to_string(), simple_table("users"));
         if let Some(text) = comment {
-            schema
-                .table_constraint_comments
-                .insert("public.users.users_pkey".to_string(), text.to_string());
+            schema.table_constraint_comments.insert(
+                crate::model::ConstraintCommentKey::new("public.users", "users_pkey"),
+                text.to_string(),
+            );
         }
         schema
     }
@@ -2349,6 +2348,73 @@ mod tests {
     }
 
     #[test]
+    fn dotted_constraint_name_routes_to_parent_not_split_off() {
+        let mut from = empty_schema();
+        let mut to = empty_schema();
+        from.tables
+            .insert("public.users".to_string(), simple_table("users"));
+        to.tables
+            .insert("public.users".to_string(), simple_table("users"));
+        to.table_constraint_comments.insert(
+            crate::model::ConstraintCommentKey::new("public.users", "chk.v2"),
+            "dotted".to_string(),
+        );
+
+        let ops = compute_diff(&from, &to);
+        assert_eq!(ops.len(), 1);
+        match &ops[0] {
+            MigrationOp::SetComment {
+                object_type,
+                schema,
+                name,
+                target,
+                on_domain,
+                comment,
+                ..
+            } => {
+                assert_eq!(*object_type, CommentObjectType::Constraint);
+                assert_eq!(schema, "public");
+                assert_eq!(name, "chk.v2");
+                assert_eq!(target.as_deref(), Some("users"));
+                assert!(!*on_domain);
+                assert_eq!(comment.as_deref(), Some("dotted"));
+            }
+            other => panic!("expected SetComment, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn dotted_parent_name_splits_schema_from_target() {
+        let parent_key = "public.orders.v2";
+        let mut from = empty_schema();
+        let mut to = empty_schema();
+        from.tables
+            .insert(parent_key.to_string(), simple_table("orders.v2"));
+        to.tables
+            .insert(parent_key.to_string(), simple_table("orders.v2"));
+        to.table_constraint_comments.insert(
+            crate::model::ConstraintCommentKey::new(parent_key, "orders_chk"),
+            "dotted table".to_string(),
+        );
+
+        let ops = compute_diff(&from, &to);
+        assert_eq!(ops.len(), 1);
+        match &ops[0] {
+            MigrationOp::SetComment {
+                schema,
+                name,
+                target,
+                ..
+            } => {
+                assert_eq!(schema, "public");
+                assert_eq!(name, "orders_chk");
+                assert_eq!(target.as_deref(), Some("orders.v2"));
+            }
+            other => panic!("expected SetComment, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn detects_added_domain_constraint_comment_with_on_domain_flag() {
         let mut from = empty_schema();
         let mut to = empty_schema();
@@ -2371,7 +2437,7 @@ mod tests {
             .insert("public.amount".to_string(), domain.clone());
         to.domains.insert("public.amount".to_string(), domain);
         to.domain_constraint_comments.insert(
-            "public.amount.amount_positive".to_string(),
+            crate::model::ConstraintCommentKey::new("public.amount", "amount_positive"),
             "must be positive".to_string(),
         );
 

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -157,19 +157,19 @@ fn push_constraint_comment_op(
 
 fn push_constraint_comment_ops(
     ops: &mut Vec<MigrationOp>,
-    sidecar: &std::collections::BTreeMap<String, String>,
+    sidecar: &std::collections::BTreeMap<crate::model::ConstraintCommentKey, String>,
     parent_schema: &str,
     parent_name: &str,
     on_domain: bool,
 ) {
-    let parent_prefix = format!("{parent_schema}.{parent_name}.");
+    let parent_key = crate::model::qualified_name(parent_schema, parent_name);
     for (key, comment) in sidecar.iter() {
-        if let Some(constraint_name) = key.strip_prefix(&parent_prefix) {
+        if key.parent_key == parent_key {
             push_constraint_comment_op(
                 ops,
                 parent_schema,
                 parent_name,
-                constraint_name,
+                &key.constraint_name,
                 comment,
                 on_domain,
             );

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -345,13 +345,13 @@ pub fn filter_by_target_schemas(schema: &Schema, target_schemas: &[String]) -> S
     }
 
     fn retain_by_key_schema(
-        map: &BTreeMap<String, String>,
+        map: &BTreeMap<crate::model::ConstraintCommentKey, String>,
         allowed: &HashSet<&str>,
-    ) -> BTreeMap<String, String> {
+    ) -> BTreeMap<crate::model::ConstraintCommentKey, String> {
         map.iter()
             .filter(|(key, _)| {
-                key.split_once('.')
-                    .is_some_and(|(s, _)| allowed.contains(s))
+                let (schema, _) = crate::model::parse_qualified_name(&key.parent_key);
+                allowed.contains(schema.as_str())
             })
             .map(|(k, v)| (k.clone(), v.clone()))
             .collect()

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1,7 +1,7 @@
 use crate::util::{
     expressions_semantically_equal, views_semantically_equal, views_semantically_equal_with_columns,
 };
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
@@ -283,20 +283,19 @@ pub struct Schema {
     pub pending_comments: Vec<PendingComment>,
     pub default_privileges: Vec<DefaultPrivilege>,
     /// Comments on named table constraints (PK, FK, CHECK, UNIQUE, EXCLUDE)
-    /// keyed as `"schema.table.constraint_name"`. Stored as a Schema-level
-    /// sidecar so adding the field does not require changing every
-    /// `Table` / `ForeignKey` / `CheckConstraint` / `Index` constructor in
-    /// the codebase. The constraint kind is irrelevant for emitting
+    /// keyed by the parent's qualified key plus the constraint name. Stored
+    /// as a Schema-level sidecar so adding the field does not require changing
+    /// every `Table` / `ForeignKey` / `CheckConstraint` / `Index` constructor
+    /// in the codebase. The constraint kind is irrelevant for emitting
     /// `COMMENT ON CONSTRAINT name ON tbl IS '...'` because PostgreSQL
     /// resolves the kind from `pg_constraint`.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub table_constraint_comments: BTreeMap<String, String>,
-    /// Comments on named CHECK constraints attached to domains, keyed as
-    /// `"schema.domain.constraint_name"`. Mirrors
+    pub table_constraint_comments: BTreeMap<ConstraintCommentKey, String>,
+    /// Comments on named CHECK constraints attached to domains. Mirrors
     /// `table_constraint_comments` but resolved against `domains` and
     /// emitted via the `ON DOMAIN` form.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub domain_constraint_comments: BTreeMap<String, String>,
+    pub domain_constraint_comments: BTreeMap<ConstraintCommentKey, String>,
     /// Identifiers declared in the source longer than 63 bytes, captured before
     /// the parser truncated them. Drives the `warn_identifier_exceeds_namedatalen`
     /// lint. Not serialized: it is a parse-time diagnostic, not schema state.
@@ -1130,6 +1129,56 @@ pub fn qualified_name(schema: &str, name: &str) -> String {
     format!("{schema}.{name}")
 }
 
+/// Key for the constraint-comment sidecar maps. Holds the parent's qualified
+/// key (`schema.parent`) and the constraint name as separate fields so a
+/// dotted constraint name or dotted table name (legal via quoted identifiers)
+/// routes unambiguously. Packing both into one dot-joined string and
+/// re-splitting with `rsplit_once('.')` misroutes such identifiers, the same
+/// bug class fixed for column/policy/trigger pending comments in pgmold-298.
+/// The schema/name split inside `parent_key` follows the same convention as
+/// the `tables` / `partitions` / `domains` map keys, so a dotted schema name
+/// remains a pre-existing, codebase-wide ambiguity this struct does not touch.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ConstraintCommentKey {
+    /// The parent's qualified key, identical to the key under which the parent
+    /// lives in `tables` / `partitions` / `domains` (`schema.parent`).
+    pub parent_key: String,
+    /// The constraint's unqualified name.
+    pub constraint_name: String,
+}
+
+impl ConstraintCommentKey {
+    pub fn new(parent_key: impl Into<String>, constraint_name: impl Into<String>) -> Self {
+        Self {
+            parent_key: parent_key.into(),
+            constraint_name: constraint_name.into(),
+        }
+    }
+}
+
+// Serialized as a JSON two-element array string so the key survives
+// `serde_json` (which requires map keys to be strings) without reintroducing
+// the dot-join ambiguity the struct exists to remove.
+impl Serialize for ConstraintCommentKey {
+    fn serialize<S: Serializer>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error> {
+        let encoded = serde_json::to_string(&(&self.parent_key, &self.constraint_name))
+            .map_err(serde::ser::Error::custom)?;
+        serializer.serialize_str(&encoded)
+    }
+}
+
+impl<'de> Deserialize<'de> for ConstraintCommentKey {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> std::result::Result<Self, D::Error> {
+        let encoded = String::deserialize(deserializer)?;
+        let (parent_key, constraint_name): (String, String) =
+            serde_json::from_str(&encoded).map_err(serde::de::Error::custom)?;
+        Ok(Self {
+            parent_key,
+            constraint_name,
+        })
+    }
+}
+
 /// Parses a qualified name into (schema, name) tuple.
 /// Defaults to "public" schema if no dot separator found.
 ///
@@ -1620,21 +1669,21 @@ impl Schema {
                 // not have to mutate every constraint variant struct. Partition
                 // children share the table sidecar because PostgreSQL stores
                 // constraint comments on the child relation, and the diff/emit
-                // path is parent-kind agnostic. The sidecar map key keeps the
-                // flat `parent.constraint` form because introspection populates
-                // the same maps with that shape.
+                // path is parent-kind agnostic. The sidecar map keys the parent
+                // and constraint names separately so a dotted identifier routes
+                // unambiguously, matching how introspection populates the maps.
                 let constraint_name = pc
                     .child_name
                     .as_deref()
                     .expect("Constraint pending comment must carry child_name");
-                let sidecar_key = format!("{}.{}", pc.object_key, constraint_name);
+                let sidecar_key = ConstraintCommentKey::new(pc.object_key.clone(), constraint_name);
                 if pc.on_domain {
                     if !self.domains.contains_key(&pc.object_key) {
                         return false;
                     }
                     update_constraint_comment(
                         &mut self.domain_constraint_comments,
-                        &sidecar_key,
+                        sidecar_key,
                         pc.comment.as_ref(),
                     );
                 } else {
@@ -1645,7 +1694,7 @@ impl Schema {
                     }
                     update_constraint_comment(
                         &mut self.table_constraint_comments,
-                        &sidecar_key,
+                        sidecar_key,
                         pc.comment.as_ref(),
                     );
                 }
@@ -1665,15 +1714,11 @@ impl Schema {
         let tables = &self.tables;
         let partitions = &self.partitions;
         self.table_constraint_comments.retain(|key, _| {
-            key.rsplit_once('.').is_some_and(|(parent, _)| {
-                tables.contains_key(parent) || partitions.contains_key(parent)
-            })
+            tables.contains_key(&key.parent_key) || partitions.contains_key(&key.parent_key)
         });
         let domains = &self.domains;
-        self.domain_constraint_comments.retain(|key, _| {
-            key.rsplit_once('.')
-                .is_some_and(|(parent, _)| domains.contains_key(parent))
-        });
+        self.domain_constraint_comments
+            .retain(|key, _| domains.contains_key(&key.parent_key));
     }
 
     fn merge_all_grants(&mut self) {
@@ -1729,16 +1774,16 @@ pub fn revoke_from_grants(
 }
 
 fn update_constraint_comment(
-    sidecar: &mut BTreeMap<String, String>,
-    key: &str,
+    sidecar: &mut BTreeMap<ConstraintCommentKey, String>,
+    key: ConstraintCommentKey,
     comment: Option<&String>,
 ) {
     match comment {
         Some(text) => {
-            sidecar.insert(key.to_string(), text.clone());
+            sidecar.insert(key, text.clone());
         }
         None => {
-            sidecar.remove(key);
+            sidecar.remove(&key);
         }
     }
 }
@@ -2117,6 +2162,43 @@ mod tests {
             parse_qualified_name("auth.accounts"),
             ("auth".to_string(), "accounts".to_string())
         );
+    }
+
+    #[test]
+    fn constraint_comment_key_serializes_as_json_array_string() {
+        let key = ConstraintCommentKey::new("public.users", "users_pkey");
+        let encoded = serde_json::to_string(&key).unwrap();
+        assert_eq!(encoded, r#""[\"public.users\",\"users_pkey\"]""#);
+        let decoded: ConstraintCommentKey = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(decoded, key);
+    }
+
+    #[test]
+    fn constraint_comment_key_round_trips_dotted_identifiers_through_serde() {
+        // A constraint name and a quoted table name each carrying a literal dot:
+        // the flat dot-joined string this struct replaced could not round-trip
+        // these without misrouting.
+        let key = ConstraintCommentKey::new("public.tbl.with.dots", "chk.v2");
+        let decoded: ConstraintCommentKey =
+            serde_json::from_str(&serde_json::to_string(&key).unwrap()).unwrap();
+        assert_eq!(decoded.parent_key, "public.tbl.with.dots");
+        assert_eq!(decoded.constraint_name, "chk.v2");
+    }
+
+    #[test]
+    fn schema_with_constraint_comments_round_trips_through_serde() {
+        let mut schema = Schema::new();
+        schema.table_constraint_comments.insert(
+            ConstraintCommentKey::new("public.users", "users_pkey"),
+            "primary key".to_string(),
+        );
+        schema.domain_constraint_comments.insert(
+            ConstraintCommentKey::new("public.amount", "amount_positive"),
+            "must be positive".to_string(),
+        );
+        let restored: Schema =
+            serde_json::from_str(&serde_json::to_string(&schema).unwrap()).unwrap();
+        assert_eq!(restored, schema);
     }
 
     #[test]

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -2930,7 +2930,10 @@ fn comment_on_overlong_constraint_name_attaches() {
     assert_eq!(
         schema
             .table_constraint_comments
-            .get(&format!("public.tbl.{}", "k".repeat(63)))
+            .get(&crate::model::ConstraintCommentKey::new(
+                "public.tbl",
+                "k".repeat(63),
+            ))
             .map(String::as_str),
         Some("hi")
     );
@@ -3200,7 +3203,10 @@ fn comment_on_constraint_on_table_captures_text() {
     assert_eq!(
         schema
             .table_constraint_comments
-            .get("public.users.users_email_chk")
+            .get(&crate::model::ConstraintCommentKey::new(
+                "public.users",
+                "users_email_chk",
+            ))
             .map(String::as_str),
         Some("positive id"),
     );
@@ -3218,9 +3224,9 @@ fn comment_on_constraint_null_clears_comment() {
         COMMENT ON CONSTRAINT users_id_chk ON public.users IS NULL;
     "#;
     let schema = parse_sql_string(sql).unwrap();
-    assert!(!schema
-        .table_constraint_comments
-        .contains_key("public.users.users_id_chk"));
+    assert!(!schema.table_constraint_comments.contains_key(
+        &crate::model::ConstraintCommentKey::new("public.users", "users_id_chk",)
+    ));
 }
 
 #[test]
@@ -3233,7 +3239,10 @@ fn comment_on_constraint_on_domain_captures_text() {
     assert_eq!(
         schema
             .domain_constraint_comments
-            .get("public.amount.amount_positive")
+            .get(&crate::model::ConstraintCommentKey::new(
+                "public.amount",
+                "amount_positive",
+            ))
             .map(String::as_str),
         Some("must be positive"),
     );
@@ -3256,7 +3265,10 @@ fn comment_on_constraint_roundtrips_through_dump() {
     assert_eq!(
         reparsed
             .table_constraint_comments
-            .get("public.users.users_id_chk")
+            .get(&crate::model::ConstraintCommentKey::new(
+                "public.users",
+                "users_id_chk",
+            ))
             .map(String::as_str),
         Some("positive id"),
     );
@@ -3275,7 +3287,10 @@ fn comment_on_constraint_on_domain_roundtrips_through_dump() {
     assert_eq!(
         reparsed
             .domain_constraint_comments
-            .get("public.amount.amount_positive")
+            .get(&crate::model::ConstraintCommentKey::new(
+                "public.amount",
+                "amount_positive",
+            ))
             .map(String::as_str),
         Some("must be positive"),
     );

--- a/src/pg/introspect.rs
+++ b/src/pg/introspect.rs
@@ -1629,7 +1629,7 @@ async fn introspect_all_policies(
 async fn introspect_table_constraint_comments(
     connection: &PgConnection,
     target_schemas: &[String],
-) -> Result<BTreeMap<String, String>> {
+) -> Result<BTreeMap<ConstraintCommentKey, String>> {
     let rows = sqlx::query(
         r#"
         SELECT
@@ -1659,7 +1659,7 @@ async fn introspect_table_constraint_comments(
         let constraint_name: String = row.get("constraint_name");
         let comment: String = row.get("comment");
         result.insert(
-            format!("{table_schema}.{table_name}.{constraint_name}"),
+            ConstraintCommentKey::new(qualified_name(&table_schema, &table_name), constraint_name),
             comment,
         );
     }
@@ -1673,7 +1673,7 @@ async fn introspect_table_constraint_comments(
 async fn introspect_domain_constraint_comments(
     connection: &PgConnection,
     target_schemas: &[String],
-) -> Result<BTreeMap<String, String>> {
+) -> Result<BTreeMap<ConstraintCommentKey, String>> {
     let rows = sqlx::query(
         r#"
         SELECT
@@ -1703,7 +1703,10 @@ async fn introspect_domain_constraint_comments(
         let constraint_name: String = row.get("constraint_name");
         let comment: String = row.get("comment");
         result.insert(
-            format!("{domain_schema}.{domain_name}.{constraint_name}"),
+            ConstraintCommentKey::new(
+                qualified_name(&domain_schema, &domain_name),
+                constraint_name,
+            ),
             comment,
         );
     }

--- a/tests/edge_cases.rs
+++ b/tests/edge_cases.rs
@@ -472,7 +472,10 @@ async fn table_constraint_comment_round_trips_through_apply_and_introspect() {
     assert_eq!(
         after
             .table_constraint_comments
-            .get("public.users.users_id_positive")
+            .get(&pgmold::model::ConstraintCommentKey::new(
+                "public.users",
+                "users_id_positive",
+            ))
             .map(String::as_str),
         Some("must be positive"),
     );
@@ -515,7 +518,10 @@ async fn domain_constraint_comment_round_trips_through_apply_and_introspect() {
     assert_eq!(
         after
             .domain_constraint_comments
-            .get("public.amount.amount_positive")
+            .get(&pgmold::model::ConstraintCommentKey::new(
+                "public.amount",
+                "amount_positive",
+            ))
             .map(String::as_str),
         Some("must be positive"),
     );
@@ -570,7 +576,7 @@ async fn partition_parent_constraint_comment_is_not_duplicated_onto_children() {
         .await
         .unwrap();
 
-    let constraint_comments: Vec<(&String, &String)> = after
+    let constraint_comments: Vec<(&pgmold::model::ConstraintCommentKey, &String)> = after
         .table_constraint_comments
         .iter()
         .filter(|(_, comment)| comment.as_str() == "parent-level sanity check")
@@ -578,7 +584,10 @@ async fn partition_parent_constraint_comment_is_not_duplicated_onto_children() {
     assert_eq!(
         constraint_comments,
         vec![(
-            &"public.measurement.measurement_peak_positive".to_string(),
+            &pgmold::model::ConstraintCommentKey::new(
+                "public.measurement",
+                "measurement_peak_positive"
+            ),
             &"parent-level sanity check".to_string()
         )],
         "parent constraint comment must introspect exactly once, on the parent, \
@@ -652,7 +661,10 @@ async fn partition_child_constraint_comment_round_trips_through_apply_and_intros
     assert_eq!(
         after
             .table_constraint_comments
-            .get("public.measurement_2024.measurement_2024_peak_positive")
+            .get(&pgmold::model::ConstraintCommentKey::new(
+                "public.measurement_2024",
+                "measurement_2024_peak_positive",
+            ))
             .map(String::as_str),
         Some("partition-local sanity check"),
         "introspect must capture COMMENT ON CONSTRAINT on partition child"


### PR DESCRIPTION
## What

The `table_constraint_comments` / `domain_constraint_comments` sidecar maps keyed each entry as a flat `"schema.parent.constraint_name"` string, then re-split it with `rsplit_once('.')` / `strip_prefix` / `split_once('.')` in five places: the model apply path, `drop_orphan_constraint_comments`, `diff_constraint_comments`, `push_constraint_comment_ops` (dump), and `retain_by_key_schema` (filter). A parent or constraint identifier containing a literal dot (legal via a quoted identifier) misrouted there the same way pgmold-298 fixed for the Column/Policy/Trigger pending comments.

This re-keys both maps on a `ConstraintCommentKey { parent_key, constraint_name }` struct that carries the parent qualified key and the constraint name as separate fields, and routes by direct lookup instead of string splitting across the parser, introspection, diff, dump, and filter consumers. The key serializes as a JSON two-element-array string so it survives `serde_json` (which requires string map keys, exercised via `Schema::fingerprint`) without reintroducing the dot ambiguity.

The schema/name split inside `parent_key` follows the same convention as the `tables` / `partitions` / `domains` map keys, so a dotted *schema* name remains a pre-existing, codebase-wide ambiguity this change does not touch.

## Tests

- `dotted_constraint_name_routes_to_parent_not_split_off` and `dotted_parent_name_splits_schema_from_target` (diff) pin that a dotted constraint name and a dotted table name route to the correct parent/target.
- Three serde round-trip tests pin the JSON-array-string encoding and a full `Schema` round-trip with constraint comments.
- Existing parser and Postgres integration round-trip tests updated to the structured key; all 1431 lib tests plus the four constraint-comment integration tests pass against real Postgres.

<!-- archie:start -->

## Diagram Analysis

### ConstraintCommentKey across producers and consumers

Two producers populate the sidecar maps and three consumers read them; all five sites switch from dot-split strings to the structured key.

```mermaid
flowchart TD
    parser["parser apply<br/>(model/mod.rs)"] -->|insert| maps["table/domain_constraint_comments<br/>BTreeMap&lt;ConstraintCommentKey, String&gt;"]
    introspect["pg introspect<br/>(introspect.rs)"] -->|insert| maps
    maps -->|direct lookup| diff["diff_constraint_comments"]
    maps -->|parent_key match| dump["push_constraint_comment_ops"]
    maps -->|parent_key schema| filter["retain_by_key_schema + drop_orphan"]
    diff --> op["SetComment op<br/>schema / name / target"]
    dump --> op
```
<!-- archie:end -->

