### PR TITLE
fix(diff): reconcile index and check-constraint changes on same-named partitions

### DIFF
--- a/src/diff/mod.rs
+++ b/src/diff/mod.rs
@@ -4624,6 +4624,189 @@ CREATE TRIGGER "on_user_role_change" AFTER INSERT OR UPDATE OR DELETE ON "public
         assert!(ops.is_empty(), "expected no ops, got {ops:?}");
     }
 
+    fn partition_with(
+        indexes: Vec<crate::model::Index>,
+        check_constraints: Vec<crate::model::CheckConstraint>,
+    ) -> crate::model::Partition {
+        crate::model::Partition {
+            name: "events_2024".to_string(),
+            schema: "public".to_string(),
+            parent_schema: "public".to_string(),
+            parent_name: "events".to_string(),
+            bound: crate::model::PartitionBound::Default,
+            indexes,
+            check_constraints,
+            owner: None,
+        }
+    }
+
+    fn partition_index(name: &str, columns: Vec<&str>) -> crate::model::Index {
+        crate::model::Index {
+            name: name.to_string(),
+            columns: columns.into_iter().map(String::from).collect(),
+            unique: false,
+            index_type: crate::model::IndexType::BTree,
+            predicate: None,
+            is_constraint: false,
+        }
+    }
+
+    fn partition_check(name: &str, expression: &str) -> crate::model::CheckConstraint {
+        crate::model::CheckConstraint {
+            name: name.to_string(),
+            expression: expression.to_string(),
+        }
+    }
+
+    fn diff_one_partition(
+        from_partition: crate::model::Partition,
+        to_partition: crate::model::Partition,
+    ) -> Vec<MigrationOp> {
+        let key = "public.events_2024".to_string();
+        let mut from = empty_schema();
+        from.partitions.insert(key.clone(), from_partition);
+        let mut to = empty_schema();
+        to.partitions.insert(key, to_partition);
+        compute_diff(&from, &to)
+    }
+
+    #[test]
+    fn added_partition_index_emits_add_index() {
+        let ops = diff_one_partition(
+            partition_with(Vec::new(), Vec::new()),
+            partition_with(
+                vec![partition_index("events_2024_logdate_idx", vec!["logdate"])],
+                Vec::new(),
+            ),
+        );
+        assert_eq!(ops.len(), 1, "expected one AddIndex, got {ops:?}");
+        match &ops[0] {
+            MigrationOp::AddIndex { table, index } => {
+                assert_eq!(table.to_string(), "public.events_2024");
+                assert_eq!(index.name, "events_2024_logdate_idx");
+                assert_eq!(index.columns, vec!["logdate".to_string()]);
+            }
+            other => panic!("expected AddIndex, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn changed_partition_index_emits_drop_then_add() {
+        let ops = diff_one_partition(
+            partition_with(
+                vec![partition_index("events_2024_idx", vec!["logdate"])],
+                Vec::new(),
+            ),
+            partition_with(
+                vec![partition_index("events_2024_idx", vec!["city_id"])],
+                Vec::new(),
+            ),
+        );
+        assert_eq!(
+            ops.len(),
+            2,
+            "expected DropIndex then AddIndex, got {ops:?}"
+        );
+        match &ops[0] {
+            MigrationOp::DropIndex { table, index_name } => {
+                assert_eq!(table.to_string(), "public.events_2024");
+                assert_eq!(index_name, "events_2024_idx");
+            }
+            other => panic!("expected DropIndex first, got {other:?}"),
+        }
+        match &ops[1] {
+            MigrationOp::AddIndex { index, .. } => {
+                assert_eq!(index.columns, vec!["city_id".to_string()]);
+            }
+            other => panic!("expected AddIndex second, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn removed_partition_index_emits_drop_index() {
+        let ops = diff_one_partition(
+            partition_with(
+                vec![partition_index("events_2024_idx", vec!["logdate"])],
+                Vec::new(),
+            ),
+            partition_with(Vec::new(), Vec::new()),
+        );
+        assert_eq!(ops.len(), 1, "expected one DropIndex, got {ops:?}");
+        match &ops[0] {
+            MigrationOp::DropIndex { table, index_name } => {
+                assert_eq!(table.to_string(), "public.events_2024");
+                assert_eq!(index_name, "events_2024_idx");
+            }
+            other => panic!("expected DropIndex, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn added_partition_check_constraint_emits_add() {
+        let check = partition_check("events_2024_peak_positive", "peaktemp > 0");
+        let ops = diff_one_partition(
+            partition_with(Vec::new(), Vec::new()),
+            partition_with(Vec::new(), vec![check]),
+        );
+        assert_eq!(ops.len(), 1, "expected one AddCheckConstraint, got {ops:?}");
+        match &ops[0] {
+            MigrationOp::AddCheckConstraint {
+                table,
+                check_constraint,
+            } => {
+                assert_eq!(table.to_string(), "public.events_2024");
+                assert_eq!(check_constraint.name, "events_2024_peak_positive");
+            }
+            other => panic!("expected AddCheckConstraint, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn changed_partition_check_constraint_emits_drop_then_add() {
+        let ops = diff_one_partition(
+            partition_with(
+                Vec::new(),
+                vec![partition_check("events_2024_chk", "peaktemp > 0")],
+            ),
+            partition_with(
+                Vec::new(),
+                vec![partition_check("events_2024_chk", "peaktemp > 10")],
+            ),
+        );
+        assert_eq!(
+            ops.len(),
+            2,
+            "expected DropCheckConstraint then AddCheckConstraint, got {ops:?}"
+        );
+        match &ops[0] {
+            MigrationOp::DropCheckConstraint {
+                table,
+                constraint_name,
+            } => {
+                assert_eq!(table.to_string(), "public.events_2024");
+                assert_eq!(constraint_name, "events_2024_chk");
+            }
+            other => panic!("expected DropCheckConstraint first, got {other:?}"),
+        }
+        match &ops[1] {
+            MigrationOp::AddCheckConstraint {
+                check_constraint, ..
+            } => {
+                assert_eq!(check_constraint.expression, "peaktemp > 10");
+            }
+            other => panic!("expected AddCheckConstraint second, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unchanged_partition_index_and_check_emit_no_ops() {
+        let index = partition_index("events_2024_idx", vec!["logdate"]);
+        let check = partition_check("events_2024_chk", "peaktemp > 0");
+        let partition = partition_with(vec![index], vec![check]);
+        let ops = diff_one_partition(partition.clone(), partition);
+        assert!(ops.is_empty(), "expected no ops, got {ops:?}");
+    }
+
     #[test]
     fn ignores_partition_owner_change_when_flag_disabled() {
         use crate::model::{Partition, PartitionBound};

--- a/src/diff/objects.rs
+++ b/src/diff/objects.rs
@@ -1,11 +1,13 @@
 use std::collections::BTreeMap;
 
 use crate::model::{
-    parse_qualified_name, qualified_name, EnumType, Grant, Schema, Sequence, Server, Trigger,
+    parse_qualified_name, qualified_name, EnumType, Grant, QualifiedName, Schema, Sequence, Server,
+    Trigger,
 };
 use crate::util::{optional_expressions_equal, partition_bounds_equal};
 
 use super::grants::{create_grants_for_new_object, diff_grants_for_object};
+use super::table_elements::{diff_check_constraint_lists, diff_index_lists};
 use super::{
     DiffOptions, DomainChanges, EnumValuePosition, GrantObjectKind, MigrationOp, OwnerObjectKind,
     SequenceChanges,
@@ -400,6 +402,27 @@ pub(super) fn diff_partitions(
                 ops.push(MigrationOp::DetachPartition(from_partition.clone()));
                 ops.push(MigrationOp::AttachPartition(to_partition.clone()));
             }
+            // A partition child is a relation in its own right: its partition-local
+            // indexes and CHECK constraints reconcile exactly like a table's, and
+            // independently of any bound/parent change above. These fields are not
+            // yet populated by the parser or introspection (pgmold-53bm), so this
+            // path is reachable only from hand-built schemas today; the planner
+            // ordering of these ops relative to a simultaneous DETACH+ATTACH is
+            // deferred to that follow-up, where it can be tested end to end.
+            let from_name = QualifiedName::new(&from_partition.schema, &from_partition.name);
+            let to_name = QualifiedName::new(&to_partition.schema, &to_partition.name);
+            ops.extend(diff_index_lists(
+                &from_name,
+                &to_name,
+                &from_partition.indexes,
+                &to_partition.indexes,
+            ));
+            ops.extend(diff_check_constraint_lists(
+                &from_name,
+                &to_name,
+                &from_partition.check_constraints,
+                &to_partition.check_constraints,
+            ));
         },
         |name, _val| MigrationOp::DropPartition(name.clone()),
         qualified_coords,

--- a/src/diff/table_elements.rs
+++ b/src/diff/table_elements.rs
@@ -1,4 +1,4 @@
-use crate::model::{Column, Index, Policy, QualifiedName, Table};
+use crate::model::{CheckConstraint, Column, Index, Policy, QualifiedName, Table};
 use crate::util::{expressions_semantically_equal, optional_expressions_equal};
 
 use super::{ColumnChanges, MigrationOp, PolicyChanges};
@@ -172,23 +172,39 @@ pub(super) fn indexes_semantically_equal(from: &Index, to: &Index) -> bool {
 }
 
 pub(super) fn diff_indexes(from_table: &Table, to_table: &Table) -> Vec<MigrationOp> {
-    let mut ops = Vec::new();
-    let qualified_table_name = QualifiedName::new(&to_table.schema, &to_table.name);
-    let from_qualified_table_name = || QualifiedName::new(&from_table.schema, &from_table.name);
+    diff_index_lists(
+        &QualifiedName::new(&from_table.schema, &from_table.name),
+        &QualifiedName::new(&to_table.schema, &to_table.name),
+        &from_table.indexes,
+        &to_table.indexes,
+    )
+}
 
-    for index in &to_table.indexes {
-        let existing = from_table.indexes.iter().find(|i| i.name == index.name);
+/// Diffs two index lists belonging to the same relation (a table or a partition
+/// child). Adds target the `to` relation; drops target the `from` relation,
+/// matching `diff_indexes`. Shared so partition children get the same index
+/// reconciliation as tables.
+pub(super) fn diff_index_lists(
+    from_name: &QualifiedName,
+    to_name: &QualifiedName,
+    from_indexes: &[Index],
+    to_indexes: &[Index],
+) -> Vec<MigrationOp> {
+    let mut ops = Vec::new();
+
+    for index in to_indexes {
+        let existing = from_indexes.iter().find(|i| i.name == index.name);
         match existing {
             None => {
                 ops.push(MigrationOp::AddIndex {
-                    table: qualified_table_name.clone(),
+                    table: to_name.clone(),
                     index: index.clone(),
                 });
             }
             Some(from_index) if !indexes_semantically_equal(from_index, index) => {
-                ops.push(drop_index_op(from_qualified_table_name(), from_index));
+                ops.push(drop_index_op(from_name.clone(), from_index));
                 ops.push(MigrationOp::AddIndex {
-                    table: qualified_table_name.clone(),
+                    table: to_name.clone(),
                     index: index.clone(),
                 });
             }
@@ -196,9 +212,9 @@ pub(super) fn diff_indexes(from_table: &Table, to_table: &Table) -> Vec<Migratio
         }
     }
 
-    for index in &from_table.indexes {
-        if !to_table.indexes.iter().any(|i| i.name == index.name) {
-            ops.push(drop_index_op(from_qualified_table_name(), index));
+    for index in from_indexes {
+        if !to_indexes.iter().any(|i| i.name == index.name) {
+            ops.push(drop_index_op(from_name.clone(), index));
         }
     }
 
@@ -274,45 +290,55 @@ pub(super) fn diff_foreign_keys(from_table: &Table, to_table: &Table) -> Vec<Mig
 }
 
 pub(super) fn diff_check_constraints(from_table: &Table, to_table: &Table) -> Vec<MigrationOp> {
-    let mut ops = Vec::new();
-    let qualified_table_name = QualifiedName::new(&to_table.schema, &to_table.name);
+    diff_check_constraint_lists(
+        &QualifiedName::new(&from_table.schema, &from_table.name),
+        &QualifiedName::new(&to_table.schema, &to_table.name),
+        &from_table.check_constraints,
+        &to_table.check_constraints,
+    )
+}
 
-    for to_constraint in &to_table.check_constraints {
-        let matching_from = from_table
-            .check_constraints
-            .iter()
-            .find(|cc| cc.name == to_constraint.name);
+/// Diffs two check-constraint lists belonging to the same relation (a table or
+/// a partition child). A changed constraint becomes a drop then an add because
+/// PostgreSQL has no in-place ALTER for a CHECK expression. Shared so partition
+/// children get the same reconciliation as tables.
+pub(super) fn diff_check_constraint_lists(
+    from_name: &QualifiedName,
+    to_name: &QualifiedName,
+    from_checks: &[CheckConstraint],
+    to_checks: &[CheckConstraint],
+) -> Vec<MigrationOp> {
+    let mut ops = Vec::new();
+
+    for to_constraint in to_checks {
+        let matching_from = from_checks.iter().find(|cc| cc.name == to_constraint.name);
 
         match matching_from {
             Some(from_constraint) => {
                 if !from_constraint.semantically_equals(to_constraint) {
                     ops.push(MigrationOp::DropCheckConstraint {
-                        table: qualified_table_name.clone(),
+                        table: from_name.clone(),
                         constraint_name: from_constraint.name.clone(),
                     });
                     ops.push(MigrationOp::AddCheckConstraint {
-                        table: qualified_table_name.clone(),
+                        table: to_name.clone(),
                         check_constraint: to_constraint.clone(),
                     });
                 }
             }
             None => {
                 ops.push(MigrationOp::AddCheckConstraint {
-                    table: qualified_table_name.clone(),
+                    table: to_name.clone(),
                     check_constraint: to_constraint.clone(),
                 });
             }
         }
     }
 
-    for from_constraint in &from_table.check_constraints {
-        if !to_table
-            .check_constraints
-            .iter()
-            .any(|cc| cc.name == from_constraint.name)
-        {
+    for from_constraint in from_checks {
+        if !to_checks.iter().any(|cc| cc.name == from_constraint.name) {
             ops.push(MigrationOp::DropCheckConstraint {
-                table: QualifiedName::new(&from_table.schema, &from_table.name),
+                table: from_name.clone(),
                 constraint_name: from_constraint.name.clone(),
             });
         }


### PR DESCRIPTION
## What

`diff_partitions` was deepened to compare a partition child's parent and bound, but the modify callback still ignored the `Partition` struct's `indexes` and `check_constraints`. A same-named partition whose partition-local index or CHECK constraint changed produced no migration, the same empty-modify-callback gap bound/parent had.

Extract the table index / check-constraint reconciliation into list-based cores (`diff_index_lists` / `diff_check_constraint_lists`) and call them from both the table path and the partition modify callback, independently of any bound/parent DETACH+ATTACH. A partition child is a relation in its own right, so its indexes and CHECK constraints reconcile exactly like a table's.

The table path is unchanged: `diff_indexes` / `diff_check_constraints` now delegate to the shared cores with identical add/drop targeting (adds target the `to` relation, drops the `from`).

## Known limitation

The parser and introspection do not yet populate `Partition.indexes` / `check_constraints` (both always empty), so this path is reachable only from in-memory schemas today. Filed as a follow-up to populate the fields, add real-PG coverage, and add planner ordering for a simultaneous bound + index/check change. PostgreSQL accepts index/check DDL on a partition child whether attached or detached, so the current undefined ordering is not an apply failure.

## Tests

- Index add / change (drop+add) / remove on a same-named partition.
- CHECK constraint add / change (drop+add).
- Unchanged index + check emits no ops.
- All 1432 lib tests pass; fmt and clippy clean.